### PR TITLE
Keep Linked Files as an Include

### DIFF
--- a/Project2015To2017/Transforms/FileTransformation.cs
+++ b/Project2015To2017/Transforms/FileTransformation.cs
@@ -78,7 +78,20 @@ namespace Project2015To2017.Transforms
 				if (includeAttribute != null && !includeAttribute.Value.Contains("*"))
 				{
 					var compiledFileAttributes = compiledFile.Attributes().Where(a => a.Name != "Include").ToList();
-					compiledFileAttributes.Add(new XAttribute("Update", includeAttribute.Value));
+
+					//keep Link as an Include
+					var linkElement = compiledFile.Elements().FirstOrDefault(a => a.Name.LocalName == "Link");
+					if (null != linkElement)
+					{
+						compiledFileAttributes.Add(new XAttribute("Include", includeAttribute.Value));
+						compiledFileAttributes.Add(new XAttribute("Link", linkElement.Value));
+						linkElement.Remove();
+					}
+					else
+					{
+						compiledFileAttributes.Add(new XAttribute("Update", includeAttribute.Value));
+					}
+
 					compiledFile.ReplaceAttributes(compiledFileAttributes);
 
 					if (!Path.GetFullPath(Path.Combine(projectFolder.FullName, includeAttribute.Value)).StartsWith(projectFolder.FullName))

--- a/Project2015To2017Tests/FileTransformationTest.cs
+++ b/Project2015To2017Tests/FileTransformationTest.cs
@@ -25,11 +25,12 @@ namespace Project2015To2017Tests
 
 	        var includeItems = project.IncludeItems;
 
-	        Assert.AreEqual(9, includeItems.Count);
+	        Assert.AreEqual(10, includeItems.Count);
 
-            Assert.AreEqual(6, includeItems.Count(x => x.Name == XmlNamespace + "Compile"));
-            Assert.AreEqual(6, includeItems.Count(x => x.Name == XmlNamespace + "Compile" && x.Attribute("Update") != null));
-            Assert.AreEqual(1, includeItems.Count(x => x.Name == XmlNamespace + "EmbeddedResource")); // #73 inlcude things that are not ending in .resx
+            Assert.AreEqual(7, includeItems.Count(x => x.Name == XmlNamespace + "Compile"));
+			Assert.AreEqual(6, includeItems.Count(x => x.Name == XmlNamespace + "Compile" && x.Attribute("Update") != null));
+			Assert.AreEqual(1, includeItems.Count(x => x.Name == XmlNamespace + "Compile" && x.Attribute("Include") != null));
+			Assert.AreEqual(1, includeItems.Count(x => x.Name == XmlNamespace + "EmbeddedResource")); // #73 inlcude things that are not ending in .resx
             Assert.AreEqual(0, includeItems.Count(x => x.Name == XmlNamespace + "Content"));
             Assert.AreEqual(2, includeItems.Count(x => x.Name == XmlNamespace + "None"));
 
@@ -43,7 +44,15 @@ namespace Project2015To2017Tests
 			
 			Assert.AreEqual("Resources.resx", dependentUponElement.Value);
 
-	        var sourceWithDesigner = includeItems.Single(
+			var linkedFile = includeItems.Single(
+										x => x.Name == XmlNamespace + "Compile"
+											 && x.Attribute("Include")?.Value == @"..\OtherTestProjects\OtherTestClass.cs"
+									);
+			var linkAttribute = linkedFile.Attributes().FirstOrDefault(a => a.Name == "Link");
+			Assert.IsNotNull(linkAttribute);
+			Assert.AreEqual("OtherTestClass.cs", linkAttribute.Value);
+
+			var sourceWithDesigner = includeItems.Single(
 								        x => x.Name == XmlNamespace + "Compile"
 								             && x.Attribute("Update")?.Value == @"SourceFileWithDesigner.cs"
 							        );

--- a/Project2015To2017Tests/TestFiles/FileInclusion/fileinclusion.testcsproj
+++ b/Project2015To2017Tests/TestFiles/FileInclusion/fileinclusion.testcsproj
@@ -87,6 +87,9 @@
 	  <DesignTime>True</DesignTime>
 	  <DependentUpon>Resources.resx</DependentUpon>
 	</Compile>
+	<Compile Include="..\OtherTestProjects\OtherTestClass.cs">
+	  <Link>OtherTestClass.cs</Link>
+	</Compile>
   </ItemGroup>
   <ItemGroup>
 	<EmbeddedResource Include="Properties\Resources.resx">

--- a/Project2015To2017Tests/TestFiles/OtherTestProjects/OtherTestClass.cs
+++ b/Project2015To2017Tests/TestFiles/OtherTestProjects/OtherTestClass.cs
@@ -1,0 +1,6 @@
+namespace Project2015To2017Tests.TestFiles.OtherTestProjects
+{
+	public class OtherTestClass
+	{
+	}
+}


### PR DESCRIPTION
Compile Includes with a Link are usually from an other directory, so they have to end as an Include and not as an Update.

fixes #128 