### PR TITLE
Fix parsing of project properties.

### DIFF
--- a/Project2015To2017/ProjectPropertiesTransformation.cs
+++ b/Project2015To2017/ProjectPropertiesTransformation.cs
@@ -15,13 +15,13 @@ namespace Project2015To2017
             var propertyGroups = projectFile.Element(nsSys + "Project").Elements(nsSys + "PropertyGroup");
             var targetFramework = propertyGroups.Elements(nsSys + "TargetFrameworkVersion").FirstOrDefault()?.Value;
 
-            definition.Optimize = "true".Equals(propertyGroups.Elements("Optimize").FirstOrDefault()?.Value, StringComparison.OrdinalIgnoreCase);
-            definition.TreatWarningsAsErrors = "true".Equals(propertyGroups.Elements("TreatWarningsAsErrors").FirstOrDefault()?.Value, StringComparison.OrdinalIgnoreCase);
-            definition.AllowUnsafeBlocks = "true".Equals(propertyGroups.Elements("AllowUnsafeBlocks").FirstOrDefault()?.Value, StringComparison.OrdinalIgnoreCase);
-            definition.DefineConstants = propertyGroups.Elements("DefineConstants").FirstOrDefault()?.Value;
+            definition.Optimize = "true".Equals(propertyGroups.Elements(nsSys + "Optimize").FirstOrDefault()?.Value, StringComparison.OrdinalIgnoreCase);
+            definition.TreatWarningsAsErrors = "true".Equals(propertyGroups.Elements(nsSys + "TreatWarningsAsErrors").FirstOrDefault()?.Value, StringComparison.OrdinalIgnoreCase);
+            definition.AllowUnsafeBlocks = "true".Equals(propertyGroups.Elements(nsSys + "AllowUnsafeBlocks").FirstOrDefault()?.Value, StringComparison.OrdinalIgnoreCase);
+            definition.DefineConstants = propertyGroups.Elements(nsSys + "DefineConstants").FirstOrDefault()?.Value;
 
-            definition.RootNamespace = propertyGroups.Elements("RootNamespace").FirstOrDefault()?.Value;
-            definition.AssemblyName = propertyGroups.Elements("AssemblyName").FirstOrDefault()?.Value;
+            definition.RootNamespace = propertyGroups.Elements(nsSys + "RootNamespace").FirstOrDefault()?.Value;
+            definition.AssemblyName = propertyGroups.Elements(nsSys + "AssemblyName").FirstOrDefault()?.Value;
             definition.Type = propertyGroups.Elements(nsSys + "TestProjectType").Any() 
                 ? ApplicationType.TestProject
                 : ToApplicationType(propertyGroups.Elements(nsSys + "OutputType").FirstOrDefault()?.Value);

--- a/Project2015To2017Tests/ProjectPropertiesTransformationTest.cs
+++ b/Project2015To2017Tests/ProjectPropertiesTransformationTest.cs
@@ -79,6 +79,108 @@ namespace Project2015To2017Tests
         }
 
         [TestMethod]
+        public async Task ReadsRootNamespace()
+        {
+            var xml = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<Project ToolsVersion=""14.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <RootNamespace>MyProject</RootNamespace>
+  </PropertyGroup>
+</Project>";
+
+            var project = await ParseAndTransformAsync(xml).ConfigureAwait(false);
+
+            Assert.AreEqual("MyProject", project.RootNamespace);
+        }
+
+        [TestMethod]
+        public async Task ReadsAssemblyName()
+        {
+            var xml = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<Project ToolsVersion=""14.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <AssemblyName>MyProject</AssemblyName>
+  </PropertyGroup>
+</Project>";
+
+            var project = await ParseAndTransformAsync(xml).ConfigureAwait(false);
+
+            Assert.AreEqual("MyProject", project.AssemblyName);
+        }
+
+        [TestMethod]
+        public async Task ReadsOptimize()
+        {
+            var xml = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<Project ToolsVersion=""14.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+</Project>";
+
+            var project = await ParseAndTransformAsync(xml).ConfigureAwait(false);
+
+            Assert.AreEqual(true, project.Optimize);
+        }
+
+        [TestMethod]
+        public async Task ReadsTreatWarningsAsErrors()
+        {
+            var xml = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<Project ToolsVersion=""14.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>";
+
+            var project = await ParseAndTransformAsync(xml).ConfigureAwait(false);
+
+            Assert.AreEqual(true, project.TreatWarningsAsErrors);
+        }
+
+        [TestMethod]
+        public async Task ReadsAllowUnsafeBlocks()
+        {
+            var xml = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<Project ToolsVersion=""14.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+</Project>";
+
+            var project = await ParseAndTransformAsync(xml).ConfigureAwait(false);
+
+            Assert.AreEqual(true, project.AllowUnsafeBlocks);
+        }
+
+        [TestMethod]
+        public async Task ReadsDefineConstants()
+        {
+            var xml = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<Project ToolsVersion=""14.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <DefineConstants>foo</DefineConstants>
+  </PropertyGroup>
+</Project>";
+
+            var project = await ParseAndTransformAsync(xml).ConfigureAwait(false);
+
+            Assert.AreEqual("foo", project.DefineConstants);
+        }
+
+        [TestMethod]
         public async Task ReadsWindowsApplication()
         {
             var xml = @"<?xml version=""1.0"" encoding=""utf-8""?>


### PR DESCRIPTION
The values of Optimize, TreatWarningsAsErrors, AllowUnsafeBlocks, DefineConstants, RootNamespace and AssemblyName were not found even though they existed in csproj file. It was missing the namespace.