### PR TITLE
Add support for solutions that are not one directory up from the project.

### DIFF
--- a/Project2015To2017/Definition/Project.cs
+++ b/Project2015To2017/Definition/Project.cs
@@ -55,15 +55,30 @@ namespace Project2015To2017.Definition
 				var nuGetSettings = Settings.LoadDefaultSettings(projectFolder);
 				var repositoryPathSetting = SettingsUtility.GetRepositoryPath(nuGetSettings);
 
-				//return the explicitly set path, or if there isn't one, then assume the solution is one level
-				//above the project and therefore so is the 'packages' folder
-				var path = repositoryPathSetting ?? Path.GetFullPath(Path.Combine(projectFolder, @"..\packages"));
+				//return the explicitly set path, or if there isn't one, then use the solution's path if one was provided.
+				//Otherwise assume a solution is one level above the project and therefore so is the 'packages' folder
+				if (repositoryPathSetting != null)
+				{
+					return new DirectoryInfo(repositoryPathSetting);
+				}
+
+				if (Solution != null)
+				{
+					return Solution.NugetPackagesPath;
+				}
+
+				var path = Path.GetFullPath(Path.Combine(projectFolder, @"..\packages"));
 
 				return new DirectoryInfo(path);
 			}
 		}
 
 		public FileInfo PackagesConfigFile { get; set; }
+
+		/// <summary>
+		/// The solution in which this project was found, if any.
+		/// </summary>
+		public Solution Solution { get; set; }
 
 		public IReadOnlyList<XElement> AssemblyAttributeProperties { get; set; } = Array.Empty<XElement>();
 	}

--- a/Project2015To2017/Definition/Solution.cs
+++ b/Project2015To2017/Definition/Solution.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.IO;
+using NuGet.Configuration;
+
+namespace Project2015To2017.Definition
+{
+	public sealed class Solution
+	{
+		public FileInfo FilePath { get; set; }
+		public IReadOnlyList<string> ProjectPaths { get; set; }
+		public DirectoryInfo SolutionFolder => FilePath.Directory;
+
+		/// <summary>
+		/// The directory where nuget stores its extracted packages for the solution.
+		/// In general this is the 'packages' folder within the solution oflder, but
+		/// it can be overridden, which is accounted for here.
+		/// </summary>
+		public DirectoryInfo NugetPackagesPath
+		{
+			get
+			{
+				var solutionFolder = SolutionFolder.FullName;
+
+				var nuGetSettings = Settings.LoadDefaultSettings(solutionFolder);
+				var repositoryPathSetting = SettingsUtility.GetRepositoryPath(nuGetSettings);
+
+				//return the explicitly set path, or if there isn't one, then assume the 'packages' folder is in the solution folder
+				var path = repositoryPathSetting ?? Path.GetFullPath(Path.Combine(solutionFolder, "packages"));
+
+				return new DirectoryInfo(path);
+			}
+		}
+	}
+}

--- a/Project2015To2017/Reading/SolutionReader.cs
+++ b/Project2015To2017/Reading/SolutionReader.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Project2015To2017.Definition;
+
+namespace Project2015To2017.Reading
+{
+	public class SolutionReader
+	{
+		public Solution Read(string filePath)
+		{
+			return Read(filePath, new Progress<string>(_ => { }));
+		}
+
+		public Solution Read(string filePath, IProgress<string> progress)
+		{
+			var fileInfo = new FileInfo(filePath);
+			var projectPaths = new List<string>();
+			using (var reader = new StreamReader(fileInfo.OpenRead()))
+			{
+				string line;
+				while ((line = reader.ReadLine()) != null)
+				{
+					if (!line.Trim().StartsWith("Project(", StringComparison.Ordinal))
+					{
+						continue;
+					}
+
+					var projectPath = line.Split('"').FirstOrDefault(x => x.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase));
+					if (projectPath != null)
+					{
+						projectPaths.Add(projectPath);
+					}
+				}
+			}
+
+			var solutionDefinition = new Solution
+			{
+				FilePath = fileInfo,
+				ProjectPaths = projectPaths
+			};
+
+			return solutionDefinition;
+		}
+	}
+}


### PR DESCRIPTION
If a solution is specified, any projects converted will now use its actual location instead of assuming the solution is one level up.  If a folder or project is specified, the behavior is unchanged.

The company I work for has solutions stored in nonstandard locations, which was causing conversions to leave `<Reference>` tags for NuGet packages because it wasn't in the standard location.