### PR TITLE
Remove props and targets that come from packages

### DIFF
--- a/Project2015To2017/Definition/Project.cs
+++ b/Project2015To2017/Definition/Project.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Xml.Linq;
+using NuGet.Configuration;
 
 namespace Project2015To2017.Definition
 {
@@ -33,5 +34,27 @@ namespace Project2015To2017.Definition
 		public string AssemblyOriginatorKeyFile { get; set; }
 		public FileInfo FilePath { get; set; }
 		public DirectoryInfo ProjectFolder => FilePath.Directory;
+
+		/// <summary>
+		/// The directory where nuget stores its extracted packages for the project.
+		/// In general this is the 'packages' folder within the parent solution, but
+		/// it can be overridden, which is accounted for here.
+		/// </summary>
+		public DirectoryInfo NugetPackagesPath
+		{
+			get
+			{
+				var projectFolder = ProjectFolder.FullName;
+
+				var nuGetSettings = Settings.LoadDefaultSettings(projectFolder);
+				var repositoryPathSetting = SettingsUtility.GetRepositoryPath(nuGetSettings);
+
+				//return the explicitly set path, or if there isn't one, then assume the solution is one level
+				//above the project and therefore so is the 'packages' folder
+				var path = repositoryPathSetting ?? Path.GetFullPath(Path.Combine(projectFolder, @"..\packages"));
+
+				return new DirectoryInfo(path);
+			}
+		}
 	}
 }

--- a/Project2015To2017/Project2015To2017.csproj
+++ b/Project2015To2017/Project2015To2017.csproj
@@ -10,6 +10,6 @@
 
   <ItemGroup>
     <Folder Include="Properties\" />
-    <PackageReference Include="NuGet.Configuration" Version="4.6.0" />
+    <PackageReference Include="NuGet.Configuration" Version="4.6.2" />
   </ItemGroup>
 </Project>

--- a/Project2015To2017/ProjectConverter.cs
+++ b/Project2015To2017/ProjectConverter.cs
@@ -18,6 +18,7 @@ namespace Project2015To2017
 			new PackageReferenceTransformation(),
 			new AssemblyReferenceTransformation(),
 			new RemovePackageAssemblyReferencesTransformation(),
+			new RemovePackageImportsTransformation(),
 			new FileTransformation(),
 			new NugetPackageTransformation()
 		};

--- a/Project2015To2017/Transforms/Helpers.cs
+++ b/Project2015To2017/Transforms/Helpers.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace Project2015To2017.Transforms
+{
+    public static class Helpers
+    {
+	    public static IEnumerable<XElement> ElementsAnyNamespace<T>(this IEnumerable<T> source, string localName)
+		    where T : XContainer
+	    {
+		    return source.Elements().Where(e => e.Name.LocalName == localName);
+	    }
+
+	    public static IEnumerable<XElement> ElementsAnyNamespace<T>(this T source, string localName)
+		    where T : XContainer
+	    {
+		    return source.Elements().Where(e => e.Name.LocalName == localName);
+	    }
+    }
+}

--- a/Project2015To2017/Transforms/RemovePackageAssemblyReferencesTransformation.cs
+++ b/Project2015To2017/Transforms/RemovePackageAssemblyReferencesTransformation.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using NuGet.Configuration;
 using Project2015To2017.Definition;
 
 namespace Project2015To2017.Transforms
@@ -17,19 +16,19 @@ namespace Project2015To2017.Transforms
 
 			var projectPath = definition.ProjectFolder.FullName;
 
-			var nugetRepositoryPath = NuGetRepositoryPath(projectPath);
+			var nugetRepositoryPath = definition.NugetPackagesPath.FullName;
 
 			var packageReferenceIds = definition.PackageReferences.Select(x => x.Id).ToArray();
 
 			var packagePaths = packageReferenceIds.Select(packageId => Path.Combine(nugetRepositoryPath, packageId).ToLower())
-												  .ToArray();
+				.ToArray();
 
 			var filteredAssemblies = definition.AssemblyReferences
-											   .Where(assembly => !packagePaths.Any(
-														    packagePath => AssemblyMatchesPackage(assembly, packagePath)
-													 )
-											    )
-												.ToList();
+				.Where(assembly => !packagePaths.Any(
+						packagePath => AssemblyMatchesPackage(assembly, packagePath)
+					)
+				)
+				.ToList();
 
 			definition.AssemblyReferences = filteredAssemblies;
 
@@ -45,16 +44,6 @@ namespace Project2015To2017.Transforms
 
 				return fullHintPath.ToLower().StartsWith(packagePath);
 			}
-		}
-
-		private static string NuGetRepositoryPath(string projectFolder)
-		{
-			var nuGetSettings = Settings.LoadDefaultSettings(projectFolder);
-			var repositoryPathSetting = SettingsUtility.GetRepositoryPath(nuGetSettings);
-
-			//return the explicitly set path, or if there isn't one, then assume the solution is one level
-			//above the project and therefore so is the 'packages' folder
-			return repositoryPathSetting ?? Path.GetFullPath(Path.Combine(projectFolder, @"..\packages"));
 		}
 	}
 }

--- a/Project2015To2017/Transforms/RemovePackageImportsTransformation.cs
+++ b/Project2015To2017/Transforms/RemovePackageImportsTransformation.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
@@ -8,6 +9,8 @@ namespace Project2015To2017.Transforms
 {
 	internal sealed class RemovePackageImportsTransformation : ITransformation
 	{
+		private static string fullConditionPath;
+
 		public void Transform(Project definition, IProgress<string> progress)
 		{
 			if (definition.PackageReferences == null || definition.PackageReferences.Count == 0)
@@ -24,14 +27,19 @@ namespace Project2015To2017.Transforms
 			var packagePaths = packageReferenceIds.Select(packageId => Path.Combine(nugetRepositoryPath, packageId).ToLower())
 												  .ToArray();
 
-			var filteredAssemblies = definition.Imports
-											   .Where(import => !packagePaths.Any(
-														    packagePath => ImportMatchesPackage(import, packagePath)
-													 )
-											   )
-											   .ToList();
+			definition.Imports = FilteredImports(definition.Imports, packagePaths, projectPath);
+			definition.Targets = FilteredTargets(definition.Targets, packagePaths, projectPath);
+		}
 
-			definition.Imports = filteredAssemblies;
+		private static List<XElement> FilteredImports(IReadOnlyList<XElement> imports, string[] packagePaths, string projectPath)
+		{
+			var filteredImports = imports
+									.Where(import => !packagePaths.Any(
+											packagePath => ImportMatchesPackage(import, packagePath)
+										)
+									).ToList();
+
+			return filteredImports;
 
 			bool ImportMatchesPackage(XElement import, string packagePath)
 			{
@@ -41,9 +49,84 @@ namespace Project2015To2017.Transforms
 					return false;
 				}
 
-				var fullImportPath = Path.IsPathRooted(importedProject) ? importedProject : Path.GetFullPath(Path.Combine(projectPath, importedProject));
+				var fullImportPath = Path.IsPathRooted(importedProject)
+					? importedProject
+					: Path.GetFullPath(Path.Combine(projectPath, importedProject));
 
 				return fullImportPath.ToLower().StartsWith(packagePath);
+			}
+		}
+
+		private static List<XElement> FilteredTargets(IReadOnlyList<XElement> targets, string[] packagePaths, string projectPath)
+		{
+			var filteredImports = targets
+									.Where(import => !packagePaths.Any(
+											packagePath => TargetMatchesPackage(import, packagePath)
+										)
+									).ToList();
+
+			return filteredImports;
+
+			bool TargetMatchesPackage(XElement target, string packagePath)
+			{
+				//To make sure we don't remove anything customly added, look for a
+				//very specific vanilla target as created by nuget
+
+				var propertyGroups = target.ElementsAnyNamespace("PropertyGroup")
+										   .ToList();
+
+				if (propertyGroups.Count() > 1)
+				{
+					//Expect no more than 1 property group
+					return false;
+				}
+
+				var errorTextPropertyGroup = propertyGroups.SingleOrDefault();
+
+				var properties = errorTextPropertyGroup?
+									.Elements()
+									.ToList();
+
+				if ((properties?.Count() ?? 0) > 1)
+				{
+					//Expect no more than 1 'ErrorText' element
+					return false;
+				}
+
+				var errorTextElement = properties?.SingleOrDefault();
+
+				if (errorTextElement != null && errorTextElement.Name.LocalName != "ErrorText")
+				{
+					//Some other property
+					return false;
+				}
+
+				var otherElements = target
+									 .Elements()
+									 .Where(x => x.Name.LocalName != "PropertyGroup").ToList();
+
+				if (otherElements.Count() > 1)
+				{
+					return false;
+				}
+
+				var errorElement = otherElements.SingleOrDefault(x => x.Name.LocalName == "Error");
+
+				var errorCondition = errorElement?.Attribute("Condition");
+
+				if (errorCondition == null)
+				{
+					//Error element with condition is required
+					return false;
+				}
+
+				var conditionPath = errorCondition.Value.Replace("!Exists('", "").Replace("')", "");
+
+				fullConditionPath = Path.IsPathRooted(conditionPath)
+					? conditionPath
+					: Path.GetFullPath(Path.Combine(projectPath, conditionPath));
+
+				return fullConditionPath.ToLower().StartsWith(packagePath);
 			}
 		}
 	}

--- a/Project2015To2017/Transforms/RemovePackageImportsTransformation.cs
+++ b/Project2015To2017/Transforms/RemovePackageImportsTransformation.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Project2015To2017.Definition;
+
+namespace Project2015To2017.Transforms
+{
+	internal sealed class RemovePackageImportsTransformation : ITransformation
+	{
+		public void Transform(Project definition, IProgress<string> progress)
+		{
+			if (definition.PackageReferences == null || definition.PackageReferences.Count == 0)
+			{
+				return;
+			}
+
+			var projectPath = definition.ProjectFolder.FullName;
+
+			var nugetRepositoryPath = definition.NugetPackagesPath.FullName;
+
+			var packageReferenceIds = definition.PackageReferences.Select(x => x.Id).ToArray();
+
+			var packagePaths = packageReferenceIds.Select(packageId => Path.Combine(nugetRepositoryPath, packageId).ToLower())
+												  .ToArray();
+
+			var filteredAssemblies = definition.Imports
+											   .Where(import => !packagePaths.Any(
+														    packagePath => ImportMatchesPackage(import, packagePath)
+													 )
+											   )
+											   .ToList();
+
+			definition.Imports = filteredAssemblies;
+
+			bool ImportMatchesPackage(XElement import, string packagePath)
+			{
+				var importedProject = import.Attribute("Project")?.Value;
+				if (importedProject == null)
+				{
+					return false;
+				}
+
+				var fullImportPath = Path.IsPathRooted(importedProject) ? importedProject : Path.GetFullPath(Path.Combine(projectPath, importedProject));
+
+				return fullImportPath.ToLower().StartsWith(packagePath);
+			}
+		}
+	}
+}

--- a/Project2015To2017Tests/Project2015To2017Tests.csproj
+++ b/Project2015To2017Tests/Project2015To2017Tests.csproj
@@ -37,9 +37,9 @@
 
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.2.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Project2015To2017Tests/RemovePackageAssemblyReferencesTransformationTest.cs
+++ b/Project2015To2017Tests/RemovePackageAssemblyReferencesTransformationTest.cs
@@ -2,6 +2,7 @@ using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Project2015To2017.Definition;
 using Project2015To2017.Reading;
 using Project2015To2017.Transforms;
@@ -80,5 +81,35 @@ namespace Project2015To2017Tests
 			Assert.AreEqual(1, project.AssemblyReferences.Count);
 			Assert.IsTrue(project.AssemblyReferences[0].Include.StartsWith("Owin"));
 		}
+
+		[TestMethod]
+		public void DedupeImportsFromPackagesAlternativePackagesFolder()
+		{
+			var projFile = @"TestFiles\AltNugetConfig\ProjectFolder\net46console.testcsproj";
+
+			var project = new ProjectReader().Read(projFile);
+
+			var transformation = new RemovePackageImportsTransformation();
+
+			var progress = new Progress<string>(x => { });
+
+			//Then attempt to clear any referencing the nuget packages folder
+			transformation.Transform(project, progress);
+
+			var expectedRemaining = new []
+			{
+				@"<Import Project=""C:\SomeTargets.props"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"" />",
+				@"<Import Project=""C:\SomeTargets.targets"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"" />"
+			};
+
+			var remainingImports = project.Imports
+										  .Select(x => x.ToString())
+										  .ToList();
+
+			//The only ones left which point to another folder
+			Assert.AreEqual(2, remainingImports.Count);
+			CollectionAssert.AreEqual(expectedRemaining, remainingImports);
+		}
+
 	}
 }

--- a/Project2015To2017Tests/RemovePackageAssemblyReferencesTransformationTest.cs
+++ b/Project2015To2017Tests/RemovePackageAssemblyReferencesTransformationTest.cs
@@ -109,6 +109,8 @@ namespace Project2015To2017Tests
 			//The only ones left which point to another folder
 			Assert.AreEqual(2, remainingImports.Count);
 			CollectionAssert.AreEqual(expectedRemaining, remainingImports);
+
+			Assert.IsFalse(project.Targets.Any());
 		}
 
 	}

--- a/Project2015To2017Tests/TestFiles/AltNugetConfig/ProjectFolder/net46console.testcsproj
+++ b/Project2015To2017Tests/TestFiles/AltNugetConfig/ProjectFolder/net46console.testcsproj
@@ -81,6 +81,27 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+
+  <!-- These should be left in as they haven't come from a package-->
+  <Import Project="C:\SomeTargets.props" />
+  <Import Project="C:\SomeTargets.targets" />
+
+  <Import Project="..\SomeOtherPackagesFolder\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\SomeOtherPackagesFolder\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\SomeOtherPackagesFolder\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\SomeOtherPackagesFolder\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+  </Target>
+
+  <Import Project="..\SomeOtherPackagesFolder\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.props" Condition="Exists('..\SomeOtherPackagesFolder\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.props')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\SomeOtherPackagesFolder\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.props')" Text="$([System.String]::Format('$(ErrorText)', '..\SomeOtherPackagesFolder\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.props'))" />
+  </Target>
+
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Project2015To2017Tests/TestFiles/AltNugetConfig/ProjectFolder/packages.config
+++ b/Project2015To2017Tests/TestFiles/AltNugetConfig/ProjectFolder/packages.config
@@ -1,8 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Owin" version="3.1.0" targetFramework="net46" />
   <package id="Microsoft.Owin.Host.SystemWeb" version="3.1.0" targetFramework="net46" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net46" />
   <package id="Owin" version="1.0" targetFramework="net46" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
These are imported at build time so don't need to be in the final project.

The check I added for the targets is quite conservative, looking for a specific set of properties as per the ones auto-generated by nuget.

I updated the nuget packages being used because I thought I was hitting a bug with ms test. Turns out it was actually DropBox causing my problem. Let me know if you would like me to roll back those updates.

I also pulled the nuget packages folder into the project as a property because I needed to re-use it for the new transformation.

Fixes #66 