### PR TITLE
Tolerate project not having AssemblyInfo.cs file

### DIFF
--- a/Project2015To2017/Reading/ProjectReader.cs
+++ b/Project2015To2017/Reading/ProjectReader.cs
@@ -164,7 +164,14 @@ namespace Project2015To2017.Reading
 										.EnumerateFiles("AssemblyInfo.cs", SearchOption.AllDirectories)
 										.ToArray();
 
-			if (assemblyInfoFiles.Length == 1)
+			if (assemblyInfoFiles.Length == 0)
+			{
+				return new AssemblyAttributes
+				{
+					AssemblyName = assemblyName ?? projectFolder.Name
+				};
+			}
+			else if (assemblyInfoFiles.Length == 1)
 			{
 				progress.Report($"Reading assembly info from {assemblyInfoFiles[0].FullName}.");
 


### PR DESCRIPTION
First of all, thanks for this awesome tool! It has helped me multiple times with the tiresome grunt work.

I found a small bug where the tool crashes when the target project does not have a referenced AssemblyInfo.cs file. I found this while testing against Spring.NET codebase.

I've attached the required fix.