### PR TITLE
Project properties simplification

### DIFF
--- a/Project2015To2017/Definition/Project.cs
+++ b/Project2015To2017/Definition/Project.cs
@@ -21,9 +21,10 @@ namespace Project2015To2017.Definition
 		public IReadOnlyList<XElement> Targets { get; set; }
 		public IReadOnlyList<XElement> BuildEvents { get; set; }
 		public IReadOnlyList<string> Configurations { get; set; }
+		public IReadOnlyList<string> Platforms { get; set; }
 		public IReadOnlyList<XElement> OtherPropertyGroups { get; set; }
 
-		public IReadOnlyList<string> TargetFrameworks { get; set; }
+		public IList<string> TargetFrameworks { get; } = new List<string>();
 		public bool AppendTargetFrameworkToOutputPath { get; set; } = true;
 		public ApplicationType Type { get; set; }
 		public bool Optimize { get; set; }

--- a/Project2015To2017/Reading/ConditionEvaluator.cs
+++ b/Project2015To2017/Reading/ConditionEvaluator.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Project2015To2017.Reading.Conditionals;
+
+namespace Project2015To2017.Reading
+{
+	/// <summary>
+	/// 
+	/// </summary>
+	public static class ConditionEvaluator
+	{
+		#region MSBuild Conditional routine
+
+		private static readonly Regex SinglePropertyRegex = new Regex(@"^\$\(([^\$\(\)]*)\)$", RegexOptions.Compiled);
+
+		/// <summary>
+		/// Update our table which keeps track of all the properties that are referenced
+		/// inside of a condition and the string values that they are being tested against.
+		/// So, for example, if the condition was " '$(Configuration)' == 'Debug' ", we
+		/// would get passed in leftValue="$(Configuration)" and rightValueExpanded="Debug".
+		/// This call would add the string "Debug" to the list of possible values for the
+		/// "Configuration" property.
+		///
+		/// This method also handles the case when two or more properties are being
+		/// concatenated together with a vertical bar, as in '
+		///     $(Configuration)|$(Platform)' == 'Debug|x86'
+		/// </summary>
+		public static void UpdateConditionedPropertiesTable
+		(
+			Dictionary<string, List<string>>
+				conditionedPropertiesTable, // List of possible values, keyed by property name
+			string leftValue, // The raw value on the left side of the operator
+			string rightValueExpanded // The fully expanded value on the right side
+			// of the operator.
+		)
+		{
+			if ((conditionedPropertiesTable != null) && (rightValueExpanded.Length > 0))
+			{
+				// The left side should be exactly "$(propertyname)" or "$(propertyname1)|$(propertyname2)"
+				// or "$(propertyname1)|$(propertyname2)|$(propertyname3)", etc.  Anything else,
+				// and we don't touch the table.
+
+				// Split up the leftValue into pieces based on the vertical bar character.
+				// PERF: Avoid allocations from string.Split by forming spans between 'pieceStart' and 'pieceEnd'
+				var pieceStart = 0;
+
+				// Loop through each of the pieces.
+				while (true)
+				{
+					var pieceSeparator = leftValue.IndexOf('|', pieceStart);
+					var lastPiece = pieceSeparator < 0;
+					var pieceEnd = lastPiece ? leftValue.Length : pieceSeparator;
+
+					var singlePropertyMatch =
+						SinglePropertyRegex.Match(leftValue, pieceStart, pieceEnd - pieceStart);
+
+					if (singlePropertyMatch.Success)
+					{
+						// Find the first vertical bar on the right-hand-side expression.
+						var indexOfVerticalBar = rightValueExpanded.IndexOf('|');
+						string rightValueExpandedPiece;
+
+						// If there was no vertical bar, then just use the remainder of the right-hand-side
+						// expression as the value of the property, and terminate the loop after this iteration.
+						// Also, if we're on the last segment of the left-hand-side, then use the remainder
+						// of the right-hand-side expression as the value of the property.
+						if ((indexOfVerticalBar == -1) || lastPiece)
+						{
+							rightValueExpandedPiece = rightValueExpanded;
+							lastPiece = true;
+						}
+						else
+						{
+							// If we found a vertical bar, then the portion before the vertical bar is the
+							// property value which we will store in our table.  Then remove that portion
+							// from the original string so that the next iteration of the loop can easily search
+							// for the first vertical bar again.
+							rightValueExpandedPiece = rightValueExpanded.Substring(0, indexOfVerticalBar);
+							rightValueExpanded = rightValueExpanded.Substring(indexOfVerticalBar + 1);
+						}
+
+						// Capture the property name out of the regular expression.
+						var propertyName = singlePropertyMatch.Groups[1].ToString();
+
+						// Get the string collection for this property name, if one already exists.
+
+						// If this property is not already represented in the table, add a new entry
+						// for it.
+						if (!conditionedPropertiesTable.TryGetValue(propertyName, out var conditionedPropertyValues))
+						{
+							conditionedPropertyValues = new List<string>();
+							conditionedPropertiesTable[propertyName] = conditionedPropertyValues;
+						}
+
+						// If the "rightValueExpanded" is not already in the string collection
+						// for this property name, add it now.
+						if (!conditionedPropertyValues.Contains(rightValueExpandedPiece))
+						{
+							conditionedPropertyValues.Add(rightValueExpandedPiece);
+						}
+					}
+
+					if (lastPiece)
+					{
+						break;
+					}
+
+					pieceStart = pieceSeparator + 1;
+				}
+			}
+		}
+
+		#endregion
+
+		public static Dictionary<string, string> GetNonAmbiguousConditionContracts(string condition)
+		{
+			var res = new Dictionary<string, string>();
+
+			// it makes little sense for condition to be that short
+			if (condition.Length < 2)
+				return res;
+
+			foreach (var keyValuePair in GetConditionValues(condition))
+			{
+				if (keyValuePair.Value.Count != 1)
+					continue;
+				res.Add(keyValuePair.Key, keyValuePair.Value[0]);
+			}
+
+			return res;
+		}
+
+		public static Dictionary<string, List<string>> GetConditionValues(string condition)
+		{
+			var state = new ConditionEvaluationStateImpl();
+
+			// it makes little sense for condition to be that short
+			if (condition.Length < 2)
+				return state.ConditionedPropertiesInProject;
+
+			var parser = new Parser();
+			try
+			{
+				var node = parser.Parse(condition, ParserOptions.AllowAll);
+				node.Evaluate(state); // return value ignored
+			}
+			catch (Exception)
+			{
+				// ignored
+			}
+
+			return state.ConditionedPropertiesInProject;
+		}
+
+		private sealed class ConditionEvaluationStateImpl : IConditionEvaluationState
+		{
+			/// <inheritdoc />
+			public Dictionary<string, List<string>> ConditionedPropertiesInProject { get; } = new Dictionary<string, List<string>>();
+
+			/// <inheritdoc />
+			public string ExpandIntoStringBreakEarly(string expression)
+			{
+				return expression;
+			}
+
+			/// <inheritdoc />
+			public string ExpandIntoString(string expression)
+			{
+				return expression;
+			}
+		}
+	}
+}

--- a/Project2015To2017/Reading/Conditionals/AndExpressionNode.cs
+++ b/Project2015To2017/Reading/Conditionals/AndExpressionNode.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace Project2015To2017.Reading.Conditionals
+{
+    /// <summary>
+    /// Performs logical AND on children
+    /// Does not update conditioned properties table
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    internal sealed class AndExpressionNode : OperatorExpressionNode
+    {
+        /// <summary>
+        /// Evaluate as boolean
+        /// </summary>
+        internal override bool BoolEvaluate(IConditionEvaluationState state)
+        {
+            if (!LeftChild.BoolEvaluate(state))
+            {
+                // Short circuit
+                return false;
+            }
+            else
+            {
+                return RightChild.BoolEvaluate(state);
+            }
+        }
+
+        internal override string DebuggerDisplay => $"(and {LeftChild.DebuggerDisplay} {RightChild.DebuggerDisplay})";
+
+        #region REMOVE_COMPAT_WARNING
+        private bool _possibleAndCollision = true;
+        internal override bool PossibleAndCollision
+        {
+            set { _possibleAndCollision = value; }
+            get { return _possibleAndCollision; }
+        }
+        #endregion
+    }
+}

--- a/Project2015To2017/Reading/Conditionals/CharacterUtilities.cs
+++ b/Project2015To2017/Reading/Conditionals/CharacterUtilities.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Project2015To2017.Reading.Conditionals
+{
+    internal static class CharacterUtilities
+    {
+        static internal bool IsNumberStart(char candidate)
+        {
+            return (candidate == '+' || candidate == '-' || candidate == '.' || char.IsDigit(candidate));
+        }
+
+        static internal bool IsSimpleStringStart(char candidate)
+        {
+            return (candidate == '_' || char.IsLetter(candidate));
+        }
+
+        static internal bool IsSimpleStringChar(char candidate)
+        {
+            return (IsSimpleStringStart(candidate) || char.IsDigit(candidate));
+        }
+
+        static internal bool IsHexAlphabetic(char candidate)
+        {
+            return (candidate == 'a' || candidate == 'b' || candidate == 'c' || candidate == 'd' || candidate == 'e' || candidate == 'f' ||
+                candidate == 'A' || candidate == 'B' || candidate == 'C' || candidate == 'D' || candidate == 'E' || candidate == 'F');
+        }
+
+        static internal bool IsHexDigit(char candidate)
+        {
+            return (char.IsDigit(candidate) || IsHexAlphabetic(candidate));
+        }
+    }
+}

--- a/Project2015To2017/Reading/Conditionals/ConversionUtilities.cs
+++ b/Project2015To2017/Reading/Conditionals/ConversionUtilities.cs
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+using System.Text;
+using error = Project2015To2017.Reading.Conditionals.ErrorUtilities;
+
+namespace Project2015To2017.Reading.Conditionals
+{
+    /// <summary>
+    /// This class contains only static methods, which are useful throughout many
+    /// of the MSBuild classes and don't really belong in any specific class.   
+    /// </summary>
+    internal static class ConversionUtilities
+    {
+        /// <summary>
+        /// Converts a string to a bool.  We consider "true/false", "on/off", and 
+        /// "yes/no" to be valid boolean representations in the XML.
+        /// </summary>
+        /// <param name="parameterValue">The string to convert.</param>
+        /// <returns>Boolean true or false, corresponding to the string.</returns>
+        internal static bool ConvertStringToBool(string parameterValue)
+        {
+            if (ValidBooleanTrue(parameterValue))
+            {
+                return true;
+            }
+            else if (ValidBooleanFalse(parameterValue))
+            {
+                return false;
+            }
+            else
+            {
+                // Unsupported boolean representation.
+                error.VerifyThrowArgument(false, "Shared.CannotConvertStringToBool", parameterValue);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns a hex representation of a byte array.
+        /// </summary>
+        /// <param name="bytes">The bytes to convert</param>
+        /// <returns>A string byte types formated as X2.</returns>
+        internal static string ConvertByteArrayToHex(byte[] bytes)
+        {
+            var sb = new StringBuilder();
+            foreach (var b in bytes)
+            {
+                sb.AppendFormat("{0:X2}", b);
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns true if the string can be successfully converted to a bool,
+        /// such as "on" or "yes"
+        /// </summary>
+        internal static bool CanConvertStringToBool(string parameterValue)
+        {
+            return (ValidBooleanTrue(parameterValue) || ValidBooleanFalse(parameterValue));
+        }
+
+        /// <summary>
+        /// Returns true if the string represents a valid MSBuild boolean true value,
+        /// such as "on", "!false", "yes"
+        /// </summary>
+        private static bool ValidBooleanTrue(string parameterValue)
+        {
+            return ((String.Compare(parameterValue, "true", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "on", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "yes", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "!false", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "!off", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "!no", StringComparison.OrdinalIgnoreCase) == 0));
+        }
+
+        /// <summary>
+        /// Returns true if the string represents a valid MSBuild boolean false value,
+        /// such as "!on" "off" "no" "!true"
+        /// </summary>
+        private static bool ValidBooleanFalse(string parameterValue)
+        {
+            return ((String.Compare(parameterValue, "false", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "off", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "no", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "!true", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "!on", StringComparison.OrdinalIgnoreCase) == 0) ||
+                    (String.Compare(parameterValue, "!yes", StringComparison.OrdinalIgnoreCase) == 0));
+        }
+
+        /// <summary>
+        /// Converts a string like "123.456" into a double. Leading sign is allowed.
+        /// </summary>
+        internal static double ConvertDecimalToDouble(string number)
+        {
+            return Double.Parse(number, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture.NumberFormat);
+        }
+
+        /// <summary>
+        /// Converts a hex string like "0xABC" into a double.
+        /// </summary>
+        internal static double ConvertHexToDouble(string number)
+        {
+            return (double)Int32.Parse(number.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture.NumberFormat);
+        }
+
+        /// <summary>
+        /// Converts a string like "123.456" or "0xABC" into a double.
+        /// Tries decimal conversion first.
+        /// </summary>
+        internal static double ConvertDecimalOrHexToDouble(string number)
+        {
+            if (ConversionUtilities.ValidDecimalNumber(number))
+            {
+                return ConversionUtilities.ConvertDecimalToDouble(number);
+            }
+            else if (ConversionUtilities.ValidHexNumber(number))
+            {
+                return ConversionUtilities.ConvertHexToDouble(number);
+            }
+            else
+            {
+                ErrorUtilities.VerifyThrow(false, "Cannot numeric evaluate");
+                return 0.0D;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the string is a valid hex number, like "0xABC"
+        /// </summary>
+        private static bool ValidHexNumber(string number)
+        {
+            bool canConvert = false;
+            if (number.Length >= 3 && number[0] == '0' && (number[1] == 'x' || number[1] == 'X'))
+            {
+                int value;
+                canConvert = Int32.TryParse(number.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture.NumberFormat, out value);
+            }
+            return canConvert;
+        }
+
+        /// <summary>
+        /// Returns true if the string is a valid decimal number, like "-123.456"
+        /// </summary>
+        private static bool ValidDecimalNumber(string number)
+        {
+            double value;
+            return Double.TryParse(number, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture.NumberFormat, out value);
+        }
+
+        /// <summary>
+        /// Returns true if the string is a valid decimal or hex number
+        /// </summary>
+        internal static bool ValidDecimalOrHexNumber(string number)
+        {
+            return ValidDecimalNumber(number) || ValidHexNumber(number);
+        }
+    }
+}

--- a/Project2015To2017/Reading/Conditionals/EqualExpressionNode.cs
+++ b/Project2015To2017/Reading/Conditionals/EqualExpressionNode.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+
+namespace Project2015To2017.Reading.Conditionals
+{
+    /// <summary>
+    /// Compares for equality
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    internal sealed class EqualExpressionNode : MultipleComparisonNode
+    {
+        /// <summary>
+        /// Compare numbers
+        /// </summary>
+        protected override bool Compare(double left, double right)
+        {
+            return left == right;
+        }
+
+        /// <summary>
+        /// Compare booleans
+        /// </summary>
+        protected override bool Compare(bool left, bool right)
+        {
+            return left == right;
+        }
+
+        /// <summary>
+        /// Compare strings
+        /// </summary>
+        protected override bool Compare(string left, string right)
+        {
+            return String.Equals(left, right, StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal override string DebuggerDisplay => $"(== {LeftChild.DebuggerDisplay} {RightChild.DebuggerDisplay})";
+    }
+}

--- a/Project2015To2017/Reading/Conditionals/ErrorUtilities.cs
+++ b/Project2015To2017/Reading/Conditionals/ErrorUtilities.cs
@@ -1,0 +1,718 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+
+#if BUILDINGAPPXTASKS
+namespace Microsoft.Build.AppxPackage.Shared
+#else
+namespace Project2015To2017.Reading.Conditionals
+#endif
+{
+    /// <summary>
+    /// This class contains methods that are useful for error checking and validation.
+    /// </summary>
+    internal static class ErrorUtilities
+    {
+        /// <summary>
+        /// Emergency escape hatch. If a customer hits a bug in the shipped product causing an internal exception,
+        /// and fortuitously it happens that ignoring the VerifyThrow allows execution to continue in a reasonable way,
+        /// then we can give them this undocumented environment variable as an immediate workaround.
+        /// </summary>
+        private static readonly bool s_throwExceptions = String.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDDONOTTHROWINTERNAL"));
+
+        #region DebugTracing
+        public static void DebugTraceMessage(string category, string formatstring, params object[] parameters)
+        {
+        }
+        #endregion
+
+#if !BUILDINGAPPXTASKS
+        #region VerifyThrow -- for internal errors
+
+        /// <summary>
+        /// Throws InternalErrorException. 
+        /// This is only for situations that would mean that there is a bug in MSBuild itself.
+        /// </summary>
+        internal static void ThrowInternalError(string message, params object[] args)
+        {
+            if (s_throwExceptions)
+            {
+                throw new InternalErrorException(String.Format(CultureInfo.CurrentCulture, message, args));
+            }
+        }
+
+        /// <summary>
+        /// Throws InternalErrorException. 
+        /// This is only for situations that would mean that there is a bug in MSBuild itself.
+        /// </summary>
+        internal static void ThrowInternalError(string message, Exception innerException, params object[] args)
+        {
+            if (s_throwExceptions)
+            {
+                throw new InternalErrorException(String.Format(CultureInfo.CurrentCulture, message, args), innerException);
+            }
+        }
+
+        /// <summary>
+        /// Throws InternalErrorException. 
+        /// Indicates the code path followed should not have been possible.
+        /// This is only for situations that would mean that there is a bug in MSBuild itself.
+        /// </summary>
+        internal static void ThrowInternalErrorUnreachable()
+        {
+            if (s_throwExceptions)
+            {
+                throw new InternalErrorException("Unreachable?");
+            }
+        }
+
+        /// <summary>
+        /// Throws InternalErrorException. 
+        /// Indicates the code path followed should not have been possible.
+        /// This is only for situations that would mean that there is a bug in MSBuild itself.
+        /// </summary>
+        internal static void ThrowIfTypeDoesNotImplementToString(object param)
+        {
+#if DEBUG
+            // Check it has a real implementation of ToString()
+            if (String.Equals(param.GetType().ToString(), param.ToString(), StringComparison.Ordinal))
+            {
+                ErrorUtilities.ThrowInternalError("This type does not implement ToString() properly {0}", param.GetType().FullName);
+            }
+#endif
+        }
+
+        /// <summary>
+        /// Helper to throw an InternalErrorException when the specified parameter is null.
+        /// This should be used ONLY if this would indicate a bug in MSBuild rather than
+        /// anything caused by user action.
+        /// </summary>
+        /// <param name="parameter">The value of the argument.</param>
+        /// <param name="parameterName">Parameter that should not be null</param>
+        internal static void VerifyThrowInternalNull(object parameter, string parameterName)
+        {
+            if (parameter == null)
+            {
+                ThrowInternalError("{0} unexpectedly null", parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Helper to throw an InternalErrorException when a lock on the specified object is not already held.
+        /// This should be used ONLY if this would indicate a bug in MSBuild rather than
+        /// anything caused by user action.
+        /// </summary>
+        /// <param name="locker">The object that should already have been used as a lock.</param>
+        internal static void VerifyThrowInternalLockHeld(object locker)
+        {
+#if !CLR2COMPATIBILITY
+            if (!Monitor.IsEntered(locker))
+            {
+                ThrowInternalError("Lock should already have been taken");
+            }
+#endif
+        }
+
+        /// <summary>
+        /// Helper to throw an InternalErrorException when the specified parameter is null or zero length.
+        /// This should be used ONLY if this would indicate a bug in MSBuild rather than
+        /// anything caused by user action.
+        /// </summary>
+        /// <param name="parameterValue">The value of the argument.</param>
+        /// <param name="parameterName">Parameter that should not be null or zero length</param>
+        internal static void VerifyThrowInternalLength(string parameterValue, string parameterName)
+        {
+            VerifyThrowInternalNull(parameterValue, parameterName);
+
+            if (parameterValue.Length == 0)
+            {
+                ThrowInternalError("{0} unexpectedly empty", parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Helper to throw an InternalErrorException when the specified parameter is not a rooted path.
+        /// This should be used ONLY if this would indicate a bug in MSBuild rather than
+        /// anything caused by user action.
+        /// </summary>
+        /// <param name="value">Parameter that should be a rooted path</param>
+        internal static void VerifyThrowInternalRooted(string value)
+        {
+            if (!Path.IsPathRooted(value))
+            {
+                ThrowInternalError("{0} unexpectedly not a rooted path", value);
+            }
+        }
+
+        /// <summary>
+        /// This method should be used in places where one would normally put
+        /// an "assert". It should be used to validate that our assumptions are
+        /// true, where false would indicate that there must be a bug in our
+        /// code somewhere. This should not be used to throw errors based on bad
+        /// user input or anything that the user did wrong.
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="unformattedMessage"></param>
+        internal static void VerifyThrow
+        (
+            bool condition,
+            string unformattedMessage
+        )
+        {
+            if (!condition)
+            {
+                // PERF NOTE: explicitly passing null for the arguments array
+                // prevents memory allocation
+                ThrowInternalError(unformattedMessage, null, null);
+            }
+        }
+
+        /// <summary>
+        /// Overload for one string format argument.
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="unformattedMessage"></param>
+        /// <param name="arg0"></param>
+        internal static void VerifyThrow
+        (
+            bool condition,
+            string unformattedMessage,
+            object arg0
+        )
+        {
+            // PERF NOTE: check the condition here instead of pushing it into
+            // the ThrowInternalError() method, because that method always
+            // allocates memory for its variable array of arguments
+            if (!condition)
+            {
+                ThrowInternalError(unformattedMessage, arg0);
+            }
+        }
+
+        /// <summary>
+        /// Overload for two string format arguments.
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="unformattedMessage"></param>
+        /// <param name="arg0"></param>
+        /// <param name="arg1"></param>
+        internal static void VerifyThrow
+        (
+            bool condition,
+            string unformattedMessage,
+            object arg0,
+            object arg1
+        )
+        {
+            // PERF NOTE: check the condition here instead of pushing it into
+            // the ThrowInternalError() method, because that method always
+            // allocates memory for its variable array of arguments
+            if (!condition)
+            {
+                ThrowInternalError(unformattedMessage, arg0, arg1);
+            }
+        }
+
+        /// <summary>
+        /// Overload for three string format arguments.
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="unformattedMessage"></param>
+        /// <param name="arg0"></param>
+        /// <param name="arg1"></param>
+        /// <param name="arg2"></param>
+        internal static void VerifyThrow
+        (
+            bool condition,
+            string unformattedMessage,
+            object arg0,
+            object arg1,
+            object arg2
+        )
+        {
+            // PERF NOTE: check the condition here instead of pushing it into
+            // the ThrowInternalError() method, because that method always
+            // allocates memory for its variable array of arguments
+            if (!condition)
+            {
+                ThrowInternalError(unformattedMessage, arg0, arg1, arg2);
+            }
+        }
+
+        /// <summary>
+        /// Overload for four string format arguments.
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="unformattedMessage"></param>
+        /// <param name="arg0"></param>
+        /// <param name="arg1"></param>
+        /// <param name="arg2"></param>
+        /// <param name="arg3"></param>
+        internal static void VerifyThrow
+        (
+            bool condition,
+            string unformattedMessage,
+            object arg0,
+            object arg1,
+            object arg2,
+            object arg3
+        )
+        {
+            // PERF NOTE: check the condition here instead of pushing it into
+            // the ThrowInternalError() method, because that method always
+            // allocates memory for its variable array of arguments
+            if (!condition)
+            {
+                ThrowInternalError(unformattedMessage, arg0, arg1, arg2, arg3);
+            }
+        }
+
+        #endregion
+
+        #region VerifyThrowInvalidOperation
+
+        /// <summary>
+        /// Throws an InvalidOperationException with the specified resource string
+        /// </summary>
+        /// <param name="resourceName">Resource to use in the exception</param>
+        /// <param name="args">Formatting args.</param>
+        internal static void ThrowInvalidOperation(string resourceName, params object[] args)
+        {
+            if (s_throwExceptions)
+            {
+                throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture, resourceName, args));
+            }
+        }
+
+        /// <summary>
+        /// Throws an InvalidOperationException if the given condition is false.
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="resourceName"></param>
+        internal static void VerifyThrowInvalidOperation
+        (
+            bool condition,
+            string resourceName
+        )
+        {
+            if (!condition)
+            {
+                // PERF NOTE: explicitly passing null for the arguments array
+                // prevents memory allocation
+                ThrowInvalidOperation(resourceName, null);
+            }
+        }
+
+        /// <summary>
+        /// Overload for one string format argument.
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="resourceName"></param>
+        /// <param name="arg0"></param>
+        internal static void VerifyThrowInvalidOperation
+        (
+            bool condition,
+            string resourceName,
+            object arg0
+        )
+        {
+            // PERF NOTE: check the condition here instead of pushing it into
+            // the ThrowInvalidOperation() method, because that method always
+            // allocates memory for its variable array of arguments
+            if (!condition)
+            {
+                ThrowInvalidOperation(resourceName, arg0);
+            }
+        }
+
+        /// <summary>
+        /// Overload for two string format arguments.
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="resourceName"></param>
+        /// <param name="arg0"></param>
+        /// <param name="arg1"></param>
+        internal static void VerifyThrowInvalidOperation
+        (
+            bool condition,
+            string resourceName,
+            object arg0,
+            object arg1
+        )
+        {
+            // PERF NOTE: check the condition here instead of pushing it into
+            // the ThrowInvalidOperation() method, because that method always
+            // allocates memory for its variable array of arguments
+            if (!condition)
+            {
+                ThrowInvalidOperation(resourceName, arg0, arg1);
+            }
+        }
+
+        /// <summary>
+        /// Overload for three string format arguments.
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="resourceName"></param>
+        /// <param name="arg0"></param>
+        /// <param name="arg1"></param>
+        /// <param name="arg2"></param>
+        internal static void VerifyThrowInvalidOperation
+        (
+            bool condition,
+            string resourceName,
+            object arg0,
+            object arg1,
+            object arg2
+        )
+        {
+            // PERF NOTE: check the condition here instead of pushing it into
+            // the ThrowInvalidOperation() method, because that method always
+            // allocates memory for its variable array of arguments
+            if (!condition)
+            {
+                ThrowInvalidOperation(resourceName, arg0, arg1, arg2);
+            }
+        }
+
+        /// <summary>
+        /// Overload for four string format arguments.
+        /// </summary>
+        /// <param name="condition"></param>
+        /// <param name="resourceName"></param>
+        /// <param name="arg0"></param>
+        /// <param name="arg1"></param>
+        /// <param name="arg2"></param>
+        /// <param name="arg3"></param>
+        internal static void VerifyThrowInvalidOperation
+        (
+            bool condition,
+            string resourceName,
+            object arg0,
+            object arg1,
+            object arg2,
+            object arg3
+        )
+        {
+            // PERF NOTE: check the condition here instead of pushing it into
+            // the ThrowInvalidOperation() method, because that method always
+            // allocates memory for its variable array of arguments
+            if (!condition)
+            {
+                ThrowInvalidOperation(resourceName, arg0, arg1, arg2, arg3);
+            }
+        }
+
+        #endregion
+
+        #region VerifyThrowArgument
+
+        /// <summary>
+        /// Throws an ArgumentException that can include an inner exception.
+        /// 
+        /// PERF WARNING: calling a method that takes a variable number of arguments
+        /// is expensive, because memory is allocated for the array of arguments -- do
+        /// not call this method repeatedly in performance-critical scenarios
+        /// </summary>
+        internal static void ThrowArgument
+        (
+            string resourceName,
+            params object[] args
+        )
+        {
+            ThrowArgument(null, resourceName, args);
+        }
+
+        /// <summary>
+        /// Throws an ArgumentException that can include an inner exception.
+        /// 
+        /// PERF WARNING: calling a method that takes a variable number of arguments
+        /// is expensive, because memory is allocated for the array of arguments -- do
+        /// not call this method repeatedly in performance-critical scenarios
+        /// </summary>
+        /// <remarks>
+        /// This method is thread-safe.
+        /// </remarks>
+        /// <param name="innerException">Can be null.</param>
+        /// <param name="resourceName"></param>
+        /// <param name="args"></param>
+        private static void ThrowArgument
+        (
+            Exception innerException,
+            string resourceName,
+            params object[] args
+        )
+        {
+            if (s_throwExceptions)
+            {
+                throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, resourceName, args), innerException);
+            }
+        }
+
+        /// <summary>
+        /// Throws an ArgumentException if the given condition is false.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        /// <param name="condition"></param>
+        /// <param name="resourceName"></param>
+        internal static void VerifyThrowArgument
+        (
+            bool condition,
+            string resourceName
+        )
+        {
+            VerifyThrowArgument(condition, null, resourceName);
+        }
+
+        /// <summary>
+        /// Overload for one string format argument.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        /// <param name="condition"></param>
+        /// <param name="resourceName"></param>
+        /// <param name="arg0"></param>
+        internal static void VerifyThrowArgument
+        (
+            bool condition,
+            string resourceName,
+            object arg0
+        )
+        {
+            VerifyThrowArgument(condition, null, resourceName, arg0);
+        }
+
+        /// <summary>
+        /// Overload for two string format arguments.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        /// <param name="condition"></param>
+        /// <param name="resourceName"></param>
+        /// <param name="arg0"></param>
+        /// <param name="arg1"></param>
+        internal static void VerifyThrowArgument
+        (
+            bool condition,
+            string resourceName,
+            object arg0,
+            object arg1
+        )
+        {
+            VerifyThrowArgument(condition, null, resourceName, arg0, arg1);
+        }
+
+        /// <summary>
+        /// Overload for three string format arguments.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        internal static void VerifyThrowArgument
+        (
+            bool condition,
+            string resourceName,
+            object arg0,
+            object arg1,
+            object arg2
+        )
+        {
+            VerifyThrowArgument(condition, null, resourceName, arg0, arg1, arg2);
+        }
+
+        /// <summary>
+        /// Overload for four string format arguments.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        internal static void VerifyThrowArgument
+        (
+            bool condition,
+            string resourceName,
+            object arg0,
+            object arg1,
+            object arg2,
+            object arg3
+        )
+        {
+            VerifyThrowArgument(condition, null, resourceName, arg0, arg1, arg2, arg3);
+        }
+
+        /// <summary>
+        /// Throws an ArgumentException that includes an inner exception, if
+        /// the given condition is false.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        /// <param name="condition"></param>
+        /// <param name="innerException">Can be null.</param>
+        /// <param name="resourceName"></param>
+        internal static void VerifyThrowArgument
+        (
+            bool condition,
+            Exception innerException,
+            string resourceName
+        )
+        {
+            if (!condition)
+            {
+                // PERF NOTE: explicitly passing null for the arguments array
+                // prevents memory allocation
+                ThrowArgument(innerException, resourceName, null);
+            }
+        }
+
+        /// <summary>
+        /// Overload for one string format argument.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        /// <param name="condition"></param>
+        /// <param name="innerException"></param>
+        /// <param name="resourceName"></param>
+        /// <param name="arg0"></param>
+        internal static void VerifyThrowArgument
+        (
+            bool condition,
+            Exception innerException,
+            string resourceName,
+            object arg0
+        )
+        {
+            // PERF NOTE: check the condition here instead of pushing it into
+            // the ThrowArgument() method, because that method always allocates
+            // memory for its variable array of arguments
+            if (!condition)
+            {
+                ThrowArgument(innerException, resourceName, arg0);
+            }
+        }
+
+        /// <summary>
+        /// Overload for two string format arguments.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        /// <param name="condition"></param>
+        /// <param name="innerException"></param>
+        /// <param name="resourceName"></param>
+        /// <param name="arg0"></param>
+        /// <param name="arg1"></param>
+        internal static void VerifyThrowArgument
+        (
+            bool condition,
+            Exception innerException,
+            string resourceName,
+            object arg0,
+            object arg1
+        )
+        {
+            // PERF NOTE: check the condition here instead of pushing it into
+            // the ThrowArgument() method, because that method always allocates
+            // memory for its variable array of arguments
+            if (!condition)
+            {
+                ThrowArgument(innerException, resourceName, arg0, arg1);
+            }
+        }
+
+        /// <summary>
+        /// Overload for three string format arguments.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        internal static void VerifyThrowArgument
+        (
+            bool condition,
+            Exception innerException,
+            string resourceName,
+            object arg0,
+            object arg1,
+            object arg2
+        )
+        {
+            // PERF NOTE: check the condition here instead of pushing it into
+            // the ThrowArgument() method, because that method always allocates
+            // memory for its variable array of arguments
+            if (!condition)
+            {
+                ThrowArgument(innerException, resourceName, arg0, arg1, arg2);
+            }
+        }
+
+        /// <summary>
+        /// Overload for four string format arguments.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        internal static void VerifyThrowArgument
+        (
+            bool condition,
+            Exception innerException,
+            string resourceName,
+            object arg0,
+            object arg1,
+            object arg2,
+            object arg3
+        )
+        {
+            // PERF NOTE: check the condition here instead of pushing it into
+            // the ThrowArgument() method, because that method always allocates
+            // memory for its variable array of arguments
+            if (!condition)
+            {
+                ThrowArgument(innerException, resourceName, arg0, arg1, arg2, arg3);
+            }
+        }
+
+        #endregion
+
+        #region VerifyThrowArgumentXXX
+
+        /// <summary>
+        /// Throws an argument out of range exception.
+        /// </summary>
+        internal static void ThrowArgumentOutOfRange(string parameterName)
+        {
+            if (s_throwExceptions)
+            {
+                throw new ArgumentOutOfRangeException(parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Throws an ArgumentOutOfRangeException using the given parameter name
+        /// if the condition is false.
+        /// </summary>
+        internal static void VerifyThrowArgumentOutOfRange(bool condition, string parameterName)
+        {
+            if (!condition)
+            {
+                ThrowArgumentOutOfRange(parameterName);
+            }
+        }
+
+        /// <summary>
+        /// Throws an ArgumentNullException if the given parameter is null.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        /// <param name="parameter"></param>
+        /// <param name="parameterName"></param>
+        internal static void VerifyThrowArgumentNull(object parameter, string parameterName)
+        {
+            VerifyThrowArgumentNull(parameter, parameterName, "Shared.ParameterCannotBeNull");
+        }
+
+        /// <summary>
+        /// Throws an ArgumentNullException if the given parameter is null.
+        /// </summary>
+        /// <remarks>This method is thread-safe.</remarks>
+        internal static void VerifyThrowArgumentNull(object parameter, string parameterName, string resourceName)
+        {
+            if (parameter == null && s_throwExceptions)
+            {
+                // Most ArgumentNullException overloads append its own rather clunky multi-line message. 
+                // So use the one overload that doesn't.
+                throw new ArgumentNullException(
+	                String.Format(CultureInfo.CurrentCulture, resourceName, parameterName),
+                    (Exception)null);
+            }
+        }
+        #endregion
+#endif
+    }
+}

--- a/Project2015To2017/Reading/Conditionals/FunctionCallExpressionNode.cs
+++ b/Project2015To2017/Reading/Conditionals/FunctionCallExpressionNode.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Project2015To2017.Reading.Conditionals
+{
+    /// <summary>
+    /// Evaluates a function expression, such as "Exists('foo')"
+    /// </summary>
+    internal sealed class FunctionCallExpressionNode : OperatorExpressionNode
+    {
+        private readonly List<GenericExpressionNode> _arguments;
+        private readonly string _functionName;
+
+        internal FunctionCallExpressionNode(string functionName, List<GenericExpressionNode> arguments)
+        {
+            _functionName = functionName;
+            _arguments = arguments;
+        }
+
+        /// <summary>
+        /// Evaluate node as boolean
+        /// </summary>
+        internal override bool BoolEvaluate(IConditionEvaluationState state)
+        {
+            if (String.Compare(_functionName, "exists", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                return true;
+            }
+            else if (String.Compare(_functionName, "HasTrailingSlash", StringComparison.OrdinalIgnoreCase) == 0)
+            {
+	            return true;
+            }
+            // We haven't implemented any other "functions"
+            else
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/Project2015To2017/Reading/Conditionals/GenericExpressionNode.cs
+++ b/Project2015To2017/Reading/Conditionals/GenericExpressionNode.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Project2015To2017.Reading.Conditionals
+{
+	/// <summary>
+	/// Base class for all expression nodes.
+	/// </summary>
+	public abstract class GenericExpressionNode
+    {
+        internal abstract bool CanBoolEvaluate(IConditionEvaluationState state);
+        internal abstract bool CanNumericEvaluate(IConditionEvaluationState state);
+        internal abstract bool CanVersionEvaluate(IConditionEvaluationState state);
+        internal abstract bool BoolEvaluate(IConditionEvaluationState state);
+        internal abstract double NumericEvaluate(IConditionEvaluationState state);
+        internal abstract Version VersionEvaluate(IConditionEvaluationState state);
+
+        /// <summary>
+        /// Returns true if this node evaluates to an empty string,
+        /// otherwise false.
+        /// (It may be cheaper to determine whether an expression will evaluate
+        /// to empty than to fully evaluate it.)
+        /// Implementations should cache the result so that calls after the first are free.
+        /// </summary>
+        internal virtual bool EvaluatesToEmpty(IConditionEvaluationState state)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// Value after any item and property expressions are expanded
+        /// </summary>
+        /// <returns></returns>
+        internal abstract string GetExpandedValue(IConditionEvaluationState state);
+
+        /// <summary>
+        /// Value before any item and property expressions are expanded
+        /// </summary>
+        /// <returns></returns>
+        internal abstract string GetUnexpandedValue(IConditionEvaluationState state);
+
+        /// <summary>
+        /// If any expression nodes cache any state for the duration of evaluation, 
+        /// now's the time to clean it up
+        /// </summary>
+        internal abstract void ResetState();
+
+        /// <summary>
+        /// The main evaluate entry point for expression trees
+        /// </summary>
+        /// <param name="state"></param>
+        /// <returns></returns>
+        internal bool Evaluate(IConditionEvaluationState state)
+        {
+            return BoolEvaluate(state);
+        }
+
+        /// <summary>
+        /// Get display string for this node for use in the debugger.
+        /// </summary>
+        internal virtual string DebuggerDisplay { get; }
+
+
+        #region REMOVE_COMPAT_WARNING
+        internal virtual bool PossibleAndCollision
+        {
+            set { /* do nothing */ }
+            get { return false; }
+        }
+
+        internal virtual bool PossibleOrCollision
+        {
+            set { /* do nothing */ }
+            get { return false; }
+        }
+
+        internal abstract bool DetectOr();
+        internal abstract bool DetectAnd();
+        #endregion
+
+    }
+}

--- a/Project2015To2017/Reading/Conditionals/GreaterThanExpressionNode.cs
+++ b/Project2015To2017/Reading/Conditionals/GreaterThanExpressionNode.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+
+namespace Project2015To2017.Reading.Conditionals
+{
+    /// <summary>
+    /// Compares for left > right
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    internal sealed class GreaterThanExpressionNode : NumericComparisonExpressionNode
+    {
+        /// <summary>
+        /// Compare numerically
+        /// </summary>
+        protected override bool Compare(double left, double right)
+        {
+            return left > right;
+        }
+
+        /// <summary>
+        /// Compare Versions. This is only intended to compare version formats like "A.B.C.D" which can otherwise not be compared numerically
+        /// </summary>
+        /// <returns></returns>
+        protected override bool Compare(Version left, Version right)
+        {
+            return left > right;
+        }
+
+        /// <summary>
+        /// Compare mixed numbers and Versions
+        /// </summary>
+        protected override bool Compare(Version left, double right)
+        {
+            if (left.Major != right)
+            {
+                return left.Major > right;
+            }
+
+            // If they have same "major" number, then that means we are comparing something like "6.X.Y.Z" to "6". Version treats the objects with more dots as
+            // "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
+            return true;
+        }
+
+        /// <summary>
+        /// Compare mixed numbers and Versions
+        /// </summary>
+        protected override bool Compare(double left, Version right)
+        {
+            if (right.Major != left)
+            {
+                return left > right.Major;
+            }
+
+            // If they have same "major" number, then that means we are comparing something like "6.X.Y.Z" to "6". Version treats the objects with more dots as
+            // "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
+            return false;
+        }
+
+        internal override string DebuggerDisplay => $"(> {LeftChild.DebuggerDisplay} {RightChild.DebuggerDisplay})";
+    }
+}

--- a/Project2015To2017/Reading/Conditionals/GreaterThanOrEqualExpressionNode.cs
+++ b/Project2015To2017/Reading/Conditionals/GreaterThanOrEqualExpressionNode.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+
+namespace Project2015To2017.Reading.Conditionals
+{
+    /// <summary>
+    /// Compares for left >= right
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    internal sealed class GreaterThanOrEqualExpressionNode : NumericComparisonExpressionNode
+    {
+        /// <summary>
+        /// Compare numerically
+        /// </summary>
+        protected override bool Compare(double left, double right)
+        {
+            return left >= right;
+        }
+
+        /// <summary>
+        /// Compare Versions. This is only intended to compare version formats like "A.B.C.D" which can otherwise not be compared numerically
+        /// </summary>
+        /// <returns></returns>
+        protected override bool Compare(Version left, Version right)
+        {
+            return left >= right;
+        }
+
+        /// <summary>
+        /// Compare mixed numbers and Versions
+        /// </summary>
+        protected override bool Compare(Version left, double right)
+        {
+            if (left.Major != right)
+            {
+                return left.Major >= right;
+            }
+
+            // If they have same "major" number, then that means we are comparing something like "6.X.Y.Z" to "6". Version treats the objects with more dots as
+            // "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
+            return true;
+        }
+
+        /// <summary>
+        /// Compare mixed numbers and Versions
+        /// </summary>
+        protected override bool Compare(double left, Version right)
+        {
+            if (right.Major != left)
+            {
+                return left >= right.Major;
+            }
+
+            // If they have same "major" number, then that means we are comparing something like "6.X.Y.Z" to "6". Version treats the objects with more dots as
+            // "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
+            return false;
+        }
+
+        internal override string DebuggerDisplay => $"(>= {LeftChild.DebuggerDisplay} {RightChild.DebuggerDisplay})";
+    }
+}

--- a/Project2015To2017/Reading/Conditionals/IConditionEvaluationState.cs
+++ b/Project2015To2017/Reading/Conditionals/IConditionEvaluationState.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+
+namespace Project2015To2017.Reading.Conditionals
+{
+	internal interface IConditionEvaluationState
+	{
+		/// <summary>
+		///     Table of conditioned properties and their values.
+		///     Used to populate configuration lists in some project systems.
+		///     If this is null, as it is for command line builds, conditioned properties
+		///     are not recorded.
+		/// </summary>
+		Dictionary<string, List<string>> ConditionedPropertiesInProject { get; }
+
+		/// <summary>
+		///     May return null if the expression would expand to non-empty and it broke out early.
+		///     Otherwise, returns the correctly expanded expression.
+		/// </summary>
+		string ExpandIntoStringBreakEarly(string expression);
+
+		/// <summary>
+		///     Expands the specified expression into a string.
+		/// </summary>
+		string ExpandIntoString(string expression);
+	}
+}

--- a/Project2015To2017/Reading/Conditionals/InternalErrorException.cs
+++ b/Project2015To2017/Reading/Conditionals/InternalErrorException.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+
+namespace Project2015To2017.Reading.Conditionals
+{
+    /// <summary>
+    /// This exception is to be thrown whenever an assumption we have made in the code turns out to be false. Thus, if this
+    /// exception ever gets thrown, it is because of a bug in our own code, not because of something the user or project author
+    /// did wrong.
+    /// 
+    /// !~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~
+    /// WARNING: When this file is shared into multiple assemblies each assembly will view this as a different type.
+    ///          Don't throw this exception from one assembly and catch it in another.
+    /// !~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~
+    ///     
+    /// </summary>
+    internal sealed class InternalErrorException : Exception
+    {
+        /// <summary>
+        /// Default constructor.
+        /// SHOULD ONLY BE CALLED BY DESERIALIZER. 
+        /// SUPPLY A MESSAGE INSTEAD.
+        /// </summary>
+        internal InternalErrorException() : base()
+        {
+            // do nothing
+        }
+
+        /// <summary>
+        /// Creates an instance of this exception using the given message.
+        /// </summary>
+        internal InternalErrorException
+        (
+            String message
+        ) :
+            base("MSB0001: Internal MSBuild Error: " + message)
+        {
+            ConsiderDebuggerLaunch(message, null);
+        }
+
+        /// <summary>
+        /// Creates an instance of this exception using the given message and inner exception.
+        /// Adds the inner exception's details to the exception message because most bug reporters don't bother
+        /// to provide the inner exception details which is typically what we care about.
+        /// </summary>
+        internal InternalErrorException
+        (
+            String message,
+            Exception innerException
+        ) :
+            base("MSB0001: Internal MSBuild Error: " + message + (innerException == null ? String.Empty : ("\n=============\n" + innerException.ToString() + "\n\n")), innerException)
+        {
+            ConsiderDebuggerLaunch(message, innerException);
+        }
+
+        #region ConsiderDebuggerLaunch
+        /// <summary>
+        /// A fatal internal error due to a bug has occurred. Give the dev a chance to debug it, if possible.
+        /// 
+        /// Will in all cases launch the debugger, if the environment variable "MSBUILDLAUNCHDEBUGGER" is set.
+        /// 
+        /// In DEBUG build, will always launch the debugger, unless we are in razzle (_NTROOT is set) or in NUnit,
+        /// or MSBUILDDONOTLAUNCHDEBUGGER is set (that could be useful in suite runs).
+        /// We don't launch in retail or LKG so builds don't jam; they get a callstack, and continue or send a mail, etc.
+        /// We don't launch in NUnit as tests often intentionally cause InternalErrorExceptions.
+        /// 
+        /// Because we only call this method from this class, just before throwing an InternalErrorException, there is 
+        /// no danger that this suppression will cause a bug to only manifest itself outside NUnit
+        /// (which would be most unfortunate!). Do not make this non-private.
+        /// 
+        /// Unfortunately NUnit can't handle unhandled exceptions like InternalErrorException on anything other than
+        /// the main test thread. However, there's still a callstack displayed before it quits.
+        /// 
+        /// If it is going to launch the debugger, it first does a Debug.Fail to give information about what needs to
+        /// be debugged -- the exception hasn't been thrown yet. This automatically displays the current callstack.
+        /// </summary>
+        private static void ConsiderDebuggerLaunch(string message, Exception innerException)
+        {
+            string innerMessage = (innerException == null) ? String.Empty : innerException.ToString();
+
+            if (Environment.GetEnvironmentVariable("MSBUILDLAUNCHDEBUGGER") != null)
+            {
+                LaunchDebugger(message, innerMessage);
+                return;
+            }
+
+#if DEBUG
+            if (!RunningTests() && Environment.GetEnvironmentVariable("MSBUILDDONOTLAUNCHDEBUGGER") == null
+                && Environment.GetEnvironmentVariable("_NTROOT") == null)
+            {
+                LaunchDebugger(message, innerMessage);
+                return;
+            }
+#endif
+        }
+
+        private static void LaunchDebugger(string message, string innerMessage)
+        {
+#if FEATURE_DEBUG_LAUNCH
+            Debug.Fail(message, innerMessage);
+            Debugger.Launch();
+#else
+            Console.WriteLine("MSBuild Failure: " + message);    
+            if (!string.IsNullOrEmpty(innerMessage))
+            {
+                Console.WriteLine(innerMessage);
+            }
+            Console.WriteLine("Waiting for debugger to attach to process: " + Process.GetCurrentProcess().Id);
+            while (!Debugger.IsAttached)
+            {
+                System.Threading.Thread.Sleep(100);
+            }
+#endif
+        }
+        #endregion
+
+        private static bool RunningTests() => false;
+    }
+}

--- a/Project2015To2017/Reading/Conditionals/LessThanExpressionNode.cs
+++ b/Project2015To2017/Reading/Conditionals/LessThanExpressionNode.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+
+namespace Project2015To2017.Reading.Conditionals
+{
+    /// <summary>
+    /// Compares for left &lt; right
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    internal sealed class LessThanExpressionNode : NumericComparisonExpressionNode
+    {
+        /// <summary>
+        /// Compare numerically
+        /// </summary>
+        protected override bool Compare(double left, double right)
+        {
+            return left < right;
+        }
+
+        /// <summary>
+        /// Compare Versions. This is only intended to compare version formats like "A.B.C.D" which can otherwise not be compared numerically
+        /// </summary>
+        /// <returns></returns>
+        protected override bool Compare(Version left, Version right)
+        {
+            return left < right;
+        }
+
+        /// <summary>
+        /// Compare mixed numbers and Versions
+        /// </summary>
+        protected override bool Compare(Version left, double right)
+        {
+            if (left.Major != right)
+            {
+                return left.Major < right;
+            }
+
+            // If they have same "major" number, then that means we are comparing something like "6.X.Y.Z" to "6". Version treats the objects with more dots as
+            // "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
+            return false;
+        }
+
+        /// <summary>
+        /// Compare mixed numbers and Versions
+        /// </summary>
+        protected override bool Compare(double left, Version right)
+        {
+            if (right.Major != left)
+            {
+                return left < right.Major;
+            }
+
+            // If they have same "major" number, then that means we are comparing something like "6.X.Y.Z" to "6". Version treats the objects with more dots as
+            // "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
+            return true;
+        }
+
+        internal override string DebuggerDisplay => $"(< {LeftChild.DebuggerDisplay} {RightChild.DebuggerDisplay})";
+    }
+}

--- a/Project2015To2017/Reading/Conditionals/LessThanOrEqualExpressionNode.cs
+++ b/Project2015To2017/Reading/Conditionals/LessThanOrEqualExpressionNode.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+
+namespace Project2015To2017.Reading.Conditionals
+{
+    /// <summary>
+    /// Compares for left &lt;= right
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    internal sealed class LessThanOrEqualExpressionNode : NumericComparisonExpressionNode
+    {
+        /// <summary>
+        /// Compare numerically
+        /// </summary>
+        protected override bool Compare(double left, double right)
+        {
+            return left <= right;
+        }
+
+        /// <summary>
+        /// Compare Versions. This is only intended to compare version formats like "A.B.C.D" which can otherwise not be compared numerically
+        /// </summary>
+        /// <returns></returns>
+        protected override bool Compare(Version left, Version right)
+        {
+            return left <= right;
+        }
+
+        /// <summary>
+        /// Compare mixed numbers and Versions
+        /// </summary>
+        protected override bool Compare(Version left, double right)
+        {
+            if (left.Major != right)
+            {
+                return left.Major <= right;
+            }
+
+            // If they have same "major" number, then that means we are comparing something like "6.X.Y.Z" to "6". Version treats the objects with more dots as
+            // "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
+            return false;
+        }
+
+        /// <summary>
+        /// Compare mixed numbers and Versions
+        /// </summary>
+        protected override bool Compare(double left, Version right)
+        {
+            if (right.Major != left)
+            {
+                return left <= right.Major;
+            }
+
+            // If they have same "major" number, then that means we are comparing something like "6.X.Y.Z" to "6". Version treats the objects with more dots as
+            // "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
+            return true;
+        }
+
+        internal override string DebuggerDisplay => $"(<= {LeftChild.DebuggerDisplay} {RightChild.DebuggerDisplay})";
+    }
+}

--- a/Project2015To2017/Reading/Conditionals/MultipleComparisonExpressionNode.cs
+++ b/Project2015To2017/Reading/Conditionals/MultipleComparisonExpressionNode.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Project2015To2017.Reading.Conditionals
+{
+    /// <summary>
+    /// Evaluates as boolean and evaluates children as boolean, numeric, or string.
+    /// Order in which comparisons are attempted is numeric, boolean, then string.
+    /// Updates conditioned properties table.
+    /// </summary>
+    internal abstract class MultipleComparisonNode : OperatorExpressionNode
+    {
+        private bool _conditionedPropertiesUpdated = false;
+
+        /// <summary>
+        /// Compare numbers
+        /// </summary>
+        protected abstract bool Compare(double left, double right);
+
+        /// <summary>
+        /// Compare booleans
+        /// </summary>
+        protected abstract bool Compare(bool left, bool right);
+
+        /// <summary>
+        /// Compare strings
+        /// </summary>
+        protected abstract bool Compare(string left, string right);
+
+        /// <summary>
+        /// Evaluates as boolean and evaluates children as boolean, numeric, or string.
+        /// Order in which comparisons are attempted is numeric, boolean, then string.
+        /// Updates conditioned properties table.
+        /// </summary>
+        internal override bool BoolEvaluate(IConditionEvaluationState state)
+        {
+            // It's sometimes possible to bail out of expansion early if we just need to know whether 
+            // the result is empty string.
+            // If at least one of the left or the right hand side will evaluate to empty, 
+            // and we know which do, then we already have enough information to evaluate this expression.
+            // That means we don't have to fully expand a condition like " '@(X)' == '' " 
+            // which is a performance advantage if @(X) is a huge item list.
+            if (LeftChild.EvaluatesToEmpty(state) || RightChild.EvaluatesToEmpty(state))
+            {
+                UpdateConditionedProperties(state);
+
+                return Compare(LeftChild.EvaluatesToEmpty(state), RightChild.EvaluatesToEmpty(state));
+            }
+
+            if (LeftChild.CanNumericEvaluate(state) && RightChild.CanNumericEvaluate(state))
+            {
+                return Compare(LeftChild.NumericEvaluate(state), RightChild.NumericEvaluate(state));
+            }
+            else if (LeftChild.CanBoolEvaluate(state) && RightChild.CanBoolEvaluate(state))
+            {
+                return Compare(LeftChild.BoolEvaluate(state), RightChild.BoolEvaluate(state));
+            }
+            else // string comparison
+            {
+                string leftExpandedValue = LeftChild.GetExpandedValue(state);
+                string rightExpandedValue = RightChild.GetExpandedValue(state);
+				
+                UpdateConditionedProperties(state);
+
+                return Compare(leftExpandedValue, rightExpandedValue);
+            }
+        }
+
+        /// <summary>
+        /// Reset temporary state
+        /// </summary>
+        internal override void ResetState()
+        {
+            base.ResetState();
+            _conditionedPropertiesUpdated = false;
+        }
+
+        /// <summary>
+        /// Updates the conditioned properties table if it hasn't already been done.
+        /// </summary>
+        private void UpdateConditionedProperties(IConditionEvaluationState state)
+        {
+            if (!_conditionedPropertiesUpdated && state.ConditionedPropertiesInProject != null)
+            {
+                string leftUnexpandedValue = LeftChild.GetUnexpandedValue(state);
+                string rightUnexpandedValue = RightChild.GetUnexpandedValue(state);
+
+                if (leftUnexpandedValue != null)
+                {
+                    ConditionEvaluator.UpdateConditionedPropertiesTable
+                        (state.ConditionedPropertiesInProject,
+                         leftUnexpandedValue,
+                         RightChild.GetExpandedValue(state));
+                }
+
+                if (rightUnexpandedValue != null)
+                {
+                    ConditionEvaluator.UpdateConditionedPropertiesTable
+                        (state.ConditionedPropertiesInProject,
+                         rightUnexpandedValue,
+                         LeftChild.GetExpandedValue(state));
+                }
+
+                _conditionedPropertiesUpdated = true;
+            }
+        }
+    }
+}

--- a/Project2015To2017/Reading/Conditionals/NotEqualExpressionNode.cs
+++ b/Project2015To2017/Reading/Conditionals/NotEqualExpressionNode.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+
+namespace Project2015To2017.Reading.Conditionals
+{
+    /// <summary>
+    /// Compares for inequality
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    internal sealed class NotEqualExpressionNode : MultipleComparisonNode
+    {
+        /// <summary>
+        /// Compare numbers
+        /// </summary>
+        protected override bool Compare(double left, double right)
+        {
+            return left != right;
+        }
+
+        /// <summary>
+        /// Compare booleans
+        /// </summary>
+        protected override bool Compare(bool left, bool right)
+        {
+            return left != right;
+        }
+
+        /// <summary>
+        /// Compare strings
+        /// </summary>
+        protected override bool Compare(string left, string right)
+        {
+            return !String.Equals(left, right, StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal override string DebuggerDisplay => $"(!= {LeftChild.DebuggerDisplay} {RightChild.DebuggerDisplay})";
+    }
+}

--- a/Project2015To2017/Reading/Conditionals/NotExpressionNode.cs
+++ b/Project2015To2017/Reading/Conditionals/NotExpressionNode.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace Project2015To2017.Reading.Conditionals
+{
+    /// <summary>
+    /// Performs logical NOT on left child
+    /// Does not update conditioned properties table
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    internal sealed class NotExpressionNode : OperatorExpressionNode
+    {
+        /// <summary>
+        /// Evaluate as boolean
+        /// </summary>
+        internal override bool BoolEvaluate(IConditionEvaluationState state)
+        {
+            return !LeftChild.BoolEvaluate(state);
+        }
+
+        internal override bool CanBoolEvaluate(IConditionEvaluationState state)
+        {
+            return LeftChild.CanBoolEvaluate(state);
+        }
+
+        /// <summary>
+        /// Returns unexpanded value with '!' prepended. Useful for error messages.
+        /// </summary>
+        internal override string GetUnexpandedValue(IConditionEvaluationState state)
+        {
+            return "!" + LeftChild.GetUnexpandedValue(state);
+        }
+
+        /// <summary>
+        /// Returns expanded value with '!' prepended. Useful for error messages.
+        /// </summary>
+        internal override string GetExpandedValue(IConditionEvaluationState state)
+        {
+            return "!" + LeftChild.GetExpandedValue(state);
+        }
+
+        internal override string DebuggerDisplay => $"(not {LeftChild.DebuggerDisplay})";
+    }
+}

--- a/Project2015To2017/Reading/Conditionals/NumericComparisonExpressionNode.cs
+++ b/Project2015To2017/Reading/Conditionals/NumericComparisonExpressionNode.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Project2015To2017.Reading.Conditionals
+{
+    /// <summary>
+    /// Evaluates a numeric comparison, such as less-than, or greater-or-equal-than
+    /// Does not update conditioned properties table.
+    /// </summary>
+    internal abstract class NumericComparisonExpressionNode : OperatorExpressionNode
+    {
+        /// <summary>
+        /// Compare numbers
+        /// </summary>
+        protected abstract bool Compare(double left, double right);
+
+        /// <summary>
+        /// Compare Versions. This is only intended to compare version formats like "A.B.C.D" which can otherwise not be compared numerically
+        /// </summary>
+        protected abstract bool Compare(Version left, Version right);
+
+        /// <summary>
+        /// Compare mixed numbers and Versions
+        /// </summary>
+        protected abstract bool Compare(Version left, double right);
+
+        /// <summary>
+        /// Compare mixed numbers and Versions
+        /// </summary>
+        protected abstract bool Compare(double left, Version right);
+
+        /// <summary>
+        /// Evaluate as boolean
+        /// </summary>
+        internal override bool BoolEvaluate(IConditionEvaluationState state)
+        {
+            bool isLeftNum = LeftChild.CanNumericEvaluate(state);
+            bool isLeftVersion = LeftChild.CanVersionEvaluate(state);
+            bool isRightNum = RightChild.CanNumericEvaluate(state);
+            bool isRightVersion = RightChild.CanVersionEvaluate(state);
+            bool isNumeric = isLeftNum && isRightNum;
+            bool isVersion = isLeftVersion && isRightVersion;
+
+            // If the values identify as numeric, make that comparison instead of the Version comparison since numeric has a stricter definition
+            if (isNumeric)
+            {
+                return Compare(LeftChild.NumericEvaluate(state), RightChild.NumericEvaluate(state));
+            }
+            else if (isVersion)
+            {
+                return Compare(LeftChild.VersionEvaluate(state), RightChild.VersionEvaluate(state));
+            }
+
+            // If the numbers are of a mixed type, call that specific Compare method
+            if (isLeftNum && isRightVersion)
+            {
+                return Compare(LeftChild.NumericEvaluate(state), RightChild.VersionEvaluate(state));
+            }
+            else if (isLeftVersion && isRightNum)
+            {
+                return Compare(LeftChild.VersionEvaluate(state), RightChild.NumericEvaluate(state));
+            }
+
+            // Throw error here as this code should be unreachable
+            ErrorUtilities.ThrowInternalErrorUnreachable();
+            return false;
+        }
+    }
+}

--- a/Project2015To2017/Reading/Conditionals/NumericExpressionNode.cs
+++ b/Project2015To2017/Reading/Conditionals/NumericExpressionNode.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+
+namespace Project2015To2017.Reading.Conditionals
+{
+    /// <summary>
+    /// Represents a number - evaluates as numeric.
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    internal sealed class NumericExpressionNode : OperandExpressionNode
+    {
+        private string _value;
+
+        private NumericExpressionNode() { }
+
+        internal NumericExpressionNode(string value)
+        {
+            _value = value;
+        }
+
+        /// <summary>
+        /// Evaluate as boolean
+        /// </summary>
+        internal override bool BoolEvaluate(IConditionEvaluationState state)
+        {
+            // Should be unreachable: all calls check CanBoolEvaluate() first
+            ErrorUtilities.VerifyThrow(false, "Can't evaluate a numeric expression as boolean.");
+            return false;
+        }
+
+        /// <summary>
+        /// Evaluate as numeric
+        /// </summary>
+        internal override double NumericEvaluate(IConditionEvaluationState state)
+        {
+            return ConversionUtilities.ConvertDecimalOrHexToDouble(_value);
+        }
+
+        /// <summary>
+        /// Evaluate as a Version
+        /// </summary>
+        internal override Version VersionEvaluate(IConditionEvaluationState state)
+        {
+            return Version.Parse(_value);
+        }
+
+        /// <summary>
+        /// Whether it can be evaluated as a boolean: never allowed for numerics
+        /// </summary>
+        internal override bool CanBoolEvaluate(IConditionEvaluationState state)
+        {
+            // Numeric expressions are never allowed to be treated as booleans.
+            return false;
+        }
+
+        /// <summary>
+        /// Whether it can be evaluated as numeric
+        /// </summary>
+        internal override bool CanNumericEvaluate(IConditionEvaluationState state)
+        {
+            // It is not always possible to numerically evaluate even a numerical expression -
+            // for example, it may overflow a double. So check here.
+            return ConversionUtilities.ValidDecimalOrHexNumber(_value);
+        }
+
+        /// <summary>
+        /// Whether it can be evaluated as a Version
+        /// </summary>
+        internal override bool CanVersionEvaluate(IConditionEvaluationState state)
+        {
+            // Check if the value can be formatted as a Version number
+            // This is needed for nodes that identify as Numeric but can't be parsed as numbers (e.g. 8.1.1.0 vs 8.1)
+            Version unused;
+            return Version.TryParse(_value, out unused);
+        }
+
+        /// <summary>
+        /// Get the unexpanded value
+        /// </summary>
+        internal override string GetUnexpandedValue(IConditionEvaluationState state)
+        {
+            return _value;
+        }
+
+        /// <summary>
+        /// Get the expanded value
+        /// </summary>
+        internal override string GetExpandedValue(IConditionEvaluationState state)
+        {
+            return _value;
+        }
+
+        /// <summary>
+        /// If any expression nodes cache any state for the duration of evaluation, 
+        /// now's the time to clean it up
+        /// </summary>
+        internal override void ResetState()
+        {
+        }
+
+        internal override string DebuggerDisplay => $"#\"{_value}\")";
+    }
+}

--- a/Project2015To2017/Reading/Conditionals/OperandExpressionNode.cs
+++ b/Project2015To2017/Reading/Conditionals/OperandExpressionNode.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Project2015To2017.Reading.Conditionals
+{
+    /// <summary>
+    /// Base class for all nodes that are operands (are leaves in the parse tree)
+    /// </summary>
+    internal abstract class OperandExpressionNode : GenericExpressionNode
+    {
+        #region REMOVE_COMPAT_WARNING
+
+        internal override bool DetectAnd()
+        {
+            return false;
+        }
+
+        internal override bool DetectOr()
+        {
+            return false;
+        }
+        #endregion
+
+    }
+}

--- a/Project2015To2017/Reading/Conditionals/OperatorExpressionNode.cs
+++ b/Project2015To2017/Reading/Conditionals/OperatorExpressionNode.cs
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Project2015To2017.Reading.Conditionals
+{
+    /// <summary>
+    /// Base class for nodes that are operators (have children in the parse tree)
+    /// </summary>
+    internal abstract class OperatorExpressionNode : GenericExpressionNode
+    {
+        /// <summary>
+        /// Numeric evaluation is never allowed for operators
+        /// </summary>
+        internal override double NumericEvaluate(IConditionEvaluationState state)
+        {
+            // Should be unreachable: all calls check CanNumericEvaluate() first
+            ErrorUtilities.VerifyThrow(false, "Cannot numeric evaluate an operator");
+            return 0.0D;
+        }
+
+        /// <summary>
+        /// Version evaluation is never allowed for operators
+        /// </summary>
+        internal override Version VersionEvaluate(IConditionEvaluationState state)
+        {
+            ErrorUtilities.VerifyThrow(false, "Cannot version evaluate an operator");
+            return null;
+        }
+
+        /// <summary>
+        /// Whether boolean evaluation is allowed: always allowed for operators
+        /// </summary>
+        internal override bool CanBoolEvaluate(IConditionEvaluationState state)
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// Whether the node can be evaluated as a numeric: by default,
+        /// this is not allowed
+        /// </summary>
+        internal override bool CanNumericEvaluate(IConditionEvaluationState state)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// Whether the node can be evaluated as a version: by default,
+        /// this is not allowed
+        /// </summary>
+        internal override bool CanVersionEvaluate(IConditionEvaluationState state)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// Value after any item and property expressions are expanded
+        /// </summary>
+        /// <returns></returns>
+        internal override string GetExpandedValue(IConditionEvaluationState state)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// Value before any item and property expressions are expanded
+        /// </summary>
+        /// <returns></returns>
+        internal override string GetUnexpandedValue(IConditionEvaluationState state)
+        {
+            return null;
+        }
+
+        /// <summary>
+        /// If any expression nodes cache any state for the duration of evaluation, 
+        /// now's the time to clean it up
+        /// </summary>
+        internal override void ResetState()
+        {
+            if (LeftChild != null)
+            {
+                LeftChild.ResetState();
+            }
+
+            if (RightChild != null)
+            {
+                RightChild.ResetState();
+            }
+        }
+
+        /// <summary>
+        /// Storage for the left child
+        /// </summary>
+        internal GenericExpressionNode LeftChild { set; get; }
+
+        /// <summary>
+        /// Storage for the right child
+        /// </summary>
+        internal GenericExpressionNode RightChild { set; get; }
+
+        #region REMOVE_COMPAT_WARNING
+        internal override bool DetectAnd()
+        {
+            // Read the state of the current node
+            bool detectedAnd = this.PossibleAndCollision;
+            // Reset the flags on the current node
+            this.PossibleAndCollision = false;
+            // Process the children of the node if preset
+            bool detectAndRChild = false;
+            bool detectAndLChild = false;
+            if (RightChild != null)
+            {
+                detectAndRChild = RightChild.DetectAnd();
+            }
+            if (LeftChild != null)
+            {
+                detectAndLChild = LeftChild.DetectAnd();
+            }
+            return detectedAnd || detectAndRChild || detectAndLChild;
+        }
+
+        internal override bool DetectOr()
+        {
+            // Read the state of the current node
+            bool detectedOr = this.PossibleOrCollision;
+            // Reset the flags on the current node
+            this.PossibleOrCollision = false;
+            // Process the children of the node if preset
+            bool detectOrRChild = false;
+            bool detectOrLChild = false;
+            if (RightChild != null)
+            {
+                detectOrRChild = RightChild.DetectOr();
+            }
+            if (LeftChild != null)
+            {
+                detectOrLChild = LeftChild.DetectOr();
+            }
+            return detectedOr || detectOrRChild || detectOrLChild;
+        }
+        #endregion
+    }
+}

--- a/Project2015To2017/Reading/Conditionals/OrExpressionNode.cs
+++ b/Project2015To2017/Reading/Conditionals/OrExpressionNode.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace Project2015To2017.Reading.Conditionals
+{
+    /// <summary>
+    /// Performs logical OR on children
+    /// Does not update conditioned properties table
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    internal sealed class OrExpressionNode : OperatorExpressionNode
+    {
+        /// <summary>
+        /// Evaluate as boolean
+        /// </summary>
+        internal override bool BoolEvaluate(IConditionEvaluationState state)
+        {
+            if (LeftChild.BoolEvaluate(state))
+            {
+                // Short circuit
+                return true;
+            }
+            else
+            {
+                return RightChild.BoolEvaluate(state);
+            }
+        }
+
+        internal override string DebuggerDisplay => $"(or {LeftChild.DebuggerDisplay} {RightChild.DebuggerDisplay})";
+
+        #region REMOVE_COMPAT_WARNING
+        private bool _possibleOrCollision = true;
+        internal override bool PossibleOrCollision
+        {
+            set { _possibleOrCollision = value; }
+            get { return _possibleOrCollision; }
+        }
+        #endregion
+    }
+}

--- a/Project2015To2017/Reading/Conditionals/Parser.cs
+++ b/Project2015To2017/Reading/Conditionals/Parser.cs
@@ -1,0 +1,322 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Project2015To2017.Reading.Conditionals
+{
+    [Flags]
+    public enum ParserOptions
+    {
+        None = 0x0,
+        AllowProperties = 0x1,
+        AllowItemLists = 0x2,
+        AllowPropertiesAndItemLists = AllowProperties | AllowItemLists,
+        AllowBuiltInMetadata = 0x4,
+        AllowCustomMetadata = 0x8,
+        AllowItemMetadata = AllowBuiltInMetadata | AllowCustomMetadata,
+        AllowPropertiesAndItemMetadata = AllowProperties | AllowItemMetadata,
+        AllowPropertiesAndCustomMetadata = AllowProperties | AllowCustomMetadata,
+        AllowAll = AllowProperties | AllowItemLists | AllowItemMetadata
+    };
+
+    /// <summary>
+    /// This class implements the grammar for complex conditionals.
+    ///
+    /// The expression tree can then be evaluated and re-evaluated as needed.
+    /// </summary>
+    /// <remarks>
+    /// UNDONE: When we copied over the conditionals code, we didn't copy over the unit tests for scanner, parser, and expression tree.
+    /// </remarks>
+    public sealed class Parser
+    {
+        private Scanner _lexer;
+        private ParserOptions _options;
+        internal int errorPosition = 0; // useful for unit tests
+
+	    public Parser()
+        {
+            // nothing to see here, move along.
+        }
+
+		//
+		// Main entry point for parser.
+		// You pass in the expression you want to parse, and you get an
+		// ExpressionTree out the back end.
+		//
+	    public GenericExpressionNode Parse(string expression, ParserOptions optionSettings)
+        {
+            // We currently have no support (and no scenarios) for disallowing property references
+            // in Conditions.
+            ErrorUtilities.VerifyThrow(0 != (optionSettings & ParserOptions.AllowProperties),
+                "Properties should always be allowed.");
+
+            _options = optionSettings;
+
+            _lexer = new Scanner(expression, _options);
+            if (!_lexer.Advance())
+            {
+                errorPosition = _lexer.GetErrorPosition();
+            }
+            GenericExpressionNode node = Expr(expression);
+            if (!_lexer.IsNext(Token.TokenType.EndOfInput))
+            {
+                errorPosition = _lexer.GetErrorPosition();
+            }
+            return node;
+        }
+
+        //
+        // Top node of grammar
+        //    See grammar for how the following methods relate to each
+        //    other.
+        //
+        private GenericExpressionNode Expr(string expression)
+        {
+            GenericExpressionNode node = BooleanTerm(expression);
+            if (!_lexer.IsNext(Token.TokenType.EndOfInput))
+            {
+                node = ExprPrime(expression, node);
+            }
+
+            return node;
+        }
+
+        private GenericExpressionNode ExprPrime(string expression, GenericExpressionNode lhs)
+        {
+            if (Same(expression, Token.TokenType.EndOfInput))
+            {
+                return lhs;
+            }
+            else if (Same(expression, Token.TokenType.Or))
+            {
+                OperatorExpressionNode orNode = new OrExpressionNode();
+                GenericExpressionNode rhs = BooleanTerm(expression);
+                orNode.LeftChild = lhs;
+                orNode.RightChild = rhs;
+                return ExprPrime(expression, orNode);
+            }
+            else
+            {
+                // I think this is ok.  ExprPrime always shows up at
+                // the rightmost side of the grammar rhs, the EndOfInput case
+                // takes care of things
+                return lhs;
+            }
+        }
+
+        private GenericExpressionNode BooleanTerm(string expression)
+        {
+            GenericExpressionNode node = RelationalExpr(expression);
+            if (null == node)
+            {
+                errorPosition = _lexer.GetErrorPosition();
+            }
+
+            if (!_lexer.IsNext(Token.TokenType.EndOfInput))
+            {
+                node = BooleanTermPrime(expression, node);
+            }
+            return node;
+        }
+
+        private GenericExpressionNode BooleanTermPrime(string expression, GenericExpressionNode lhs)
+        {
+            if (_lexer.IsNext(Token.TokenType.EndOfInput))
+            {
+                return lhs;
+            }
+            else if (Same(expression, Token.TokenType.And))
+            {
+                GenericExpressionNode rhs = RelationalExpr(expression);
+                if (null == rhs)
+                {
+                    errorPosition = _lexer.GetErrorPosition();
+                }
+
+                OperatorExpressionNode andNode = new AndExpressionNode();
+                andNode.LeftChild = lhs;
+                andNode.RightChild = rhs;
+                return BooleanTermPrime(expression, andNode);
+            }
+            else
+            {
+                // Should this be error case?
+                return lhs;
+            }
+        }
+
+        private GenericExpressionNode RelationalExpr(string expression)
+        {
+            {
+                GenericExpressionNode lhs = Factor(expression);
+                if (null == lhs)
+                {
+                    errorPosition = _lexer.GetErrorPosition();
+                }
+
+                OperatorExpressionNode node = RelationalOperation(expression);
+                if (node == null)
+                {
+                    return lhs;
+                }
+                GenericExpressionNode rhs = Factor(expression);
+                node.LeftChild = lhs;
+                node.RightChild = rhs;
+                return node;
+            }
+        }
+
+
+        private OperatorExpressionNode RelationalOperation(string expression)
+        {
+            OperatorExpressionNode node = null;
+            if (Same(expression, Token.TokenType.LessThan))
+            {
+                node = new LessThanExpressionNode();
+            }
+            else if (Same(expression, Token.TokenType.GreaterThan))
+            {
+                node = new GreaterThanExpressionNode();
+            }
+            else if (Same(expression, Token.TokenType.LessThanOrEqualTo))
+            {
+                node = new LessThanOrEqualExpressionNode();
+            }
+            else if (Same(expression, Token.TokenType.GreaterThanOrEqualTo))
+            {
+                node = new GreaterThanOrEqualExpressionNode();
+            }
+            else if (Same(expression, Token.TokenType.EqualTo))
+            {
+                node = new EqualExpressionNode();
+            }
+            else if (Same(expression, Token.TokenType.NotEqualTo))
+            {
+                node = new NotEqualExpressionNode();
+            }
+            return node;
+        }
+
+        private GenericExpressionNode Factor(string expression)
+        {
+            // Checks for TokenTypes String, Numeric, Property, ItemMetadata, and ItemList.
+            GenericExpressionNode arg = this.Arg(expression);
+
+            // If it's one of those, return it.
+            if (arg != null)
+            {
+                return arg;
+            }
+
+            // If it's not one of those, check for other TokenTypes.
+            Token current = _lexer.CurrentToken;
+            if (Same(expression, Token.TokenType.Function))
+            {
+                if (!Same(expression, Token.TokenType.LeftParenthesis))
+                {
+                    errorPosition = _lexer.GetErrorPosition();
+                    return null;
+                }
+                var arglist = new List<GenericExpressionNode>();
+                Arglist(expression, arglist);
+                if (!Same(expression, Token.TokenType.RightParenthesis))
+                {
+                    errorPosition = _lexer.GetErrorPosition();
+                    return null;
+                }
+                return new FunctionCallExpressionNode(current.String, arglist);
+            }
+            else if (Same(expression, Token.TokenType.LeftParenthesis))
+            {
+                GenericExpressionNode child = Expr(expression);
+                if (Same(expression, Token.TokenType.RightParenthesis))
+                    return child;
+                else
+                {
+                    errorPosition = _lexer.GetErrorPosition();
+                }
+            }
+            else if (Same(expression, Token.TokenType.Not))
+            {
+                OperatorExpressionNode notNode = new NotExpressionNode();
+                GenericExpressionNode expr = Factor(expression);
+                if (expr == null)
+                {
+                    errorPosition = _lexer.GetErrorPosition();
+                }
+                notNode.LeftChild = expr;
+                return notNode;
+            }
+            else
+            {
+                errorPosition = _lexer.GetErrorPosition();
+            }
+            return null;
+        }
+
+        private void Arglist(string expression, List<GenericExpressionNode> arglist)
+        {
+            if (!_lexer.IsNext(Token.TokenType.RightParenthesis))
+            {
+                Args(expression, arglist);
+            }
+        }
+
+        private void Args(string expression, List<GenericExpressionNode> arglist)
+        {
+            GenericExpressionNode arg = Arg(expression);
+            arglist.Add(arg);
+            if (Same(expression, Token.TokenType.Comma))
+            {
+                Args(expression, arglist);
+            }
+        }
+
+        private GenericExpressionNode Arg(string expression)
+        {
+            Token current = _lexer.CurrentToken;
+            if (Same(expression, Token.TokenType.String))
+            {
+                return new StringExpressionNode(current.String, current.Expandable);
+            }
+            else if (Same(expression, Token.TokenType.Numeric))
+            {
+                return new NumericExpressionNode(current.String);
+            }
+            else if (Same(expression, Token.TokenType.Property))
+            {
+                return new StringExpressionNode(current.String, true /* requires expansion */);
+            }
+            else if (Same(expression, Token.TokenType.ItemMetadata))
+            {
+                return new StringExpressionNode(current.String, true /* requires expansion */);
+            }
+            else if (Same(expression, Token.TokenType.ItemList))
+            {
+                return new StringExpressionNode(current.String, true /* requires expansion */);
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+        private bool Same(string expression, Token.TokenType token)
+        {
+            if (_lexer.IsNext(token))
+            {
+                if (!_lexer.Advance())
+                {
+                    errorPosition = _lexer.GetErrorPosition();
+                }
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/Project2015To2017/Reading/Conditionals/Scanner.cs
+++ b/Project2015To2017/Reading/Conditionals/Scanner.cs
@@ -1,0 +1,683 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace Project2015To2017.Reading.Conditionals
+{
+    /// <summary>
+    /// Class:       Scanner
+    /// This class does the scanning of the input and returns tokens.
+    /// The usage pattern is:
+    ///    Scanner s = new Scanner(expression, CultureInfo)
+    ///    do {
+    ///      s.Advance();
+    ///    while (s.IsNext(Token.EndOfInput));
+    /// 
+    ///  After Advance() is called, you can get the current token (s.CurrentToken),
+    ///  check it's type (s.IsNext()), get the string for it (s.NextString()).
+    /// </summary>
+    internal sealed class Scanner
+    {
+        private string _expression;
+        private int _parsePoint;
+        private Token _lookahead;
+        private bool _errorState;
+        private int _errorPosition;
+        // What we found instead of what we were looking for
+        private string _unexpectedlyFound = null;
+        private ParserOptions _options;
+        private string _errorResource = null;
+        private static string s_endOfInput = null;
+
+        /// <summary>
+        /// Lazily format resource string to help avoid (in some perf critical cases) even loading
+        /// resources at all.
+        /// </summary>
+        private string EndOfInput
+        {
+            get
+            {
+                if (s_endOfInput == null)
+                {
+                    s_endOfInput = "EndOfInputTokenName";
+                }
+
+                return s_endOfInput;
+            }
+        }
+
+        private Scanner() { }
+        //
+        // Constructor takes the string to parse and the culture.
+        //
+        internal Scanner(string expressionToParse, ParserOptions options)
+        {
+            // We currently have no support (and no scenarios) for disallowing property references
+            // in Conditions.
+            ErrorUtilities.VerifyThrow(0 != (options & ParserOptions.AllowProperties),
+                "Properties should always be allowed.");
+
+            _expression = expressionToParse;
+            _parsePoint = 0;
+            _errorState = false;
+            _errorPosition = -1; // invalid
+            _options = options;
+        }
+
+        /// <summary>
+        /// If the lexer errors, it has the best knowledge of the error message to show. For example,
+        /// 'unexpected character' or 'illformed operator'. This method returns the name of the resource
+        /// string that the parser should display.
+        /// </summary>
+        /// <remarks>Intentionally not a property getter to avoid the debugger triggering the Assert dialog</remarks>
+        /// <returns></returns>
+        internal string GetErrorResource()
+        {
+            if (_errorResource == null)
+            {
+                // I do not believe this is reachable, but provide a reasonable default.
+                Debug.Assert(false, "What code path did not set an appropriate error resource? Expression: " + _expression);
+                _unexpectedlyFound = EndOfInput;
+                return "UnexpectedCharacterInCondition";
+            }
+            else
+            {
+                return _errorResource;
+            }
+        }
+
+        internal bool IsNext(Token.TokenType type)
+        {
+            return _lookahead.IsToken(type);
+        }
+
+        internal string IsNextString()
+        {
+            return _lookahead.String;
+        }
+
+        internal Token CurrentToken
+        {
+            get { return _lookahead; }
+        }
+
+        internal int GetErrorPosition()
+        {
+            Debug.Assert(-1 != _errorPosition); // We should have set it
+            return _errorPosition;
+        }
+
+        // The string (usually a single character) we found unexpectedly. 
+        // We might want to show it in the error message, to help the user spot the error.
+        internal string UnexpectedlyFound
+        {
+            get
+            {
+                return _unexpectedlyFound;
+            }
+        }
+
+        /// <summary>
+        /// Advance
+        /// returns true on successful advance
+        ///     and false on an erroneous token
+        ///
+        /// Doesn't return error until the bogus input is encountered.
+        /// Advance() returns true even after EndOfInput is encountered.
+        /// </summary>
+        internal bool Advance()
+        {
+            if (_errorState)
+                return false;
+
+            if (_lookahead != null && _lookahead.IsToken(Token.TokenType.EndOfInput))
+                return true;
+
+            SkipWhiteSpace();
+
+            // Update error position after skipping whitespace
+            _errorPosition = _parsePoint + 1;
+
+            if (_parsePoint >= _expression.Length)
+            {
+                _lookahead = Token.EndOfInput;
+            }
+            else
+            {
+                switch (_expression[_parsePoint])
+                {
+                    case ',':
+                        _lookahead = Token.Comma;
+                        _parsePoint++;
+                        break;
+                    case '(':
+                        _lookahead = Token.LeftParenthesis;
+                        _parsePoint++;
+                        break;
+                    case ')':
+                        _lookahead = Token.RightParenthesis;
+                        _parsePoint++;
+                        break;
+                    case '$':
+                        if (!ParseProperty())
+                            return false;
+                        break;
+                    case '%':
+                        if (!ParseItemMetadata())
+                            return false;
+                        break;
+                    case '@':
+                        int start = _parsePoint;
+                        // If the caller specified that he DOESN'T want to allow item lists ...
+                        if ((_options & ParserOptions.AllowItemLists) == 0)
+                        {
+                            if ((_parsePoint + 1) < _expression.Length && _expression[_parsePoint + 1] == '(')
+                            {
+                                _errorPosition = start + 1;
+                                _errorState = true;
+                                _errorResource = "ItemListNotAllowedInThisConditional";
+                                return false;
+                            }
+                        }
+                        if (!ParseItemList())
+                            return false;
+                        break;
+                    case '!':
+                        // negation and not-equal
+                        if ((_parsePoint + 1) < _expression.Length && _expression[_parsePoint + 1] == '=')
+                        {
+                            _lookahead = Token.NotEqualTo;
+                            _parsePoint += 2;
+                        }
+                        else
+                        {
+                            _lookahead = Token.Not;
+                            _parsePoint++;
+                        }
+                        break;
+                    case '>':
+                        // gt and gte
+                        if ((_parsePoint + 1) < _expression.Length && _expression[_parsePoint + 1] == '=')
+                        {
+                            _lookahead = Token.GreaterThanOrEqualTo;
+                            _parsePoint += 2;
+                        }
+                        else
+                        {
+                            _lookahead = Token.GreaterThan;
+                            _parsePoint++;
+                        }
+                        break;
+                    case '<':
+                        // lt and lte
+                        if ((_parsePoint + 1) < _expression.Length && _expression[_parsePoint + 1] == '=')
+                        {
+                            _lookahead = Token.LessThanOrEqualTo;
+                            _parsePoint += 2;
+                        }
+                        else
+                        {
+                            _lookahead = Token.LessThan;
+                            _parsePoint++;
+                        }
+                        break;
+                    case '=':
+                        if ((_parsePoint + 1) < _expression.Length && _expression[_parsePoint + 1] == '=')
+                        {
+                            _lookahead = Token.EqualTo;
+                            _parsePoint += 2;
+                        }
+                        else
+                        {
+                            _errorPosition = _parsePoint + 2; // expression[parsePoint + 1], counting from 1
+                            _errorResource = "IllFormedEqualsInCondition";
+                            if ((_parsePoint + 1) < _expression.Length)
+                            {
+                                // store the char we found instead
+                                _unexpectedlyFound = Convert.ToString(_expression[_parsePoint + 1], CultureInfo.InvariantCulture);
+                            }
+                            else
+                            {
+                                _unexpectedlyFound = EndOfInput;
+                            }
+                            _parsePoint++;
+                            _errorState = true;
+                            return false;
+                        }
+                        break;
+                    case '\'':
+                        if (!ParseQuotedString())
+                            return false;
+                        break;
+                    default:
+                        // Simple strings, function calls, decimal numbers, hex numbers
+                        if (!ParseRemaining())
+                            return false;
+                        break;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Parses either the $(propertyname) syntax or the %(metadataname) syntax, 
+        /// and returns the parsed string beginning with the '$' or '%', and ending with the
+        /// closing parenthesis.
+        /// </summary>
+        /// <returns></returns>
+        private string ParsePropertyOrItemMetadata()
+        {
+            int start = _parsePoint; // set start so that we include "$(" or "%("
+            _parsePoint++;
+
+            if (_parsePoint < _expression.Length && _expression[_parsePoint] != '(')
+            {
+                _errorState = true;
+                _errorPosition = start + 1;
+                _errorResource = "IllFormedPropertyOpenParenthesisInCondition";
+                _unexpectedlyFound = Convert.ToString(_expression[_parsePoint], CultureInfo.InvariantCulture);
+                return null;
+            }
+
+            _parsePoint = ScanForPropertyExpressionEnd(_expression, _parsePoint++);
+
+            // Maybe we need to generate an error for invalid characters in property/metadata name?
+            // For now, just wait and let the property/metadata evaluation handle the error case.
+            if (_parsePoint >= _expression.Length)
+            {
+                _errorState = true;
+                _errorPosition = start + 1;
+                _errorResource = "IllFormedPropertyCloseParenthesisInCondition";
+                _unexpectedlyFound = EndOfInput;
+                return null;
+            }
+
+            _parsePoint++;
+            return _expression.Substring(start, _parsePoint - start);
+        }
+
+        /// <summary>
+        /// Scan for the end of the property expression
+        /// </summary>
+        private static int ScanForPropertyExpressionEnd(string expression, int index)
+        {
+			int nestLevel = 0;
+
+			while (index < expression.Length)
+			{
+				char character = expression[index];
+				if (character == '(')
+				{
+					nestLevel++;
+				}
+				else if (character == ')')
+				{
+					nestLevel--;
+				}
+
+				// We have reached the end of the parenthesis nesting
+				// this should be the end of the property expression
+				// If it is not then the calling code will determine that
+				if (nestLevel == 0)
+				{
+					return index;
+				}
+				else
+				{
+					index++;
+				}
+			}
+
+			return index;
+		}
+
+        /// <summary>
+        /// Parses a string of the form $(propertyname).
+        /// </summary>
+        /// <returns></returns>
+        private bool ParseProperty()
+        {
+            string propertyExpression = this.ParsePropertyOrItemMetadata();
+
+            if (propertyExpression == null)
+            {
+                return false;
+            }
+            else
+            {
+                _lookahead = new Token(Token.TokenType.Property, propertyExpression);
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Parses a string of the form %(itemmetadataname).
+        /// </summary>
+        /// <returns></returns>
+        private bool ParseItemMetadata()
+        {
+            string itemMetadataExpression = this.ParsePropertyOrItemMetadata();
+
+            if (itemMetadataExpression == null)
+            {
+                // The ParsePropertyOrItemMetadata method returns the correct error resources
+                // for parsing properties such as $(propertyname).  At this stage in the Whidbey
+                // cycle, we're not allowed to add new string resources, so I can't add a new
+                // resource specific to item metadata, so here, we just change the error to
+                // the generic "UnexpectedCharacter".
+                _errorResource = "UnexpectedCharacterInCondition";
+                return false;
+            }
+
+            _lookahead = new Token(Token.TokenType.ItemMetadata, itemMetadataExpression);
+
+            if (!CheckForUnexpectedMetadata(itemMetadataExpression))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Helper to verify that any AllowBuiltInMetadata or AllowCustomMetadata
+        /// specifications are not respected.
+        /// Returns true if it is ok, otherwise false.
+        /// </summary>
+        private bool CheckForUnexpectedMetadata(string expression)
+        {
+            if ((_options & ParserOptions.AllowItemMetadata) == ParserOptions.AllowItemMetadata)
+            {
+                return true;
+            }
+
+            return true;
+        }
+
+        private bool ParseInternalItemList()
+        {
+            int start = _parsePoint;
+            _parsePoint++;
+
+            if (_parsePoint < _expression.Length && _expression[_parsePoint] != '(')
+            {
+                // @ was not followed by (
+                _errorPosition = start + 1;
+                _errorResource = "IllFormedItemListOpenParenthesisInCondition";
+                // Not useful to set unexpectedlyFound here. The message is going to be detailed enough.
+                _errorState = true;
+                return false;
+            }
+            _parsePoint++;
+            // Maybe we need to generate an error for invalid characters in itemgroup name?
+            // For now, just let item evaluation handle the error.
+            bool fInReplacement = false;
+            int parenToClose = 0;
+            while (_parsePoint < _expression.Length)
+            {
+                if (_expression[_parsePoint] == '\'')
+                {
+                    fInReplacement = !fInReplacement;
+                }
+                else if (_expression[_parsePoint] == '(' && !fInReplacement)
+                {
+                    parenToClose++;
+                }
+                else if (_expression[_parsePoint] == ')' && !fInReplacement)
+                {
+                    if (parenToClose == 0)
+                    {
+                        break;
+                    }
+                    else { parenToClose--; }
+                }
+                _parsePoint++;
+            }
+            if (_parsePoint >= _expression.Length)
+            {
+                _errorPosition = start + 1;
+                if (fInReplacement)
+                {
+                    // @( ... ' was never followed by a closing quote before the closing parenthesis
+                    _errorResource = "IllFormedItemListQuoteInCondition";
+                }
+                else
+                {
+                    // @( was never followed by a )
+                    _errorResource = "IllFormedItemListCloseParenthesisInCondition";
+                }
+                // Not useful to set unexpectedlyFound here. The message is going to be detailed enough.
+                _errorState = true;
+                return false;
+            }
+            _parsePoint++;
+            return true;
+        }
+
+        private bool ParseItemList()
+        {
+            int start = _parsePoint;
+            if (!ParseInternalItemList())
+            {
+                return false;
+            }
+            _lookahead = new Token(Token.TokenType.ItemList, _expression.Substring(start, _parsePoint - start));
+            return true;
+        }
+
+        /// <summary>
+        /// Parse any part of the conditional expression that is quoted. It may contain a property, item, or 
+        /// metadata element that needs expansion during evaluation.
+        /// </summary>
+        private bool ParseQuotedString()
+        {
+            _parsePoint++;
+            int start = _parsePoint;
+            bool expandable = false;
+            while (_parsePoint < _expression.Length && _expression[_parsePoint] != '\'')
+            {
+                // Standalone percent-sign must be allowed within a condition because it's
+                // needed to escape special characters.  However, percent-sign followed
+                // by open-parenthesis is an indication of an item metadata reference, and
+                // that is only allowed in certain contexts.
+                if ((_expression[_parsePoint] == '%') && ((_parsePoint + 1) < _expression.Length) && (_expression[_parsePoint + 1] == '('))
+                {
+                    expandable = true;
+                    string name = String.Empty;
+
+                    int endOfName = _expression.IndexOf(')', _parsePoint) - 1;
+                    if (endOfName < 0)
+                    {
+                        endOfName = _expression.Length - 1;
+                    }
+
+                    // If it's %(a.b) the name is just 'b'
+                    if (_parsePoint + 3 < _expression.Length)
+                    {
+                        name = _expression.Substring(_parsePoint + 2, (endOfName - _parsePoint - 2 + 1));
+                    }
+
+                    if (!CheckForUnexpectedMetadata(name))
+                    {
+                        return false;
+                    }
+                }
+                else if (_expression[_parsePoint] == '@' && ((_parsePoint + 1) < _expression.Length) && (_expression[_parsePoint + 1] == '('))
+                {
+                    expandable = true;
+
+                    // If the caller specified that he DOESN'T want to allow item lists ...
+                    if ((_options & ParserOptions.AllowItemLists) == 0)
+                    {
+                        _errorPosition = start + 1;
+                        _errorState = true;
+                        _errorResource = "ItemListNotAllowedInThisConditional";
+                        return false;
+                    }
+
+                    // Item lists have to be parsed because of the replacement syntax e.g. @(Foo,'_').
+                    // I have to know how to parse those so I can skip over the tic marks.  I don't
+                    // have to do that with other things like propertygroups, hence itemlists are
+                    // treated specially.
+
+                    ParseInternalItemList();
+                    continue;
+                }
+                else if (_expression[_parsePoint] == '$' && ((_parsePoint + 1) < _expression.Length) && (_expression[_parsePoint + 1] == '('))
+                {
+                    expandable = true;
+                }
+                else if (_expression[_parsePoint] == '%')
+                {
+                    // There may be some escaped characters in the expression
+                    expandable = true;
+                }
+                _parsePoint++;
+            }
+
+            if (_parsePoint >= _expression.Length)
+            {
+                // Quoted string wasn't closed
+                _errorState = true;
+                _errorPosition = start; // The message is going to say "expected after position n" so don't add 1 here.
+                _errorResource = "IllFormedQuotedStringInCondition";
+                // Not useful to set unexpectedlyFound here. By definition it got to the end of the string.
+                return false;
+            }
+            string originalTokenString = _expression.Substring(start, _parsePoint - start);
+
+            _lookahead = new Token(Token.TokenType.String, originalTokenString, expandable);
+            _parsePoint++;
+            return true;
+        }
+
+        private bool ParseRemaining()
+        {
+            int start = _parsePoint;
+            if (CharacterUtilities.IsNumberStart(_expression[_parsePoint])) // numeric
+            {
+                if (!ParseNumeric(start))
+                    return false;
+            }
+            else if (CharacterUtilities.IsSimpleStringStart(_expression[_parsePoint])) // simple string (handle 'and' and 'or')
+            {
+                if (!ParseSimpleStringOrFunction(start))
+                    return false;
+            }
+            else
+            {
+                // Something that wasn't a number or a letter, like a newline (%0a)
+                _errorState = true;
+                _errorPosition = start + 1;
+                _errorResource = "UnexpectedCharacterInCondition";
+                _unexpectedlyFound = Convert.ToString(_expression[_parsePoint], CultureInfo.InvariantCulture);
+                return false;
+            }
+            return true;
+        }
+
+        // There is a bug here that spaces are not required around 'and' and 'or'. For example,
+        // this works perfectly well:
+        // Condition="%(a.Identity)!=''and%(a.m)=='1'"
+        // Since people now depend on this behavior, we must not change it.
+        private bool ParseSimpleStringOrFunction(int start)
+        {
+            SkipSimpleStringChars();
+            if (0 == string.Compare(_expression.Substring(start, _parsePoint - start), "and", StringComparison.OrdinalIgnoreCase))
+            {
+                _lookahead = Token.And;
+            }
+            else if (0 == string.Compare(_expression.Substring(start, _parsePoint - start), "or", StringComparison.OrdinalIgnoreCase))
+            {
+                _lookahead = Token.Or;
+            }
+            else
+            {
+                int end = _parsePoint;
+                SkipWhiteSpace();
+                if (_parsePoint < _expression.Length && _expression[_parsePoint] == '(')
+                {
+                    _lookahead = new Token(Token.TokenType.Function, _expression.Substring(start, end - start));
+                }
+                else
+                {
+                    string tokenValue = _expression.Substring(start, end - start);
+                    _lookahead = new Token(Token.TokenType.String, tokenValue);
+                }
+            }
+            return true;
+        }
+        private bool ParseNumeric(int start)
+        {
+            if ((_expression.Length - _parsePoint) > 2 && _expression[_parsePoint] == '0' && (_expression[_parsePoint + 1] == 'x' || _expression[_parsePoint + 1] == 'X'))
+            {
+                // Hex number
+                _parsePoint += 2;
+                SkipHexDigits();
+                _lookahead = new Token(Token.TokenType.Numeric, _expression.Substring(start, _parsePoint - start));
+            }
+            else if (CharacterUtilities.IsNumberStart(_expression[_parsePoint]))
+            {
+                // Decimal number
+                if (_expression[_parsePoint] == '+')
+                {
+                    _parsePoint++;
+                }
+                else if (_expression[_parsePoint] == '-')
+                {
+                    _parsePoint++;
+                }
+                do
+                {
+                    SkipDigits();
+                    if (_parsePoint < _expression.Length && _expression[_parsePoint] == '.')
+                    {
+                        _parsePoint++;
+                    }
+                    if (_parsePoint < _expression.Length)
+                    {
+                        SkipDigits();
+                    }
+                } while (_parsePoint < _expression.Length && _expression[_parsePoint] == '.');
+                // Do we need to error on malformed input like 0.00.00)? or will the conversion handle it?
+                // For now, let the conversion generate the error.
+                _lookahead = new Token(Token.TokenType.Numeric, _expression.Substring(start, _parsePoint - start));
+            }
+            else
+            {
+                // Unreachable
+                _errorState = true;
+                _errorPosition = start + 1;
+                return false;
+            }
+            return true;
+        }
+        private void SkipWhiteSpace()
+        {
+            while (_parsePoint < _expression.Length && char.IsWhiteSpace(_expression[_parsePoint]))
+                _parsePoint++;
+            return;
+        }
+        private void SkipDigits()
+        {
+            while (_parsePoint < _expression.Length && char.IsDigit(_expression[_parsePoint]))
+                _parsePoint++;
+            return;
+        }
+        private void SkipHexDigits()
+        {
+            while (_parsePoint < _expression.Length && CharacterUtilities.IsHexDigit(_expression[_parsePoint]))
+                _parsePoint++;
+            return;
+        }
+        private void SkipSimpleStringChars()
+        {
+            while (_parsePoint < _expression.Length && CharacterUtilities.IsSimpleStringChar(_expression[_parsePoint]))
+                _parsePoint++;
+            return;
+        }
+    }
+}

--- a/Project2015To2017/Reading/Conditionals/StringExpressionNode.cs
+++ b/Project2015To2017/Reading/Conditionals/StringExpressionNode.cs
@@ -1,0 +1,144 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+
+namespace Project2015To2017.Reading.Conditionals
+{
+    /// <summary>
+    /// Node representing a string
+    /// </summary>
+    [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    internal sealed class StringExpressionNode : OperandExpressionNode
+    {
+        private string _value;
+        private string _cachedExpandedValue;
+
+        /// <summary>
+        /// Whether the string potentially has expandable content,
+        /// such as a property expression or escaped character.
+        /// </summary>
+        private bool _expandable;
+
+        internal StringExpressionNode(string value, bool expandable)
+        {
+            _value = value;
+            _expandable = expandable;
+        }
+
+        /// <summary>
+        /// Evaluate as boolean
+        /// </summary>
+        internal override bool BoolEvaluate(IConditionEvaluationState state)
+        {
+            return ConversionUtilities.ConvertStringToBool(GetExpandedValue(state));
+        }
+
+        /// <summary>
+        /// Evaluate as numeric
+        /// </summary>
+        internal override double NumericEvaluate(IConditionEvaluationState state)
+        {
+            return ConversionUtilities.ConvertDecimalOrHexToDouble(GetExpandedValue(state));
+        }
+
+        internal override Version VersionEvaluate(IConditionEvaluationState state)
+        {
+            return Version.Parse(GetExpandedValue(state));
+        }
+
+        internal override bool CanBoolEvaluate(IConditionEvaluationState state)
+        {
+            return ConversionUtilities.CanConvertStringToBool(GetExpandedValue(state));
+        }
+
+        internal override bool CanNumericEvaluate(IConditionEvaluationState state)
+        {
+            return ConversionUtilities.ValidDecimalOrHexNumber(GetExpandedValue(state));
+        }
+
+        internal override bool CanVersionEvaluate(IConditionEvaluationState state)
+        {
+            Version unused;
+            return Version.TryParse(GetExpandedValue(state), out unused);
+        }
+
+        /// <summary>
+        /// Returns true if this node evaluates to an empty string,
+        /// otherwise false.
+        /// It may be cheaper to determine whether an expression will evaluate
+        /// to empty than to fully evaluate it.
+        /// Implementations should cache the result so that calls after the first are free.
+        /// </summary>
+        internal override bool EvaluatesToEmpty(IConditionEvaluationState state)
+        {
+            if (_cachedExpandedValue == null)
+            {
+                if (_expandable)
+                {
+                    string expandBreakEarly = state.ExpandIntoStringBreakEarly(_value);
+
+                    if (expandBreakEarly == null)
+                    {
+                        // It broke early: we can't store the value, we just
+                        // know it's non empty
+                        return false;
+                    }
+
+                    // It didn't break early, the result is accurate,
+                    // so store it so the work isn't done again.
+                    _cachedExpandedValue = expandBreakEarly;
+                }
+                else
+                {
+                    _cachedExpandedValue = _value;
+                }
+            }
+
+            return (_cachedExpandedValue.Length == 0);
+        }
+
+
+        /// <summary>
+        /// Value before any item and property expressions are expanded
+        /// </summary>
+        /// <returns></returns>
+        internal override string GetUnexpandedValue(IConditionEvaluationState state)
+        {
+            return _value;
+        }
+
+        /// <summary>
+        /// Value after any item and property expressions are expanded
+        /// </summary>
+        /// <returns></returns>
+        internal override string GetExpandedValue(IConditionEvaluationState state)
+        {
+            if (_cachedExpandedValue == null)
+            {
+                if (_expandable)
+                {
+                    _cachedExpandedValue = state.ExpandIntoString(_value);
+                }
+                else
+                {
+                    _cachedExpandedValue = _value;
+                }
+            }
+
+            return _cachedExpandedValue;
+        }
+
+        /// <summary>
+        /// If any expression nodes cache any state for the duration of evaluation, 
+        /// now's the time to clean it up
+        /// </summary>
+        internal override void ResetState()
+        {
+            _cachedExpandedValue = null;
+        }
+
+        internal override string DebuggerDisplay => $"\"{_value}\"";
+    }
+}

--- a/Project2015To2017/Reading/Conditionals/Token.cs
+++ b/Project2015To2017/Reading/Conditionals/Token.cs
@@ -1,0 +1,155 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Project2015To2017.Reading.Conditionals
+{
+    /// <summary>
+    /// This class represents a token in the Complex Conditionals grammar.  It's
+    /// really just a bag that contains the type of the token and the string that
+    /// was parsed into the token.  This isn't very useful for operators, but
+    /// is useful for strings and such.
+    /// </summary>
+    internal sealed class Token
+    {
+        internal readonly static Token Comma = new Token(TokenType.Comma);
+        internal readonly static Token LeftParenthesis = new Token(TokenType.LeftParenthesis);
+        internal readonly static Token RightParenthesis = new Token(TokenType.RightParenthesis);
+        internal readonly static Token LessThan = new Token(TokenType.LessThan);
+        internal readonly static Token GreaterThan = new Token(TokenType.GreaterThan);
+        internal readonly static Token LessThanOrEqualTo = new Token(TokenType.LessThanOrEqualTo);
+        internal readonly static Token GreaterThanOrEqualTo = new Token(TokenType.GreaterThanOrEqualTo);
+        internal readonly static Token And = new Token(TokenType.And);
+        internal readonly static Token Or = new Token(TokenType.Or);
+        internal readonly static Token EqualTo = new Token(TokenType.EqualTo);
+        internal readonly static Token NotEqualTo = new Token(TokenType.NotEqualTo);
+        internal readonly static Token Not = new Token(TokenType.Not);
+        internal readonly static Token EndOfInput = new Token(TokenType.EndOfInput);
+
+        /// <summary>
+        /// Valid tokens
+        /// </summary>
+        internal enum TokenType
+        {
+            Comma, LeftParenthesis, RightParenthesis,
+            LessThan, GreaterThan, LessThanOrEqualTo, GreaterThanOrEqualTo,
+            And, Or,
+            EqualTo, NotEqualTo, Not,
+            Property, String, Numeric, ItemList, ItemMetadata, Function,
+            EndOfInput
+        };
+
+        private TokenType _tokenType;
+        private string _tokenString;
+
+        /// <summary>
+        /// Constructor for types that don't have values
+        /// </summary>
+        /// <param name="tokenType"></param>
+        private Token(TokenType tokenType)
+        {
+            _tokenType = tokenType;
+            _tokenString = null;
+        }
+
+        /// <summary>
+        /// Constructor takes the token type and the string that
+        /// represents the token
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="tokenString"></param>
+        internal Token(TokenType type, string tokenString)
+            : this(type, tokenString, false /* not expandable */)
+        { }
+
+        /// <summary>
+        /// Constructor takes the token type and the string that
+        /// represents the token.
+        /// If the string may contain content that needs expansion, expandable is set.
+        /// </summary>
+        internal Token(TokenType type, string tokenString, bool expandable)
+        {
+            ErrorUtilities.VerifyThrow
+                (
+                type == TokenType.Property ||
+                type == TokenType.String ||
+                type == TokenType.Numeric ||
+                type == TokenType.ItemList ||
+                type == TokenType.ItemMetadata ||
+                type == TokenType.Function,
+                "Unexpected token type"
+                );
+
+            ErrorUtilities.VerifyThrowInternalNull(tokenString, "tokenString");
+
+            _tokenType = type;
+            _tokenString = tokenString;
+            this.Expandable = expandable;
+        }
+
+        /// <summary>
+        /// Whether the content potentially has expandable content,
+        /// such as a property expression or escaped character.
+        /// </summary>
+        internal bool Expandable
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        internal bool IsToken(TokenType type)
+        {
+            return _tokenType == type;
+        }
+
+        internal string String
+        {
+            get
+            {
+                if (_tokenString != null)
+                {
+                    return _tokenString;
+                }
+
+                // Return a token string for 
+                // an error message.
+                switch (_tokenType)
+                {
+                    case TokenType.Comma:
+                        return ",";
+                    case TokenType.LeftParenthesis:
+                        return "(";
+                    case TokenType.RightParenthesis:
+                        return ")";
+                    case TokenType.LessThan:
+                        return "<";
+                    case TokenType.GreaterThan:
+                        return ">";
+                    case TokenType.LessThanOrEqualTo:
+                        return "<=";
+                    case TokenType.GreaterThanOrEqualTo:
+                        return ">=";
+                    case TokenType.And:
+                        return "and";
+                    case TokenType.Or:
+                        return "or";
+                    case TokenType.EqualTo:
+                        return "==";
+                    case TokenType.NotEqualTo:
+                        return "!=";
+                    case TokenType.Not:
+                        return "!";
+                    case TokenType.EndOfInput:
+                        return null;
+                    default:
+                        ErrorUtilities.ThrowInternalErrorUnreachable();
+                        return null;
+                }
+            }
+        }
+    }
+}

--- a/Project2015To2017/Reading/ProjectPropertiesReader.cs
+++ b/Project2015To2017/Reading/ProjectPropertiesReader.cs
@@ -1,9 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Project2015To2017.Definition;
-
 using static Project2015To2017.Definition.Project;
 
 namespace Project2015To2017.Reading
@@ -12,64 +13,76 @@ namespace Project2015To2017.Reading
 	{
 		public static void PopulateProperties(Project project, XDocument projectXml)
 		{
-			var propertyGroups = projectXml.Element(XmlNamespace + "Project").Elements(XmlNamespace + "PropertyGroup");
+			var propertyGroups = projectXml.Element(XmlNamespace + "Project").Elements(XmlNamespace + "PropertyGroup")
+				.ToArray();
 
 			var unconditionalPropertyGroups = propertyGroups.Where(x => x.Attribute("Condition") == null).ToArray();
 			if (unconditionalPropertyGroups.Length == 0)
 			{
-				throw new NotSupportedException("No unconditional property group found. Cannot determine important properties like target framework and others.");
+				throw new NotSupportedException(
+					"No unconditional property group found. Cannot determine important properties like target framework and others.");
+			}
+
+			project.Optimize =
+				"true".Equals(unconditionalPropertyGroups.Elements(XmlNamespace + "Optimize").FirstOrDefault()?.Value,
+					StringComparison.OrdinalIgnoreCase);
+			project.TreatWarningsAsErrors =
+				"true".Equals(
+					unconditionalPropertyGroups.Elements(XmlNamespace + "TreatWarningsAsErrors").FirstOrDefault()
+						?.Value, StringComparison.OrdinalIgnoreCase);
+			project.AllowUnsafeBlocks =
+				"true".Equals(
+					unconditionalPropertyGroups.Elements(XmlNamespace + "AllowUnsafeBlocks").FirstOrDefault()?.Value,
+					StringComparison.OrdinalIgnoreCase);
+
+			project.RootNamespace = unconditionalPropertyGroups.Elements(XmlNamespace + "RootNamespace")
+				.FirstOrDefault()?.Value;
+			project.AssemblyName = unconditionalPropertyGroups.Elements(XmlNamespace + "AssemblyName").FirstOrDefault()
+				?.Value;
+
+			project.SignAssembly =
+				"true".Equals(
+					unconditionalPropertyGroups.Elements(XmlNamespace + "SignAssembly").FirstOrDefault()?.Value,
+					StringComparison.OrdinalIgnoreCase);
+			if (bool.TryParse(
+				unconditionalPropertyGroups.Elements(XmlNamespace + "DelaySign").FirstOrDefault()?.Value,
+				out bool delaySign))
+				project.DelaySign = delaySign;
+			project.AssemblyOriginatorKeyFile = unconditionalPropertyGroups
+				.Elements(XmlNamespace + "AssemblyOriginatorKeyFile").FirstOrDefault()?.Value;
+
+			var targetFramework = unconditionalPropertyGroups.Elements(XmlNamespace + "TargetFrameworkVersion").FirstOrDefault();
+			if (targetFramework?.Value != null)
+			{
+				project.TargetFrameworks.Add(ToTargetFramework(targetFramework.Value));
+				targetFramework.Remove();
+			}
+
+			// Ref.: https://www.codeproject.com/Reference/720512/List-of-Visual-Studio-Project-Type-GUIDs
+			if (unconditionalPropertyGroups.Elements(XmlNamespace + "TestProjectType").Any() ||
+			    unconditionalPropertyGroups.Elements(XmlNamespace + "ProjectTypeGuids").Any(e =>
+				    e.Value.IndexOf("3AC096D0-A1C2-E12C-1390-A8335801FDAB", StringComparison.OrdinalIgnoreCase) > -1))
+			{
+				project.Type = ApplicationType.TestProject;
 			}
 			else
 			{
-				project.Optimize = "true".Equals(unconditionalPropertyGroups.Elements(XmlNamespace + "Optimize").FirstOrDefault()?.Value, StringComparison.OrdinalIgnoreCase);
-				project.TreatWarningsAsErrors = "true".Equals(unconditionalPropertyGroups.Elements(XmlNamespace + "TreatWarningsAsErrors").FirstOrDefault()?.Value, StringComparison.OrdinalIgnoreCase);
-				project.AllowUnsafeBlocks = "true".Equals(unconditionalPropertyGroups.Elements(XmlNamespace + "AllowUnsafeBlocks").FirstOrDefault()?.Value, StringComparison.OrdinalIgnoreCase);
-
-				project.RootNamespace = unconditionalPropertyGroups.Elements(XmlNamespace + "RootNamespace").FirstOrDefault()?.Value;
-				project.AssemblyName = unconditionalPropertyGroups.Elements(XmlNamespace + "AssemblyName").FirstOrDefault()?.Value;
-
-				project.SignAssembly = "true".Equals(unconditionalPropertyGroups.Elements(XmlNamespace + "SignAssembly").FirstOrDefault()?.Value, StringComparison.OrdinalIgnoreCase);
-				if (Boolean.TryParse(unconditionalPropertyGroups.Elements(XmlNamespace + "DelaySign").FirstOrDefault()?.Value, out bool delaySign))
-					project.DelaySign = delaySign;
-				project.AssemblyOriginatorKeyFile = unconditionalPropertyGroups.Elements(XmlNamespace + "AssemblyOriginatorKeyFile").FirstOrDefault()?.Value;
-
-				// Ref.: https://www.codeproject.com/Reference/720512/List-of-Visual-Studio-Project-Type-GUIDs
-				if (unconditionalPropertyGroups.Elements(XmlNamespace + "TestProjectType").Any() ||
-					unconditionalPropertyGroups.Elements(XmlNamespace + "ProjectTypeGuids").Any(e => e.Value.IndexOf("3AC096D0-A1C2-E12C-1390-A8335801FDAB", StringComparison.OrdinalIgnoreCase) > -1))
-				{
-					project.Type = ApplicationType.TestProject;
-				}
-				else
-				{
-					project.Type = ToApplicationType(unconditionalPropertyGroups.Elements(XmlNamespace + "OutputType").FirstOrDefault()?.Value ??
-						propertyGroups.Elements(XmlNamespace + "OutputType").FirstOrDefault()?.Value);
-				}
-
-				var targetFramework = unconditionalPropertyGroups.Elements(XmlNamespace + "TargetFrameworkVersion").FirstOrDefault();
-				if (targetFramework?.Value != null)
-				{
-					project.TargetFrameworks = new[] { ToTargetFramework(targetFramework.Value) };
-					targetFramework.Remove();
-				}
+				project.Type = ToApplicationType(
+					unconditionalPropertyGroups.Elements(XmlNamespace + "OutputType").FirstOrDefault()?.Value ??
+					propertyGroups.Elements(XmlNamespace + "OutputType").FirstOrDefault()?.Value);
 			}
 
-			// yuk... but hey it works...
-			project.Configurations = propertyGroups
-				.Where(x => x.Attribute("Condition") != null)
-				.Select(x => x.Attribute("Condition").Value)
-				.Where(x => x.Contains("'$(Configuration)|$(Platform)'"))
-				.Select(x => x.Split('\'').Skip(3).FirstOrDefault())
-				.Where(x => x != null)
-				.Select(x => x.Split('|')[0])
-				.ToArray();
+			(project.Configurations, project.Platforms) = ReadConditionals(unconditionalPropertyGroups, projectXml);
 
-			project.BuildEvents = propertyGroups.Elements().Where(x => x.Name == XmlNamespace + "PostBuildEvent" || x.Name == XmlNamespace + "PreBuildEvent").ToArray();
-			project.AdditionalPropertyGroups = ReadAdditionalPropertyGroups(propertyGroups);
+			project.BuildEvents = propertyGroups.Elements().Where(x =>
+				x.Name == XmlNamespace + "PostBuildEvent" || x.Name == XmlNamespace + "PreBuildEvent").ToArray();
+			project.AdditionalPropertyGroups = ReadAdditionalPropertyGroups(project, propertyGroups);
 
 			project.Imports = projectXml.Element(XmlNamespace + "Project").Elements(XmlNamespace + "Import").Where(x =>
-					x.Attribute("Project")?.Value != @"$(MSBuildToolsPath)\Microsoft.CSharp.targets" &&
-					x.Attribute("Project")?.Value != @"$(MSBuildBinPath)\Microsoft.CSharp.targets" &&
-					x.Attribute("Project")?.Value != @"$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props").ToArray();
+				x.Attribute("Project")?.Value != @"$(MSBuildToolsPath)\Microsoft.CSharp.targets" &&
+				x.Attribute("Project")?.Value != @"$(MSBuildBinPath)\Microsoft.CSharp.targets" &&
+				x.Attribute("Project")?.Value !=
+				@"$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props").ToArray();
 
 			project.Targets = projectXml.Element(XmlNamespace + "Project").Elements(XmlNamespace + "Target").ToArray();
 
@@ -79,20 +92,278 @@ namespace Project2015To2017.Reading
 			}
 		}
 
-		private static List<XElement> ReadAdditionalPropertyGroups(IEnumerable<XElement> propertyGroups)
+		private static (List<string>, List<string>) ReadConditionals(XElement[] unconditionalPropertyGroups,
+			XDocument projectXml)
 		{
-			var additionalPropertyGroups = propertyGroups.Where(x => x.Attribute("Condition") != null).ToList();
-			var versionControlElements = propertyGroups
-				.SelectMany(x => x.Elements().Where(e => e.Name.LocalName.StartsWith("Scc")));
-			var otherElementsInPropertyGroupWithNoCondition = propertyGroups.Where(x => x.Attribute("Condition") == null)
-				.SelectMany(x => x.Elements());
+			var configurationSet = new HashSet<string>();
+			var platformSet = new HashSet<string>();
 
-			if (versionControlElements != null)
+			var configurationsFromProperty = ParseFromProperty("Configurations");
+			var platformsFromProperty = ParseFromProperty("Platforms");
+
+			if (configurationsFromProperty != null)
 			{
-				additionalPropertyGroups.Add(new XElement("PropertyGroup", versionControlElements.Concat(otherElementsInPropertyGroupWithNoCondition).ToArray()));
+				foreach (var configuration in configurationsFromProperty)
+					configurationSet.Add(configuration);
 			}
 
+			if (platformsFromProperty != null)
+			{
+				foreach (var platform in platformsFromProperty)
+					platformSet.Add(platform);
+			}
+
+			var (needConfigurations, needPlatforms) = (configurationsFromProperty == null, platformsFromProperty == null);
+
+			if (needConfigurations || needPlatforms)
+			{
+				foreach (var x in projectXml.Descendants())
+				{
+					var condition = x.Attribute("Condition");
+					if (condition == null) continue;
+
+					var conditionValue = condition.Value;
+					if (!conditionValue.Contains("$(Configuration)") && !conditionValue.Contains("$(Platform)")) continue;
+
+					var conditionEvaluated = ConditionEvaluator.GetConditionValues(conditionValue);
+
+					if (needConfigurations && conditionEvaluated.TryGetValue("Configuration", out var configurations))
+					{
+						foreach (var configuration in configurations)
+							configurationSet.Add(configuration);
+					}
+
+					if (needPlatforms && conditionEvaluated.TryGetValue("Platform", out var platforms))
+					{
+						foreach (var platform in platforms)
+							platformSet.Add(platform);
+					}
+				}
+			}
+
+			var configurationList = configurationSet.ToList();
+			var platformList = platformSet.ToList();
+			configurationList.Sort();
+			platformList.Sort();
+			return (configurationList, platformList);
+
+			string[] ParseFromProperty(string name) => unconditionalPropertyGroups.Elements(XmlNamespace + name)
+				.FirstOrDefault()
+				?.Value
+				.Split(new[] {';'}, StringSplitOptions.RemoveEmptyEntries);
+		}
+
+		private static List<XElement> ReadAdditionalPropertyGroups(Project project, XElement[] propertyGroups)
+		{
+			var additionalPropertyGroups = propertyGroups.Where(x => x.Attribute("Condition") != null).ToList();
+			var otherElementsInPropertyGroupWithNoCondition = propertyGroups
+				.Where(x => x.Attribute("Condition") == null)
+				.SelectMany(x => x.Elements());
+
+			additionalPropertyGroups.Add(new XElement("PropertyGroup",
+				otherElementsInPropertyGroupWithNoCondition.ToArray()));
+
+			FilterUnneededProperties(project, additionalPropertyGroups);
+
 			return additionalPropertyGroups;
+		}
+
+		private static void FilterUnneededProperties(Project project, IList<XElement> additionalPropertyGroups)
+		{
+			// special case handling for when condition-guarded props override global props not set to their defaults
+			var globalOverrides = RetrieveGlobalOverrides(additionalPropertyGroups);
+
+			if (!globalOverrides.TryGetValue("ProjectName", out var projectName))
+				if (!globalOverrides.TryGetValue("AssemblyName", out projectName))
+					projectName = project.FilePath.Name.Replace(".csproj", "");
+
+			var removeQueue = new List<XElement>();
+
+			foreach (var propertyGroup in additionalPropertyGroups)
+			{
+				foreach (var child in propertyGroup.Elements())
+				{
+					var parentCondition = propertyGroup.Attribute("Condition")?.Value.Trim() ?? "";
+					var hasParentCondition = parentCondition.Length > 1; // no sane condition is 1 char long
+					var parentConditionEvaluated = ConditionEvaluator.GetNonAmbiguousConditionContracts(parentCondition);
+					var parentConditionHasPlatform =
+						parentConditionEvaluated.TryGetValue("Platform", out var parentConditionPlatform);
+					var parentConditionHasConfiguration =
+						parentConditionEvaluated.TryGetValue("Configuration", out var parentConditionConfiguration);
+					var parentConditionPlatformLower = parentConditionPlatform?.ToLowerInvariant();
+					var parentConditionConfigurationLower = parentConditionConfiguration?.ToLowerInvariant();
+					var isDebugOnly = parentConditionHasConfiguration && parentConditionConfigurationLower == "debug";
+					var isReleaseOnly = parentConditionHasConfiguration && parentConditionConfigurationLower == "release";
+
+					var tagLocalName = child.Name.LocalName;
+					var valueLower = child.Value.ToLowerInvariant();
+					var valueLowerTrim = valueLower.Trim();
+					var hasGlobalOverride = globalOverrides.TryGetValue(tagLocalName, out var globalOverride);
+					var globalOverrideLower = globalOverride?.ToLowerInvariant();
+
+					// Regex is the easiest way to replace string between two unknown chars preserving both as is
+					// so that bin\Debug\net472 is turned into bin\$(Configuration)\net472
+					// and bin/Debug\net472 is turned into bin/$(Configuration)\net472, preserving path separators
+					var configurationPathRegex = parentConditionHasConfiguration
+						? new Regex($@"([\\/]){parentConditionConfiguration}([\\/])")
+						: null;
+
+					var childCondition = child.Attribute("Condition");
+					switch (tagLocalName)
+					{
+						// VS2013 NuGet bugs workaround
+						case "NuGetPackageImportStamp":
+						// used by Project2015To2017 and not needed anymore
+						case "OutputType" when !hasParentCondition:
+						case "Platforms" when !hasParentCondition:
+						case "Configurations" when !hasParentCondition:
+						case "TargetFrameworkVersion" when !hasParentCondition:
+						case "TargetFrameworkIdentifier" when !hasParentCondition:
+						case "TargetFrameworkProfile" when !hasParentCondition && valueLowerTrim.Length == 0:
+						// VCS properties
+						case "SccProjectName" when !hasParentCondition && valueLowerTrim.Length == 0:
+						case "SccLocalPath" when !hasParentCondition && valueLowerTrim.Length == 0:
+						case "SccAuxPath" when !hasParentCondition && valueLowerTrim.Length == 0:
+						case "SccProvider" when !hasParentCondition && valueLowerTrim.Length == 0:
+						// Project properties set to defaults (Microsoft.NET.Sdk)
+						case "OutputType" when ValidateDefaultValue("Library"):
+						case "FileAlignment" when ValidateDefaultValue("512"):
+						case "ErrorReport" when ValidateDefaultValue("prompt"):
+						case "Deterministic" when ValidateDefaultValue("true"):
+						case "WarningLevel" when ValidateDefaultValue("4"):
+						case "DebugType" when ValidateDefaultValue("portable"):
+						case "ResolveNuGetPackages" when ValidateDefaultValue("false"):
+						case "SkipImportNuGetProps" when ValidateDefaultValue("true"):
+						case "SkipImportNuGetBuildTargets" when ValidateDefaultValue("true"):
+						case "RestoreProjectStyle" when ValidateDefaultValue("packagereference"):
+						case "AllowUnsafeBlocks" when ValidateDefaultValue("false"):
+						case "TreatWarningsAsErrors" when ValidateDefaultValue("false"):
+						case "Prefer32Bit" when ValidateDefaultValue("false"):
+						case "SignAssembly" when ValidateDefaultValue("false"):
+						case "DelaySign" when ValidateDefaultValue("false"):
+						case "GeneratePackageOnBuild" when ValidateDefaultValue("false"):
+						case "PackageRequireLicenseAcceptance" when ValidateDefaultValue("false"):
+						case "DebugSymbols" when ValidateDefaultValue("false"):
+						case "CheckForOverflowUnderflow" when ValidateDefaultValue("false"):
+						case "AppendTargetFrameworkToOutputPath" when ValidateDefaultValue("true"):
+						case "AppDesignerFolder" when ValidateDefaultValue("properties"):
+						case "DefaultProjectTypeGuid" when ValidateDefaultValue("{fae04ec0-301f-11d3-bf4b-00c04f79efbc}"):
+						case "DefaultLanguageSourceExtension" when ValidateDefaultValue(".cs"):
+						case "Language" when ValidateDefaultValue("C#"):
+						case "TargetRuntime" when ValidateDefaultValue("managed"):
+						case "Utf8Output" when ValidateDefaultValue("true"):
+						case "PlatformName" when ValidateDefaultValue("$(platform)")
+						                         || (parentConditionHasPlatform &&
+						                             ValidateDefaultValue(parentConditionPlatformLower)):
+						// Conditional platform default values
+						case "PlatformTarget" when parentConditionHasPlatform && child.Value == parentConditionPlatform
+						                                                      && !hasGlobalOverride:
+						// Conditional configuration (Debug/Release) default values
+						case "DefineConstants" when isDebugOnly && ValidateDefaultConstants(valueLower, "debug", "trace") &&
+						                            !hasGlobalOverride:
+						case "DefineConstants" when isReleaseOnly && ValidateDefaultConstants(valueLower, "trace") &&
+						                            !hasGlobalOverride:
+						case "Optimize" when isDebugOnly && valueLower == "false" && !hasGlobalOverride:
+						case "Optimize" when isReleaseOnly && valueLower == "true" && !hasGlobalOverride:
+						case "DebugSymbols" when isDebugOnly && valueLower == "true" && !hasGlobalOverride:
+						// Default project values for Platform and Configuration
+						case "Platform" when !hasParentCondition && ValidateEmptyConditionValue(childCondition) &&
+						                     valueLower == "anycpu":
+						case "Configuration" when !hasParentCondition && ValidateEmptyConditionValue(childCondition) &&
+						                          valueLower == "debug":
+						// Extra ProjectName duplicates
+						case "RootNamespace" when !hasParentCondition && ValidateEmptyConditionValue(childCondition) &&
+						                          child.Value == projectName:
+						case "AssemblyName" when !hasParentCondition && ValidateEmptyConditionValue(childCondition) &&
+						                         child.Value == projectName:
+						{
+							removeQueue.Add(child);
+							break;
+						}
+
+						// Default configuration-specific paths
+						// todo: move duplicated paths from conditional groups to non-conditional one
+						case "OutputPath"
+							when parentConditionHasConfiguration && configurationPathRegex.IsMatch(child.Value):
+						{
+							child.Value = configurationPathRegex.Replace(child.Value, "$1$(Configuration)$2");
+							break;
+						}
+					}
+
+					// following local methods will capture parent scope
+					bool ValidateDefaultValue(string @default)
+					{
+						return (!hasParentCondition && valueLower == @default) ||
+						       (hasParentCondition && ValidateConditionedDefaultValue(@default));
+					}
+
+					bool ValidateConditionedDefaultValue(string @default)
+					{
+						return (valueLower == @default) && (!hasGlobalOverride || globalOverrideLower == @default);
+					}
+
+					// following local methods will not capture parent scope
+					bool ValidateEmptyConditionValue(XAttribute condition)
+					{
+						if (condition == null)
+							return true;
+						var value = condition.Value;
+						return (value.Count(x => x == '=') == 2) && value.Contains("''");
+					}
+
+					bool ValidateDefaultConstants(string value, params string[] expected)
+					{
+						var defines = value.Split(new[] {';'}, StringSplitOptions.RemoveEmptyEntries);
+						var set = new HashSet<string>(defines);
+						foreach (var expecto in expected)
+							if (!set.Remove(expecto))
+								return false;
+						return set.Count == 0;
+					}
+				}
+			}
+
+			// we cannot remove elements correctly while iterating through elements, 2nd pass is needed
+			foreach (var child in removeQueue)
+				child.Remove();
+		}
+
+		/// <summary>
+		/// Get all non-conditional properties and their respective values
+		/// </summary>
+		/// <param name="additionalPropertyGroups">PropertyGroups to be inspected</param>
+		/// <returns>Dictionary of properties' keys and values</returns>
+		private static IDictionary<string, string> RetrieveGlobalOverrides(IList<XElement> additionalPropertyGroups)
+		{
+			var globalOverrides = new Dictionary<string, string>();
+			foreach (var propertyGroup in additionalPropertyGroups)
+			{
+				if (!HasEmptyCondition(propertyGroup))
+					continue;
+
+				foreach (var child in propertyGroup.Elements())
+				{
+					if (!HasEmptyCondition(child))
+						continue;
+
+					globalOverrides[child.Name.LocalName] = child.Value.Trim();
+				}
+			}
+
+			return globalOverrides;
+
+			bool HasEmptyCondition(XElement element)
+			{
+				var conditionAttribute = element.Attribute("Condition");
+				if (conditionAttribute == null)
+					return true;
+
+				var condition = conditionAttribute.Value.Trim() ?? "";
+
+				// no sane condition is 1 char long
+				return condition.Length <= 1;
+			}
 		}
 
 		private static string ToTargetFramework(string targetFramework)

--- a/Project2015To2017/Reading/upstream.md
+++ b/Project2015To2017/Reading/upstream.md
@@ -1,0 +1,22 @@
+# upstream links
+To support advanced and always precise Condition attribute parsing we use parts of MSBuild code licensed under MIT. This document is designated to assist in updating imported code or alike purposes.
+
+## Code version
+The code was brought in on July 21st 2018. The latest commit ID for Conditionals\ directory was *f147a76*.
+
+## ConditionEvaluator
+Has parts of [ConditionEvaluator](https://github.com/Microsoft/msbuild/blob/master/src/Build/Evaluation/ConditionEvaluator.cs) code in "MSBuild Conditional routine" region.
+
+Changes:
+* Some method doc changes (usage section was incorrect)
+* SinglePropertyRegex was wrapped in Lazy<T>
+* IConditionEvaluationState was moved out to the outer scope and then to Conditionals\ directory
+
+## Conditionals\ directory
+Most of it is based on [Microsoft.Build.Evaluation\Conditionals](https://github.com/Microsoft/msbuild/tree/master/src/Build/Evaluation/Conditionals), with some parts from [Microsoft.Build.Shared](https://github.com/Microsoft/msbuild/tree/master/src/Shared).
+
+Changes:
+* Removed some deprecated code for compat with old MSBuild expression parser (too many dependencies)
+* Removed many verify-guards so that if in doubt an exception will likely be thrown (we don't need user-oriented error reporting facilities if conditionals contain syntax errors)
+* Included some utility classes (CharacterUtilities, ConversionUtilities, ErrorUtilities)
+* Changed namespace to match new location

--- a/Project2015To2017/Transforms/TargetFrameworkTransformation.cs
+++ b/Project2015To2017/Transforms/TargetFrameworkTransformation.cs
@@ -23,7 +23,11 @@ namespace Project2015To2017.Transforms
 				return;
 			if (null != TargetFrameworks && TargetFrameworks.Any())
 			{
-				definition.TargetFrameworks = TargetFrameworks;
+				definition.TargetFrameworks.Clear();
+				foreach (var targetFramework in TargetFrameworks)
+				{
+					definition.TargetFrameworks.Add(targetFramework);
+				}
 			}
 			definition.AppendTargetFrameworkToOutputPath = AppendTargetFrameworkToOutputPath;
 		}

--- a/Project2015To2017/Writing/ProjectWriter.cs
+++ b/Project2015To2017/Writing/ProjectWriter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
@@ -331,7 +332,18 @@ namespace Project2015To2017.Writing
 
 			AddTargetFrameworks(mainPropertyGroup, project.TargetFrameworks);
 
-			AddIfNotNull(mainPropertyGroup, "Configurations", string.Join(";", project.Configurations?.Distinct() ?? Array.Empty<string>()));
+			var configurations = project.Configurations ?? Array.Empty<string>();
+			if (configurations.Count != 0)
+				// ignore default "Debug;Release" configuration set
+				if (configurations.Count != 2 || !configurations.Contains("Debug") || !configurations.Contains("Release"))
+					AddIfNotNull(mainPropertyGroup, "Configurations", string.Join(";", configurations));
+
+			var platforms = project.Platforms ?? Array.Empty<string>();
+			if (platforms.Count != 0)
+				// ignore default "AnyCPU" platform set
+				if (platforms.Count != 1 || !platforms.Contains("AnyCPU"))
+					AddIfNotNull(mainPropertyGroup, "Platforms", string.Join(";", platforms));
+
 			AddIfNotNull(mainPropertyGroup, "Optimize", project.Optimize ? "true" : null);
 			AddIfNotNull(mainPropertyGroup, "TreatWarningsAsErrors", project.TreatWarningsAsErrors ? "true" : null);
 			AddIfNotNull(mainPropertyGroup, "RootNamespace", project.RootNamespace != Path.GetFileNameWithoutExtension(outputFile.Name) ? project.RootNamespace : null);
@@ -398,13 +410,12 @@ namespace Project2015To2017.Writing
 			}
 		}
 
-		private void AddTargetFrameworks(XElement mainPropertyGroup, IReadOnlyList<string> targetFrameworks)
+		private void AddTargetFrameworks(XElement mainPropertyGroup, IList<string> targetFrameworks)
 		{
-			if (targetFrameworks == null)
-			{
+			if (targetFrameworks == null || targetFrameworks.Count == 0)
 				return;
-			}
-			else if (targetFrameworks.Count > 1)
+
+			if (targetFrameworks.Count > 1)
 			{
 				AddIfNotNull(mainPropertyGroup, "TargetFrameworks", string.Join(";", targetFrameworks));
 			}

--- a/Project2015To2017Tests/PackageReferenceTransformationTest.cs
+++ b/Project2015To2017Tests/PackageReferenceTransformationTest.cs
@@ -1,9 +1,6 @@
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
-using System.Xml.Linq;
 using Project2015To2017.Definition;
 using Project2015To2017.Reading;
 using Project2015To2017.Transforms;
@@ -19,8 +16,8 @@ namespace Project2015To2017Tests
 	        var project = new ProjectReader().Read("TestFiles\\OtherTestProjects\\net46console.testcsproj");
 
 	        project.Type = ApplicationType.TestProject;
-	        project.TargetFrameworks = new[] { "net45" };
-			
+	        project.TargetFrameworks.Add("net45");
+
             var transformation = new PackageReferenceTransformation();
 
 	        var progress = new Progress<string>(x => { });
@@ -39,8 +36,8 @@ namespace Project2015To2017Tests
 	        var project = new ProjectReader().Read("TestFiles\\OtherTestProjects\\net46console.testcsproj");
 
 	        project.Type = ApplicationType.TestProject;
-	        project.TargetFrameworks = new[] { "netstandard2.0" };
-			
+	        project.TargetFrameworks.Add("netstandard2.0");
+
 			var transformation = new PackageReferenceTransformation();
 
 	        var progress = new Progress<string>(x => { });
@@ -61,7 +58,7 @@ namespace Project2015To2017Tests
 			var project = new ProjectReader()
 								.Read(@"TestFiles\\OtherTestProjects\\containsTestSDK.testcsproj");
 
-	        project.TargetFrameworks = new[] { "net45" };
+	        project.TargetFrameworks.Add("net45");
 
 	        var progress = new Progress<string>(x => { });
 

--- a/Project2015To2017Tests/ProjectPropertiesReadTest.cs
+++ b/Project2015To2017Tests/ProjectPropertiesReadTest.cs
@@ -1,8 +1,11 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Threading.Tasks;
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Xml.Linq;
 using Project2015To2017.Definition;
 using Project2015To2017.Reading;
 
@@ -105,7 +108,7 @@ namespace Project2015To2017Tests
 <Project ToolsVersion=""14.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
   <PropertyGroup>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-  </PropertyGroup>  
+  </PropertyGroup>
   <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "">
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
@@ -331,7 +334,8 @@ namespace Project2015To2017Tests
 
 			var project = await ParseAndTransform(xml).ConfigureAwait(false);
 
-			Assert.IsNull(project.TargetFrameworks);
+			Assert.IsNotNull(project.TargetFrameworks);
+			Assert.AreEqual(0, project.TargetFrameworks.Count);
         }
 
         [TestMethod]
@@ -406,7 +410,7 @@ namespace Project2015To2017Tests
   <Import Project=""Other"" />
   <Target Name=""BeforeBuild"">
   </Target>
-  <Target Name=""AfterBuild""> 
+  <Target Name=""AfterBuild"">
   </Target>
  </Project>";
 
@@ -465,7 +469,8 @@ namespace Project2015To2017Tests
 			var project = await ParseAndTransform(xml).ConfigureAwait(false);
 
 			Assert.AreEqual(1, project.AdditionalPropertyGroups.Count);
-			Assert.AreEqual(35, project.AdditionalPropertyGroups[0].Elements().Count());
+			var children = project.AdditionalPropertyGroups[0].Elements().ToImmutableArray();
+			Assert.AreEqual(4, children.Count(x => x.Name.LocalName.StartsWith("Scc")));
 		}
 
 		[TestMethod]
@@ -580,7 +585,199 @@ if $(ConfigurationName) == Debug (
 
 			Assert.AreEqual(3, project.Configurations.Count);
 			Assert.AreEqual(1, project.Configurations.Count(x => x == "Debug"));
+			Assert.AreEqual(1, project.Configurations.Count(x => x == "Release"));
 			Assert.AreEqual(1, project.Configurations.Count(x => x == "Release_CI"));
+		}
+
+
+		[TestMethod]
+		public async Task ReadsUnknownConfigurations()
+		{
+			var xml = @"
+<Project DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"" ToolsVersion=""4.0"">
+  <Import Project=""$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props"" Condition=""Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"" />
+  <PropertyGroup>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <Configurations>Debug;Release</Configurations>
+  </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <AssemblyName>Class1</AssemblyName>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "">
+    <DebugSymbols>true</DebugSymbols>
+    <Optimize>false</Optimize>
+  </PropertyGroup>
+  <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "">
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <PropertyGroup Condition=""'$(Configuration)|$(Platform)' == 'Release_CI|AnyCPU'"">
+    <OutputPath>bin/Release_CI\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <CodeAnalysisRuleSet>..\FxCop.Rules.ruleset</CodeAnalysisRuleSet>
+    <DocumentationFile>bin\Release_CI\Class1.xml</DocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <RunCodeAnalysis>true</RunCodeAnalysis>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+ </Project>";
+
+			var project = await ParseAndTransform(xml).ConfigureAwait(false);
+
+			// Configurations property must take precedence
+			// Release_CI will be ignored, but still some transformations will apply
+			// We must assume if user intentionally omits things from Configurations or Platforms
+			// they did that in full awareness of the consequences
+			Assert.AreEqual(2, project.Configurations.Count);
+			Assert.AreEqual(1, project.Configurations.Count(x => x == "Debug"));
+			Assert.AreEqual(1, project.Configurations.Count(x => x == "Release"));
+
+			Assert.AreEqual(4, project.AdditionalPropertyGroups.Count);
+
+			Assert.IsNotNull(project.AdditionalPropertyGroups[0].Attribute("Condition"));
+			Assert.IsNotNull(project.AdditionalPropertyGroups[1].Attribute("Condition"));
+			Assert.IsNotNull(project.AdditionalPropertyGroups[2].Attribute("Condition"));
+			Assert.IsNull(project.AdditionalPropertyGroups[3].Attribute("Condition"));
+
+			var childrenDebug = project.AdditionalPropertyGroups[0].Elements().ToImmutableArray();
+			Assert.AreEqual(0, childrenDebug.Length);
+
+			var childrenRelease = project.AdditionalPropertyGroups[1].Elements().ToImmutableArray();
+			Assert.AreEqual(0, childrenRelease.Length);
+
+			var childrenReleaseCI = project.AdditionalPropertyGroups[2].Elements().ToImmutableArray();
+			// We remove only one property set to global default (FileAlignment)
+			Assert.AreEqual(7, childrenReleaseCI.Length);
+			Assert.IsTrue(ValidateChildren(childrenReleaseCI,
+				"DefineConstants", "OutputPath", "Optimize", "CodeAnalysisRuleSet", "DocumentationFile",
+				"TreatWarningsAsErrors", "RunCodeAnalysis"));
+			// check we are keeping original slashes and replacing configuration name with $(Configuration)
+			Assert.AreEqual(@"bin/$(Configuration)\", childrenReleaseCI.First(x => x.Name.LocalName == "OutputPath").Value);
+
+			var childrenGlobal = project.AdditionalPropertyGroups[3].Elements().ToImmutableArray();
+			Assert.AreEqual(0, childrenGlobal.Length);
+		}
+
+		[TestMethod]
+		public async Task SimplifiesProperties()
+		{
+			var xml = @"
+<Project ToolsVersion=""14.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <PropertyGroup>
+    <Configuration Condition="" '$(Configuration)' == '' "">Debug</Configuration>
+    <Platform Condition="" '$(Platform)' == '' "">AnyCPU</Platform>
+    <ProjectGuid>{5C9DE16E-C69A-4182-9C0C-30FF7CC944CD}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Dopamine.Tests</RootNamespace>
+    <AssemblyName>Dopamine.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition=""'$(VisualStudioVersion)' == ''"">10.0</VisualStudioVersion>
+    <VSToolsPath Condition=""'$(VSToolsPath)' == ''"">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <SccProjectName>
+    </SccProjectName>
+    <SccLocalPath>
+    </SccLocalPath>
+    <SccAuxPath>
+    </SccAuxPath>
+    <SccProvider>
+    </SccProvider>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+</Project>";
+
+			var project = await ParseAndTransform(xml).ConfigureAwait(false);
+
+			Assert.AreEqual(3, project.AdditionalPropertyGroups.Count);
+
+			Assert.IsNotNull(project.AdditionalPropertyGroups[0].Attribute("Condition"));
+			Assert.IsNotNull(project.AdditionalPropertyGroups[1].Attribute("Condition"));
+			Assert.IsNull(project.AdditionalPropertyGroups[2].Attribute("Condition"));
+
+			var childrenDebug = project.AdditionalPropertyGroups[0].Elements().ToImmutableArray();
+			Assert.AreEqual(2, childrenDebug.Length);
+			Assert.IsTrue(ValidateChildren(childrenDebug, "DebugType", "OutputPath"));
+			var childrenRelease = project.AdditionalPropertyGroups[1].Elements().ToImmutableArray();
+			Assert.AreEqual(2, childrenRelease.Length);
+			Assert.IsTrue(ValidateChildren(childrenRelease, "DebugType", "OutputPath"));
+			var childrenGlobal = project.AdditionalPropertyGroups[2].Elements().ToImmutableArray();
+			Assert.AreEqual(7, childrenGlobal.Length);
+			Assert.IsTrue(ValidateChildren(childrenGlobal,
+				"ProjectGuid", "ProjectTypeGuids", "VisualStudioVersion", "VSToolsPath",
+				"ReferencePath", "IsCodedUITest", "TestProjectType"));
+		}
+
+		[TestMethod]
+		public async Task HandlesComplexConditions()
+		{
+			var xml = @"
+<Project ToolsVersion=""14.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <AssemblyName>Dopamine.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="" '$(Configuration)' == 'Debug' And '$(Platform)' == 'AnyCPU' "">
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="" '$(Platform)|$(Configuration)' == 'AnyCPU|Release' "">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+  </PropertyGroup>
+</Project>";
+
+			var project = await ParseAndTransform(xml).ConfigureAwait(false);
+
+			Assert.AreEqual(2, project.Configurations.Count);
+			Assert.AreEqual(1, project.Configurations.Count(x => x == "Debug"));
+			Assert.AreEqual(1, project.Configurations.Count(x => x == "Release"));
+
+			Assert.AreEqual(1, project.Platforms.Count);
+			Assert.AreEqual(1, project.Platforms.Count(x => x == "AnyCPU"));
+
+			Assert.AreEqual(3, project.AdditionalPropertyGroups.Count);
+
+			Assert.IsNotNull(project.AdditionalPropertyGroups[0].Attribute("Condition"));
+			Assert.IsNotNull(project.AdditionalPropertyGroups[1].Attribute("Condition"));
+			Assert.IsNull(project.AdditionalPropertyGroups[2].Attribute("Condition"));
+
+			var childrenDebug = project.AdditionalPropertyGroups[0].Elements().ToImmutableArray();
+			Assert.AreEqual(2, childrenDebug.Length);
+			Assert.IsTrue(ValidateChildren(childrenDebug, "DebugType", "OutputPath"));
+			var childrenRelease = project.AdditionalPropertyGroups[1].Elements().ToImmutableArray();
+			Assert.AreEqual(1, childrenRelease.Length);
+			Assert.IsTrue(ValidateChildren(childrenRelease, "OutputPath"));
+			var childrenGlobal = project.AdditionalPropertyGroups[2].Elements().ToImmutableArray();
+			Assert.AreEqual(0, childrenGlobal.Length);
 		}
 
 		private static async Task<Project> ParseAndTransform(
@@ -595,6 +792,16 @@ if $(ConfigurationName) == Debug (
 			var project = new ProjectReader().Read(testCsProjFile);
 
 			return project;
+		}
+
+		internal static bool ValidateChildren(IEnumerable<XElement> value, params string[] expected)
+		{
+			var defines = value.Select(x => x.Name.LocalName);
+			var set = new HashSet<string>(defines);
+			foreach (var expecto in expected)
+				if (!set.Remove(expecto))
+					return false;
+			return set.Count == 0;
 		}
 	}
 }

--- a/Project2015To2017Tests/ProjectWriterTest.cs
+++ b/Project2015To2017Tests/ProjectWriterTest.cs
@@ -43,7 +43,7 @@ namespace Project2015To2017Tests
 			});
 			writer.Write(project, false, progress);
 		}
-		
+
 
 		[TestMethod]
 		public async Task WritesDistinctConfigurations()
@@ -125,15 +125,15 @@ namespace Project2015To2017Tests
 
 			var project = await ParseAndTransform(xml).ConfigureAwait(false);
 
-			Assert.AreEqual(4, project.Configurations.Count);
-			Assert.AreEqual(2, project.Configurations.Count(x => x == "Debug"));
-			Assert.AreEqual(2, project.Configurations.Count(x => x == "Release"));
+			Assert.AreEqual(2, project.Configurations.Count);
+			Assert.AreEqual(1, project.Configurations.Count(x => x == "Debug"));
+			Assert.AreEqual(1, project.Configurations.Count(x => x == "Release"));
 
 			var writer = new ProjectWriter();
 			var xmlNode = writer.CreateXml(project);
 
 			var generatedConfigurations = xmlNode.Element("PropertyGroup").Element("Configurations");
-			Assert.AreEqual("Debug;Release", generatedConfigurations.Value);
+			Assert.IsNull(generatedConfigurations);
 		}
 
 		[TestMethod]
@@ -383,7 +383,7 @@ namespace Project2015To2017Tests
 			var writer = new ProjectWriter(_ => { }, _ => { });
 
 			var xmlNode = writer.CreateXml(project);
-			
+
 			Assert.IsNull(xmlNode.Element("ItemGroup"));
 		}
 

--- a/Project2015To2017Tests/TargetFrameworkTransformationTest.cs
+++ b/Project2015To2017Tests/TargetFrameworkTransformationTest.cs
@@ -22,31 +22,11 @@ namespace Project2015To2017Tests
 
 			Assert.IsNull(project);
 		}
-
-		[TestMethod]
-		public void HandlesProjectTargetFrameworksNull()
-		{
-			var project = new Project()
-			{
-				TargetFrameworks = null
-			};
-			var targetFrameworks = new List<string> { "netstandard2.0" };
-
-			var progress = new Progress<string>(x => { });
-
-			var transformation = new TargetFrameworkTransformation(targetFrameworks);
-			transformation.Transform(project, progress);
-
-			Assert.AreEqual(1, project.TargetFrameworks.Count);
-			Assert.AreEqual("netstandard2.0", project.TargetFrameworks[0]);
-		}
+		
 		[TestMethod]
 		public void HandlesProjectTargetFrameworksEmpty()
 		{
-			var project = new Project()
-			{
-				TargetFrameworks = new List<string>()
-			};
+			var project = new Project();
 			var targetFrameworks = new List<string> { "netstandard2.0" };
 
 			var progress = new Progress<string>(x => { });
@@ -63,7 +43,7 @@ namespace Project2015To2017Tests
 		{
 			var project = new Project()
 			{
-				TargetFrameworks = new List<string> { "net46" }
+				TargetFrameworks = { "net46" }
 			};
 			IReadOnlyList<string> targetFrameworks = null;
 
@@ -80,7 +60,7 @@ namespace Project2015To2017Tests
 		{
 			var project = new Project()
 			{
-				TargetFrameworks = new List<string> { "net46" }
+				TargetFrameworks = { "net46" }
 			};
 			var targetFrameworks = new List<string>();
 
@@ -98,7 +78,7 @@ namespace Project2015To2017Tests
 		{
 			var project = new Project()
 			{
-				TargetFrameworks = new List<string> { "net46" }
+				TargetFrameworks = { "net46" }
 			};
 			var targetFrameworks = new List<string> { "netstandard2.0" };
 
@@ -116,7 +96,7 @@ namespace Project2015To2017Tests
 		{
 			var project = new Project()
 			{
-				TargetFrameworks = new List<string> { "net46" }
+				TargetFrameworks = { "net46" }
 			};
 			var targetFrameworks = new List<string> { "netstandard2.0", "net47" };
 

--- a/Project2015To2017Tests/XamlTransformationTest.cs
+++ b/Project2015To2017Tests/XamlTransformationTest.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Project2015To2017.Definition;
+using Project2015To2017.Reading;
+using Project2015To2017.Transforms;
+using static Project2015To2017.Definition.Project;
+
+namespace Project2015To2017Tests
+{
+	[TestClass]
+	public class XamlTransformationTest
+	{
+		[TestMethod]
+		public async Task TransformsPresentationPages()
+		{
+			var project = await ParseAndTransform(@"
+<Project ToolsVersion=""14.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <AssemblyName>Dopamine</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+  </PropertyGroup>
+  <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DefineConstants>TRACE;DEBUG;WINDOWS_DESKTOP</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' "">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DefineConstants>TRACE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationIcon>Dopamine.ico</ApplicationIcon>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include=""System"" />
+    <Reference Include=""System.Net.Http"" />
+    <Reference Include=""System.Xaml"">
+      <RequiredTargetFramework>4.0</RequiredTargetFramework>
+    </Reference>
+    <Reference Include=""PresentationCore"" />
+    <Reference Include=""PresentationFramework"" />
+  </ItemGroup>
+  <ItemGroup>
+    <ApplicationDefinition Include=""App.xaml"">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </ApplicationDefinition>
+    <Compile Include=""App.xaml.cs"">
+      <DependentUpon>App.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include=""Views\Shell.xaml.cs"">
+      <DependentUpon>Shell.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="".\..\Views\Initialize.xaml.cs"">
+      <DependentUpon>Initialize.xaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Page Include=""Views\Shell.xaml"">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="".\..\Views\Initialize.xaml"">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+  </ItemGroup>
+</Project>");
+
+			Assert.IsTrue(project.IsWindowsPresentationFoundationProject);
+			Assert.IsFalse(project.IsWindowsFormsProject);
+
+			Assert.AreEqual(1, project.TargetFrameworks.Count);
+			Assert.AreEqual(1, project.TargetFrameworks.Count(x => x == "net461"));
+
+			Assert.AreEqual(2, project.Configurations.Count);
+			Assert.AreEqual(1, project.Configurations.Count(x => x == "Debug"));
+			Assert.AreEqual(1, project.Configurations.Count(x => x == "Release"));
+
+			Assert.AreEqual(1, project.Platforms.Count);
+			Assert.AreEqual(1, project.Platforms.Count(x => x == "AnyCPU"));
+
+			Assert.AreEqual(3, project.AdditionalPropertyGroups.Count);
+
+			Assert.IsNotNull(project.AdditionalPropertyGroups[0].Attribute("Condition"));
+			Assert.IsNotNull(project.AdditionalPropertyGroups[1].Attribute("Condition"));
+			Assert.IsNull(project.AdditionalPropertyGroups[2].Attribute("Condition"));
+
+			var childrenDebug = project.AdditionalPropertyGroups[0].Elements().ToImmutableArray();
+			Assert.AreEqual(1, childrenDebug.Length);
+			// non-standard additional WINDOWS_DESKTOP constant present only in Debug
+			Assert.IsTrue(ProjectPropertiesReadTest.ValidateChildren(childrenDebug, "DefineConstants"));
+
+			var childrenRelease = project.AdditionalPropertyGroups[1].Elements().ToImmutableArray();
+			Assert.AreEqual(0, childrenRelease.Length);
+
+			var childrenGlobal = project.AdditionalPropertyGroups[2].Elements().ToImmutableArray();
+			Assert.AreEqual(3, childrenGlobal.Length);
+			Assert.IsTrue(ProjectPropertiesReadTest.ValidateChildren(childrenGlobal,
+				"ProjectTypeGuids", "ApplicationIcon", "ApplicationManifest"));
+
+			var fileTransformation = new FileTransformation();
+			var transformation = new XamlPagesTransformation();
+
+			var progress = new Progress<string>();
+
+			fileTransformation.Transform(project, progress);
+			transformation.Transform(project, progress);
+
+			var includeItems = project.IncludeItems;
+
+			// App.xaml is NOT included due to ApplicationDefinition
+			// App.xaml.cs is NOT included due to <SubType>Code</SubType> (FileTransformation)
+			// Views\Shell.xaml.cs is included due to DependentUpon
+			// .\..\Views\Initialize.xaml.cs is included due to DependentUpon
+			// Views\Shell.xaml is NOT included due to Page
+			// .\..\Views\Initialize.xaml is included due to Page not in project folder
+
+			Assert.AreEqual(3, includeItems.Count);
+
+			Assert.AreEqual(1, includeItems.Count(x => x.Name == XmlNamespace + "Page"));
+			Assert.AreEqual(0, includeItems.Count(x => x.Name == XmlNamespace + "ApplicationDefinition"));
+			Assert.AreEqual(2, includeItems.Count(x => x.Name == XmlNamespace + "Compile"));
+			Assert.AreEqual(2,
+				includeItems.Count(x => x.Name == XmlNamespace + "Compile" && x.Attribute("Update") != null));
+			Assert.AreEqual(0,
+				includeItems.Count(x => x.Name == XmlNamespace + "Compile" && x.Attribute("Include") != null));
+			Assert.AreEqual(0,
+				includeItems.Count(x => x.Name == XmlNamespace + "Compile" && x.Attribute("Remove") != null));
+		}
+
+		private static async Task<Project> ParseAndTransform(
+			string xml,
+			[System.Runtime.CompilerServices.CallerMemberName]
+			string memberName = ""
+		)
+		{
+			var testCsProjFile = $"{memberName}_test.csproj";
+
+			await File.WriteAllTextAsync(testCsProjFile, xml);
+
+			var project = new ProjectReader().Read(testCsProjFile);
+
+			return project;
+		}
+	}
+}


### PR DESCRIPTION
* Import and adapt parts of Microsoft.Build.Evaluation for precise Condition attribute parsing [MIT]
* Create ConditionEvaluator to glue Project2015To2017 and MSBuild expression trees
* Add sophisticated simplification routine to ProjectPropertiesReader to reduce duplication of defaults (handling variety of cases, including non-default project-wide property override and default conditionalpropertygroup-wide override)
* ProjectPropertiesReader: replace hacky configuration list retrieval routine with a better one using ConditionEvaluator
* Add Project.Platforms list property retrieval to match Project.Configurations
* [breaking change] Real support for multiple TargetFrameworks (Project.TargetFrameworks: IReadOnlyList<string> -> IList<string>, now always non-null, set accessor removed)
* Do not write default values of $(Configurations) and $(Platforms) in ProjectWriter
* Update tests to reflect changes (e.g. changed type of Project.TargetFrameworks)
* Create a number of tests to showcase and verify simplification behavior