### PR TITLE
Allow for files called \ObjSomething.xyz

### DIFF
--- a/Project2015To2017/Transforms/FileTransformation.cs
+++ b/Project2015To2017/Transforms/FileTransformation.cs
@@ -132,7 +132,7 @@ namespace Project2015To2017.Transforms
 
             foreach (var nonListedFile in filesInFolder.Except(knownFullPaths))
             {
-                if (nonListedFile.StartsWith(Path.Combine(projectFolder.FullName + "\\obj"), StringComparison.OrdinalIgnoreCase))
+                if (nonListedFile.StartsWith(Path.Combine(projectFolder.FullName + "\\obj\\"), StringComparison.OrdinalIgnoreCase))
                 {
                     // skip the generated files in obj
                     continue;


### PR DESCRIPTION
Spotted this one while working on another fix.

Make sure that files starting with 'Obj' don't get picked up by the check for the obj folder.