### PR TITLE
Use UTF8 encoding for project file

### DIFF
--- a/Project2015To2017/Writing/ProjectWriter.cs
+++ b/Project2015To2017/Writing/ProjectWriter.cs
@@ -74,7 +74,7 @@ namespace Project2015To2017.Writing
             }
 
             using (var filestream = File.Open(outputFile.FullName, FileMode.Create))
-            using (var streamWriter = new StreamWriter(filestream))
+            using (var streamWriter = new StreamWriter(filestream, Encoding.UTF8))
             {
                 streamWriter.Write(projectNode.ToString());
             }


### PR DESCRIPTION
I found that when you change properties of a converted project using Visual Studio UI or using "Edit xxx.csproj", then it re-added a UTF-8 BOM that was removed during conversion.