### PR TITLE
Fix .csproj and directory processing regression

### DIFF
--- a/Project2015To2017/Program.cs
+++ b/Project2015To2017/Program.cs
@@ -64,7 +64,7 @@ namespace Project2015To2017
 			}
 
             // Process all csprojs found in given directory
-            if (Path.GetExtension(args[0]).Equals(".csproj", StringComparison.OrdinalIgnoreCase))
+            if (!Path.GetExtension(args[0]).Equals(".csproj", StringComparison.OrdinalIgnoreCase))
             {
                 var projectFiles = Directory.EnumerateFiles(args[0], "*.csproj", SearchOption.AllDirectories).ToArray();
                 if (projectFiles.Length == 0)


### PR DESCRIPTION
Logic error is causing it to think projects are directories and vice versa