### PR TITLE
Convert non default assembly references as well.

### DIFF
--- a/Project2015To2017/AssemblyReferenceTransformation.cs
+++ b/Project2015To2017/AssemblyReferenceTransformation.cs
@@ -1,0 +1,19 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Project2015To2017.Definition;
+using System.Linq;
+
+namespace Project2015To2017
+{
+    internal sealed class AssemblyReferenceTransformation : ITransformation
+    {
+        public Task TransformAsync(XDocument projectFile, DirectoryInfo projectFolder, Project definition)
+        {
+            XNamespace nsSys = "http://schemas.microsoft.com/developer/msbuild/2003";
+
+            definition.AssemblyReferences = projectFile.Element(nsSys + "Project").Elements(nsSys + "ItemGroup").Elements(nsSys + "Reference").Where(x => !x.Elements(nsSys + "HintPath").Any()).Select(x => x.Attribute("Include").Value).ToArray();
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Project2015To2017/Definition/Project.cs
+++ b/Project2015To2017/Definition/Project.cs
@@ -6,6 +6,7 @@ namespace Project2015To2017.Definition
     internal sealed class Project
     {
         public IReadOnlyList<XElement> ConditionalPropertyGroups { get; internal set; }
+        public IReadOnlyList<string> AssemblyReferences { get; internal set; }
         public IReadOnlyList<string> ProjectReferences { get; internal set; }
         public IReadOnlyList<PackageReference> PackageReferences { get; internal set; }
         public IReadOnlyList<XElement> ItemsToInclude { get; internal set; }

--- a/Project2015To2017/Program.cs
+++ b/Project2015To2017/Program.cs
@@ -19,6 +19,7 @@ namespace Project2015To2017
             new ProjectPropertiesTransformation(),
             new ProjectReferenceTransformation(),
             new PackageReferenceTransformation(),
+            new AssemblyReferenceTransformation(),
             new FileTransformation(),
             new AssemblyInfoTransformation(),
             new NugetPackageTransformation()

--- a/Project2015To2017/Writing/ProjectWriter.cs
+++ b/Project2015To2017/Writing/ProjectWriter.cs
@@ -45,6 +45,17 @@ namespace Project2015To2017.Writing
                 projectNode.Add(nugetReferences);
             }
 
+            if (project.AssemblyReferences?.Count > 0)
+            {
+                var assemblyReferences = new XElement("ItemGroup");
+                foreach (var assemblyReference in project.AssemblyReferences.Where(x => !IsDefaultIncludedAssemblyReference(x)))
+                {
+                    assemblyReferences.Add(new XElement("Reference", new XAttribute("Include", assemblyReference)));
+                }
+
+                projectNode.Add(assemblyReferences);
+            }
+
             // resx wildcards
             projectNode.Add(
                 new XElement("ItemGroup",
@@ -61,6 +72,22 @@ namespace Project2015To2017.Writing
             {
                 streamWriter.Write(projectNode.ToString());
             }
+        }
+
+        private bool IsDefaultIncludedAssemblyReference(string assemblyReference)
+        {
+            return new string[]
+            {
+                "System",
+                "System.Core",
+                "System.Data",
+                "System.Drawing",
+                "System.IO.Compression.FileSystem",
+                "System.Numerics",
+                "System.Runtime.Serialization",
+                "System.Xml",
+                "System.Xml.Linq"
+            }.Contains(assemblyReference);
         }
 
         private XElement GetMainPropertyGroup(Project project)

--- a/Project2015To2017Tests/AssemblyReferenceTransformationTest.cs
+++ b/Project2015To2017Tests/AssemblyReferenceTransformationTest.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Project2015To2017;
+using Project2015To2017.Definition;
+using System.Linq;
+using System.IO;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace Project2015To2017Tests
+{
+    [TestClass]
+    public class AssemblyReferenceTransformationTest
+    {
+        [TestMethod]
+        public async Task TransformsAssemblyReferencesAsync()
+        {
+            var project = new Project();
+            var transformation = new AssemblyReferenceTransformation();
+
+            var directoryInfo = new DirectoryInfo(".\\TestFiles");
+            var doc = XDocument.Load("TestFiles\\net46console.testcsproj");
+
+            await transformation.TransformAsync(doc, directoryInfo, project).ConfigureAwait(false);
+
+            Assert.AreEqual(8, project.AssemblyReferences.Count);
+            Assert.IsTrue(project.AssemblyReferences.Contains(@"System.Xml.Linq"));
+        }
+    }
+}


### PR DESCRIPTION
If your project file previously had extra assemblies added - e.g. `System.configuration`, then this was missing after converting the project file.

It appears some assemblies are included by default even when not specified, so I filtered them out.