### PR TITLE
Small fixes for encountered problems

### DIFF
--- a/Project2015To2017/Config.cs
+++ b/Project2015To2017/Config.cs
@@ -1,0 +1,7 @@
+﻿namespace Project2015To2017
+{
+    public static class Config
+    {
+        public static bool RemoveAssemblyInfo = true;
+    }
+}

--- a/Project2015To2017/FileTransformation.cs
+++ b/Project2015To2017/FileTransformation.cs
@@ -38,6 +38,7 @@ namespace Project2015To2017
 
             // Remove packages.config since those references were already added to the CSProj file.
             otherIncludes.Where(x => x.Attribute("Include")?.Value == "packages.config").Remove();
+            otherIncludes.Where(x => x.Attribute("Include") != null && x.Attribute("Include").Value.EndsWith(".nuspec")).Remove();
 
             definition.ItemsToInclude = compileManualIncludes.Concat(otherIncludes).ToArray();
 
@@ -57,6 +58,10 @@ namespace Project2015To2017
                 var includeAttribute = compiledFile.Attribute("Include");
                 if (includeAttribute != null && !includeAttribute.Value.Contains("*"))
                 {
+                    var compiledFileAttributes = compiledFile.Attributes().Where(a => a.Name != "Include").ToList();
+                    compiledFileAttributes.Add(new XAttribute("Update", includeAttribute.Value));
+                    compiledFile.ReplaceAttributes(compiledFileAttributes);
+
                     if (!Path.GetFullPath(Path.Combine(projectFolder.FullName, includeAttribute.Value)).StartsWith(projectFolder.FullName))
                     {
                         Console.WriteLine($"Include cannot be done through wildcard, adding as separate include {compiledFile}.");

--- a/Project2015To2017/Program.cs
+++ b/Project2015To2017/Program.cs
@@ -103,6 +103,15 @@ namespace Project2015To2017
                 }
             }
 
+            var nuspecFile = fileInfo.FullName.Replace("csproj", "nuspec");
+            if (File.Exists(nuspecFile))
+            {
+                if (!RenameFile(nuspecFile))
+                {
+                    return;
+                }
+            }
+
             new ProjectWriter().Write(projectDefinition, fileInfo);
         }
 

--- a/Project2015To2017/Program.cs
+++ b/Project2015To2017/Program.cs
@@ -20,7 +20,7 @@ namespace Project2015To2017
             new ProjectReferenceTransformation(),
             new PackageReferenceTransformation(),
             new AssemblyReferenceTransformation(),
-			new RemovePackageAssemblyReferencesTransformation(),
+            new RemovePackageAssemblyReferencesTransformation(),
             new FileTransformation(),
             new AssemblyInfoTransformation(),
             new NugetPackageTransformation()
@@ -33,6 +33,8 @@ namespace Project2015To2017
                 Console.WriteLine($"Please specify a project file.");
                 return;
             }
+
+            Console.WriteLine($"Remove Assembly info: {Config.RemoveAssemblyInfo}");
 
             // Process all csprojs found in given directory
             if (Path.GetExtension(args[0]) != ".csproj")
@@ -110,6 +112,15 @@ namespace Project2015To2017
                 {
                     return;
                 }
+            }
+
+            if (Config.RemoveAssemblyInfo)
+            {
+                var assemblyInfoFiles = new DirectoryInfo(fileInfo.DirectoryName)
+                    .EnumerateFiles("AssemblyInfo.cs", SearchOption.AllDirectories)
+                    .ToArray();
+                foreach(var assemblyInfoFile in assemblyInfoFiles)
+                    assemblyInfoFile.Delete();
             }
 
             new ProjectWriter().Write(projectDefinition, fileInfo);

--- a/Project2015To2017/ProjectPropertiesTransformation.cs
+++ b/Project2015To2017/ProjectPropertiesTransformation.cs
@@ -54,6 +54,7 @@ namespace Project2015To2017
             definition.ConditionalPropertyGroups = propertyGroups.Where(x => x.Attribute("Condition") != null).ToArray();
             definition.Imports = projectFile.Element(nsSys + "Project").Elements(nsSys + "Import").Where(x => 
                     x.Attribute("Project")?.Value != @"$(MSBuildToolsPath)\Microsoft.CSharp.targets" &&
+                    x.Attribute("Project")?.Value != @"$(MSBuildBinPath)\Microsoft.CSharp.targets" &&
                     x.Attribute("Project")?.Value != @"$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props").ToArray();
             definition.Targets = projectFile.Element(nsSys + "Project").Elements(nsSys + "Target").ToArray();
 

--- a/Project2015To2017/Writing/ProjectWriter.cs
+++ b/Project2015To2017/Writing/ProjectWriter.cs
@@ -209,6 +209,9 @@ namespace Project2015To2017.Writing
             AddIfNotNull(mainPropertyGroup, "PackageTags", packageConfiguration.Tags);
             AddIfNotNull(mainPropertyGroup, "Version", packageConfiguration.Version);
 
+            if(packageConfiguration.Id != null)
+                mainPropertyGroup.Add(new XElement("RepositoryType", "Library"));
+
             if (packageConfiguration.RequiresLicenseAcceptance)
             {
                 mainPropertyGroup.Add(new XElement("PackageRequireLicenseAcceptance", "true"));

--- a/Project2015To2017/Writing/ProjectWriter.cs
+++ b/Project2015To2017/Writing/ProjectWriter.cs
@@ -209,8 +209,8 @@ namespace Project2015To2017.Writing
             AddIfNotNull(mainPropertyGroup, "PackageTags", packageConfiguration.Tags);
             AddIfNotNull(mainPropertyGroup, "Version", packageConfiguration.Version);
 
-            if(packageConfiguration.Id != null)
-                mainPropertyGroup.Add(new XElement("RepositoryType", "Library"));
+            if(packageConfiguration.Id != null && packageConfiguration.Tags == null)
+                mainPropertyGroup.Add(new XElement("PackageTags", "Library"));
 
             if (packageConfiguration.RequiresLicenseAcceptance)
             {
@@ -220,7 +220,7 @@ namespace Project2015To2017.Writing
 
         private void AddAssemblyAttributeNodes(XElement mainPropertyGroup, AssemblyAttributes assemblyAttributes)
         {
-            if (assemblyAttributes == null)
+            if (assemblyAttributes == null || Config.RemoveAssemblyInfo)
             {
                 return;
             }

--- a/Project2015To2017/Writing/ProjectWriter.cs
+++ b/Project2015To2017/Writing/ProjectWriter.cs
@@ -207,7 +207,7 @@ namespace Project2015To2017.Writing
             AddIfNotNull(mainPropertyGroup, "PackageProjectUrl", packageConfiguration.ProjectUrl);
             AddIfNotNull(mainPropertyGroup, "PackageReleaseNotes", packageConfiguration.ReleaseNotes);
             AddIfNotNull(mainPropertyGroup, "PackageTags", packageConfiguration.Tags);
-            AddIfNotNull(mainPropertyGroup, "PackageVersion", packageConfiguration.Version);
+            AddIfNotNull(mainPropertyGroup, "Version", packageConfiguration.Version);
 
             if (packageConfiguration.RequiresLicenseAcceptance)
             {
@@ -236,7 +236,7 @@ namespace Project2015To2017.Writing
             };
 
             var childNodes = attributes
-                .Where(x => !string.IsNullOrWhiteSpace(x.Value))
+                .Where(x => x.Value != null)
                 .Select(x => new XElement(x.Key, "false"))
                 .ToArray();
 

--- a/Project2015To2017/Writing/ProjectWriter.cs
+++ b/Project2015To2017/Writing/ProjectWriter.cs
@@ -33,7 +33,7 @@ namespace Project2015To2017.Writing
 
             if (project.Imports != null)
             {
-                foreach (var import in project.Imports)
+                foreach (var import in project.Imports.Select(RemoveAllNamespaces))
                 {
                     projectNode.Add(import);
                 }
@@ -41,7 +41,7 @@ namespace Project2015To2017.Writing
 
             if (project.Targets != null)
             {
-                foreach (var target in project.Targets)
+                foreach (var target in project.Targets.Select(RemoveAllNamespaces))
                 {
                     projectNode.Add(target);
                 }


### PR DESCRIPTION
Avoid double assemblyinfo attributes,
use 'Version' instead of PackageVersion,
always update compile items (as compile files are include automatic, update is need to avoid double inclusion error),
remove .nuspec from project