### PR TITLE
Add support for alternative folder for extracted packages

### DIFF
--- a/Project2015To2017/Project2015To2017.csproj
+++ b/Project2015To2017/Project2015To2017.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,5 +7,6 @@
 
   <ItemGroup>
     <Folder Include="Properties\" />
+    <PackageReference Include="NuGet.Configuration" Version="4.6.0" />
   </ItemGroup>
 </Project>

--- a/Project2015To2017Tests/Project2015To2017Tests.csproj
+++ b/Project2015To2017Tests/Project2015To2017Tests.csproj
@@ -9,6 +9,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="TestFiles\AltNugetConfig\ProjectFolder\net46console.testcsproj">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="OtherPackagesConfig\net46console.testcsproj">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -67,6 +70,12 @@
 
   <ItemGroup>
     <None Update="OtherPackagesConfig\packages.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="TestFiles\AltNugetConfig\nuget.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="TestFiles\AltNugetConfig\ProjectFolder\packages.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="TestFiles\packages.config">

--- a/Project2015To2017Tests/ProjectReferenceTransformationTest.cs
+++ b/Project2015To2017Tests/ProjectReferenceTransformationTest.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Project2015To2017;
 using Project2015To2017.Definition;
 using System.Linq;

--- a/Project2015To2017Tests/RemovePackageAssemblyReferencesTransformationTest.cs
+++ b/Project2015To2017Tests/RemovePackageAssemblyReferencesTransformationTest.cs
@@ -1,6 +1,11 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Project2015To2017;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Project2015To2017.Definition;
 
 namespace Project2015To2017Tests
 {
@@ -10,7 +15,7 @@ namespace Project2015To2017Tests
         [TestMethod]
         public void HandlesNoPackagesConfig()
         {
-            var project = new Project2015To2017.Definition.Project();
+            var project = new Project();
 
             var transformation = new RemovePackageAssemblyReferencesTransformation();
             transformation.TransformAsync(null, null, project);
@@ -19,20 +24,20 @@ namespace Project2015To2017Tests
         [TestMethod]
 		public void DedupeReferencesFromPackages()
 		{
-			var project = new Project2015To2017.Definition.Project
+			var project = new Project
 			{
-				AssemblyReferences = new List<Project2015To2017.Definition.AssemblyReference>
+				AssemblyReferences = new List<AssemblyReference>
 				{
-					new Project2015To2017.Definition.AssemblyReference
+					new AssemblyReference
 					{
 						Include = "Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL",
 						HintPath = @"..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll"
 					},
-					new Project2015To2017.Definition.AssemblyReference
+					new AssemblyReference
 					{
 						Include = "System.Data.DataSetExtensions"
 					},
-					new Project2015To2017.Definition.AssemblyReference
+					new AssemblyReference
 					{
 						Include = "Owin",
 						HintPath = @"..\packages\Owin.1.0\lib\net40\Owin.dll"
@@ -40,7 +45,7 @@ namespace Project2015To2017Tests
 				},
 				PackageReferences = new[]
 				{
-					new Project2015To2017.Definition.PackageReference
+					new PackageReference
 					{
 						Id = "Newtonsoft.Json"
 					}
@@ -48,9 +53,35 @@ namespace Project2015To2017Tests
 			};
 
 			var transformation = new RemovePackageAssemblyReferencesTransformation();
-			transformation.TransformAsync(null, null, project);
+
+			var projectFolder = new DirectoryInfo(".");
+
+			transformation.TransformAsync(null, projectFolder, project);
 
 			Assert.AreEqual(2, project.AssemblyReferences.Count);
 		}
+
+	    [TestMethod]
+	    public async Task DedupeReferencesFromPackagesAlternativePackagesFolderAsync()
+	    {
+		    var project = new Project();
+		    var transformation = new RemovePackageAssemblyReferencesTransformation();
+		    
+		    var projFile = @"TestFiles\AltNugetConfig\ProjectFolder\net46console.testcsproj";
+		    var projFolder = new FileInfo(projFile).Directory;
+
+		    var doc = XDocument.Load(projFile);
+
+			//First load information about the references and package references
+		    await new AssemblyReferenceTransformation().TransformAsync(doc, projFolder, project).ConfigureAwait(false);
+			await new PackageReferenceTransformation().TransformAsync(doc, projFolder, project).ConfigureAwait(false);
+
+			//Then attempt to clear any referencing the nuget packages folder
+		    await transformation.TransformAsync(doc, projFolder, project).ConfigureAwait(false);
+
+			//The only one left which points to another folder
+		    Assert.AreEqual(1, project.AssemblyReferences.Count);
+		    Assert.IsTrue(project.AssemblyReferences[0].Include.StartsWith("Owin"));
+	    }
     }
 }

--- a/Project2015To2017Tests/TestFiles/AltNugetConfig/ProjectFolder/net46console.testcsproj
+++ b/Project2015To2017Tests/TestFiles/AltNugetConfig/ProjectFolder/net46console.testcsproj
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{62CAD5A7-4966-4289-9203-E6843CDEE4C6}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Net46Console</RootNamespace>
+    <AssemblyName>Net46Console</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Owin, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\SomeOtherPackagesFolder\Microsoft.Owin.3.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\SomeOtherPackagesFolder\Microsoft.Owin.Host.SystemWeb.3.1.0\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\SomeOtherPackagesFolder\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+	  <!--Put in a reference which should actually be left alone because for this project '..\packages' is not the nuget packages folder-->
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="AutoMapper" Version="6.1.1">
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+    <PackageReference Include="Microsoft.Owin.Host.HttpListener">
+      <Version>3.1.0</Version>
+    </PackageReference>
+	</ItemGroup>
+  <ItemGroup>
+    <None Include="Class1.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="..\FileTransformationTest.cs" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SomeOtherProject\SomeOtherProject.csproj">
+      <Project>{E5D98CC4-93A3-450D-B33E-F9CAD02BBD8C}</Project>
+      <Name>SomeOtherProject</Name>
+			<Aliases>global,one</Aliases>
+    </ProjectReference>
+    <ProjectReference Include="..\YetAnotherProject\YetAnotherProject.csproj">
+      <Project>{E5D98CC5-93A3-450D-B33E-F9CAD02BBD8C}</Project>
+      <Name>YetAnotherProject</Name>
+			<Aliases>global</Aliases>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Project2015To2017Tests/TestFiles/AltNugetConfig/ProjectFolder/packages.config
+++ b/Project2015To2017Tests/TestFiles/AltNugetConfig/ProjectFolder/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Owin" version="3.1.0" targetFramework="net46" />
+  <package id="Microsoft.Owin.Host.SystemWeb" version="3.1.0" targetFramework="net46" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net46" />
+  <package id="Owin" version="1.0" targetFramework="net46" />
+  <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net46" developmentDependency="true" />
+</packages>

--- a/Project2015To2017Tests/TestFiles/AltNugetConfig/nuget.config
+++ b/Project2015To2017Tests/TestFiles/AltNugetConfig/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+	<config>
+		<!-- Repository path is relative to the nuget.config file -->
+		<add key="repositoryPath" value="SomeOtherPackagesFolder" />
+	</config>
+</configuration>


### PR DESCRIPTION
The deleting of assembly references that are catered for by PackageReference style packages is now extended to support a different packages folder being specified in nuget.config.

Fixes #61