### PR TITLE
Nuspec in top directory only

### DIFF
--- a/Project2015To2017/Reading/NuSpecReader.cs
+++ b/Project2015To2017/Reading/NuSpecReader.cs
@@ -12,7 +12,7 @@ namespace Project2015To2017.Reading
 		public PackageConfiguration Read(FileInfo projectFile, IProgress<string> progress)
 		{
 			var nuspecFiles = projectFile.Directory
-										 .EnumerateFiles("*.nuspec", SearchOption.AllDirectories)
+										 .EnumerateFiles("*.nuspec", SearchOption.TopDirectoryOnly)
 										 .Where(x => !x.FullName.Contains(@"\obj\"))										
 										 .ToArray();
 

--- a/Project2015To2017/Reading/NuSpecReader.cs
+++ b/Project2015To2017/Reading/NuSpecReader.cs
@@ -13,6 +13,7 @@ namespace Project2015To2017.Reading
 		{
 			var nuspecFiles = projectFile.Directory
 										 .EnumerateFiles("*.nuspec", SearchOption.AllDirectories)
+										 .Where(x => !x.FullName.Contains(@"\obj\"))										
 										 .ToArray();
 
 			if (nuspecFiles.Length == 0)

--- a/Project2015To2017/Reading/NuSpecReader.cs
+++ b/Project2015To2017/Reading/NuSpecReader.cs
@@ -12,8 +12,7 @@ namespace Project2015To2017.Reading
 		public PackageConfiguration Read(FileInfo projectFile, IProgress<string> progress)
 		{
 			var nuspecFiles = projectFile.Directory
-										 .EnumerateFiles("*.nuspec", SearchOption.TopDirectoryOnly)
-										 .Where(x => !x.FullName.Contains(@"\obj\"))										
+										 .EnumerateFiles("*.nuspec", SearchOption.TopDirectoryOnly)								
 										 .ToArray();
 
 			if (nuspecFiles.Length == 0)

--- a/Project2015To2017/Transforms/NugetPackageTransformation.cs
+++ b/Project2015To2017/Transforms/NugetPackageTransformation.cs
@@ -77,7 +77,8 @@ namespace Project2015To2017.Transforms
 				Tags = rawPackageConfig.Tags,
 				ReleaseNotes = rawPackageConfig.ReleaseNotes,
 				RequiresLicenseAcceptance = rawPackageConfig.RequiresLicenseAcceptance,
-				Dependencies = rawPackageConfig.Dependencies
+				Dependencies = rawPackageConfig.Dependencies,
+				NuspecFile = rawPackageConfig.NuspecFile
 			};
 		}
 


### PR DESCRIPTION
I had a problem where nuspecs were getting picked up from solutions in sub-folders and from the backup folder when I had previously run the transform and then reverted it. 

In our case the nuspec is always at the root of the project and I think this is a safe assumption.