### PR TITLE
Fix nuspec namespace

### DIFF
--- a/Project2015To2017/NugetPackageTransformation.cs
+++ b/Project2015To2017/NugetPackageTransformation.cs
@@ -32,8 +32,16 @@ namespace Project2015To2017
                     nuspec = XDocument.Load(filestream);
                 }
 
-                XNamespace ns = "http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd";
-                ExtractPackageConfiguration(definition, nuspec, ns);
+                var namespaces = new XNamespace[]
+                {
+                    "http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd",
+                    "http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd",
+                    "http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd"
+                };
+                foreach (var ns in namespaces)
+                {
+                    ExtractPackageConfiguration(definition, nuspec, ns);
+                }
             }
             else
             {

--- a/Project2015To2017/NugetPackageTransformation.cs
+++ b/Project2015To2017/NugetPackageTransformation.cs
@@ -33,41 +33,7 @@ namespace Project2015To2017
                 }
 
                 XNamespace ns = "http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd";
-                var metadata = nuspec?.Element(ns + "package")?.Element(ns + "metadata");
-
-                if (metadata != null)
-                {
-                    var id = metadata.Element(ns + "id")?.Value;
-                    if (id == "$id$")
-                    {
-                        id = null;
-                    }
-
-                    var version = metadata.Element(ns + "version")?.Value;
-                    if (version == "$version$")
-                    {
-                        version = null;
-                    }
-
-                    definition.PackageConfiguration = new PackageConfiguration
-                    {
-                        Id = id,
-                        Version = version,
-                        Authors = ReadValueAndReplace(metadata, ns + "authors", definition.AssemblyAttributes),
-                        Description = ReadValueAndReplace(metadata, ns + "description", definition.AssemblyAttributes),
-                        Copyright = ReadValueAndReplace(metadata, ns + "copyright", definition.AssemblyAttributes),
-                        LicenseUrl = ReadValueAndReplace(metadata, ns + "licenseUrl", definition.AssemblyAttributes),
-                        ProjectUrl = ReadValueAndReplace(metadata, ns + "projectUrl", definition.AssemblyAttributes),
-                        IconUrl = ReadValueAndReplace(metadata, ns + "iconUrl", definition.AssemblyAttributes),
-                        Tags = ReadValueAndReplace(metadata, ns + "tags", definition.AssemblyAttributes),
-                        ReleaseNotes = ReadValueAndReplace(metadata, ns + "releaseNotes", definition.AssemblyAttributes),
-                        RequiresLicenseAcceptance = metadata.Element(ns + "requireLicenseAcceptance")?.Value != null ? bool.Parse(metadata.Element(ns + "requireLicenseAcceptance")?.Value) : false
-                    };
-                }
-                else
-                {
-                    Console.WriteLine("Error reading package info from nuspec.");
-                }
+                ExtractPackageConfiguration(definition, nuspec, ns);
             }
             else
             {
@@ -76,6 +42,45 @@ namespace Project2015To2017
             }
 
             return Task.CompletedTask;
+        }
+
+        private void ExtractPackageConfiguration(Project definition, XDocument nuspec, XNamespace ns)
+        {
+            var metadata = nuspec?.Element(ns + "package")?.Element(ns + "metadata");
+
+            if (metadata != null)
+            {
+                var id = metadata.Element(ns + "id")?.Value;
+                if (id == "$id$")
+                {
+                    id = null;
+                }
+
+                var version = metadata.Element(ns + "version")?.Value;
+                if (version == "$version$")
+                {
+                    version = null;
+                }
+
+                definition.PackageConfiguration = new PackageConfiguration
+                {
+                    Id = id,
+                    Version = version,
+                    Authors = ReadValueAndReplace(metadata, ns + "authors", definition.AssemblyAttributes),
+                    Description = ReadValueAndReplace(metadata, ns + "description", definition.AssemblyAttributes),
+                    Copyright = ReadValueAndReplace(metadata, ns + "copyright", definition.AssemblyAttributes),
+                    LicenseUrl = ReadValueAndReplace(metadata, ns + "licenseUrl", definition.AssemblyAttributes),
+                    ProjectUrl = ReadValueAndReplace(metadata, ns + "projectUrl", definition.AssemblyAttributes),
+                    IconUrl = ReadValueAndReplace(metadata, ns + "iconUrl", definition.AssemblyAttributes),
+                    Tags = ReadValueAndReplace(metadata, ns + "tags", definition.AssemblyAttributes),
+                    ReleaseNotes = ReadValueAndReplace(metadata, ns + "releaseNotes", definition.AssemblyAttributes),
+                    RequiresLicenseAcceptance = metadata.Element(ns + "requireLicenseAcceptance")?.Value != null ? bool.Parse(metadata.Element(ns + "requireLicenseAcceptance")?.Value) : false
+                };
+            }
+            else
+            {
+                Console.WriteLine("Error reading package info from nuspec.");
+            }
         }
 
         private string ReadValueAndReplace(XElement metadata, XName elementName, AssemblyAttributes assemblyAttributes)

--- a/Project2015To2017/NugetPackageTransformation.cs
+++ b/Project2015To2017/NugetPackageTransformation.cs
@@ -42,6 +42,11 @@ namespace Project2015To2017
                 {
                     ExtractPackageConfiguration(definition, nuspec, ns);
                 }
+
+                if (definition.PackageConfiguration == null)
+                {
+                    Console.WriteLine("Error reading package info from nuspec.");
+                }
             }
             else
             {
@@ -84,10 +89,6 @@ namespace Project2015To2017
                     ReleaseNotes = ReadValueAndReplace(metadata, ns + "releaseNotes", definition.AssemblyAttributes),
                     RequiresLicenseAcceptance = metadata.Element(ns + "requireLicenseAcceptance")?.Value != null ? bool.Parse(metadata.Element(ns + "requireLicenseAcceptance")?.Value) : false
                 };
-            }
-            else
-            {
-                Console.WriteLine("Error reading package info from nuspec.");
             }
         }
 


### PR DESCRIPTION
Apparently there are multiple variants of the namespace for the nuspec file

https://docs.microsoft.com/en-us/nuget/schema/nuspec uses `http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd` as example.

This might not be a complete list, but solves it for my projects at least.