### PR TITLE
Add missing generate assembly attribute property group elements

### DIFF
--- a/Project2015To2017/Writing/ProjectWriter.cs
+++ b/Project2015To2017/Writing/ProjectWriter.cs
@@ -161,6 +161,8 @@ namespace Project2015To2017.Writing
             AddIfNotNull(mainPropertyGroup, "GenerateAssemblyCopyrightAttribute", "false");
             AddIfNotNull(mainPropertyGroup, "GenerateAssemblyInformationalVersionAttribute", "false");
             AddIfNotNull(mainPropertyGroup, "GenerateAssemblyVersionAttribute", "false");
+            AddIfNotNull(mainPropertyGroup, "GenerateAssemblyFileVersionAttribute", "false");
+            AddIfNotNull(mainPropertyGroup, "GenerateAssemblyConfigurationAttribute", "false");
         }
 
         private void AddIfNotNull(XElement node, string elementName, string value)


### PR DESCRIPTION
A normal (old) project also includes `AssemblyFileVersion` and `AssemblyConfiguration` in `AssemblyInfo.cs`. I was getting a duplicated attribute compile error.

This fixes it.