### PR TITLE
Enable WPF, Windows Forms, UAP/UWP and Xamarin conversion

### DIFF
--- a/Project2015To2017/Definition/Project.cs
+++ b/Project2015To2017/Definition/Project.cs
@@ -81,5 +81,8 @@ namespace Project2015To2017.Definition
 		public Solution Solution { get; set; }
 
 		public IReadOnlyList<XElement> AssemblyAttributeProperties { get; set; } = Array.Empty<XElement>();
+
+		public bool IsWindowsFormsProject { get; set; }
+		public bool IsWindowsPresentationFoundationProject { get; set; }
 	}
 }

--- a/Project2015To2017/ProjectConverter.cs
+++ b/Project2015To2017/ProjectConverter.cs
@@ -21,7 +21,8 @@ namespace Project2015To2017
 			new RemovePackageImportsTransformation(),
 			new FileTransformation(),
 			new NugetPackageTransformation(),
-			new AssemblyAttributeTransformation()
+			new AssemblyAttributeTransformation(),
+			new XamlPagesTransformation(),
 		};
 
 		public static IEnumerable<Definition.Project> Convert(

--- a/Project2015To2017/Transforms/XamlPagesTransformation.cs
+++ b/Project2015To2017/Transforms/XamlPagesTransformation.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Project2015To2017.Definition;
+
+namespace Project2015To2017.Transforms
+{
+	public class XamlPagesTransformation : ITransformation
+	{
+		/// <inheritdoc />
+		public void Transform(Project definition, IProgress<string> progress)
+		{
+			if (!definition.IsWindowsPresentationFoundationProject)
+				return;
+
+			var removeQueue = new List<XElement>();
+			foreach (var item in definition.IncludeItems.Where(x => XamlPageFilter(x, definition)))
+			{
+				var path = item.Attribute("Include")?.Value;
+				progress.Report($"Removing XAML item thanks to MSBuild.Sdk.Extras defaults: '{path}'");
+				removeQueue.Add(item);
+			}
+
+			definition.IncludeItems = definition.IncludeItems.Except(removeQueue).ToArray();
+		}
+
+		private static bool XamlPageFilter(XElement x, Project definition)
+		{
+			var tagLocalName = x.Name.LocalName;
+			if (tagLocalName != "Page" && tagLocalName != "ApplicationDefinition")
+				return false;
+
+			var include = x.Attribute("Include")?.Value;
+
+			if (include == null)
+				return false;
+
+			var projectFolder = definition.ProjectFolder.FullName;
+			return include.EndsWith(".xaml")
+			       && Path.GetFullPath(Path.Combine(projectFolder, include)).StartsWith(projectFolder);
+		}
+	}
+}

--- a/Project2015To2017/UnsupportedProjectTypes.cs
+++ b/Project2015To2017/UnsupportedProjectTypes.cs
@@ -21,12 +21,7 @@ namespace Project2015To2017
 			if (xmlDocument == null) throw new ArgumentNullException(nameof(xmlDocument));
 			XNamespace nsSys = "http://schemas.microsoft.com/developer/msbuild/2003";
 
-			// get the MyType tag
-			var outputType = xmlDocument.Descendants(nsSys + "MyType").FirstOrDefault();
-			// WinForms applications
-			if (outputType?.Value == "WindowsForms") return true;
-
-			// try to get project type - may not exist 
+			// try to get project type - may not exist
 			var typeElement = xmlDocument.Descendants(nsSys + "ProjectTypeGuids").FirstOrDefault();
 			// no matching tag found, project should be okay to convert
 			if (typeElement == null) return false;
@@ -54,16 +49,12 @@ namespace Project2015To2017
 		/// </remarks>
 		private static readonly string[] unsupportedGuids =
 			{
-			"{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}",   // ASP.NET 5			
+			"{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}",   // ASP.NET 5
 			"{603C0E0B-DB56-11DC-BE95-000D561079B0}",   // ASP.NET MVC 1
 			"{F85E285D-A4E0-4152-9332-AB1D724D3325}",   // ASP.NET MVC 2
 			"{E53F8FEA-EAE0-44A6-8774-FFD645390401}",   // ASP.NET MVC 3
 			"{E3E379DF-F4C6-4180-9B81-6769533ABE47}",   // ASP.NET MVC 4
 			"{349C5851-65DF-11DA-9384-00065B846F21}",   // ASP.NET MVC 5
-			"{EFBA0AD7-5A72-4C68-AF49-83D382785DCF}",   // Xamarin-android
-			"{6BC8ED88-2882-458C-8E55-DFD12B67127B}",   // Xamarin-iOS
-			"{60DC8134-EBA5-43B8-BCC9-BB4BC16C2548}",   // WPF
-			"{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A}"   // UWP
 			};
 	}
 }

--- a/Project2015To2017/Writing/ProjectWriter.cs
+++ b/Project2015To2017/Writing/ProjectWriter.cs
@@ -9,6 +9,7 @@ namespace Project2015To2017.Writing
 {
 	public class ProjectWriter
 	{
+		private const string SdkExtrasVersion = "MSBuild.Sdk.Extras/1.6.41";
 		private readonly Action<FileSystemInfo> deleteFileOperation;
 		private readonly Action<FileSystemInfo> checkoutOperation;
 
@@ -165,7 +166,10 @@ namespace Project2015To2017.Writing
 		{
 			var outputFile = project.FilePath;
 
-			var projectNode = new XElement("Project", new XAttribute("Sdk", "Microsoft.NET.Sdk"));
+			var netSdk = "Microsoft.NET.Sdk";
+			if (project.IsWindowsFormsProject || project.IsWindowsPresentationFoundationProject)
+				netSdk = SdkExtrasVersion;
+			var projectNode = new XElement("Project", new XAttribute("Sdk", netSdk));
 
 			projectNode.Add(GetMainPropertyGroup(project, outputFile));
 
@@ -331,6 +335,11 @@ namespace Project2015To2017.Writing
 			AddIfNotNull(mainPropertyGroup, "SignAssembly", project.SignAssembly ? "true" : null);
 			AddIfNotNull(mainPropertyGroup, "DelaySign", project.DelaySign.HasValue ? (project.DelaySign.Value ? "true" : "false") : null);
 			AddIfNotNull(mainPropertyGroup, "AssemblyOriginatorKeyFile", project.AssemblyOriginatorKeyFile);
+
+			AddIfNotNull(mainPropertyGroup, "ExtrasEnableWpfProjectSetup",
+				project.IsWindowsPresentationFoundationProject ? "true" : null);
+			AddIfNotNull(mainPropertyGroup, "ExtrasEnableWinFormsProjectSetup",
+				project.IsWindowsFormsProject ? "true" : null);
 
 			switch (project.Type)
 			{

--- a/Project2015To2017Tests/UnsupportedProjectTypesTest.cs
+++ b/Project2015To2017Tests/UnsupportedProjectTypesTest.cs
@@ -36,7 +36,7 @@ namespace Project2015To2017Tests
 		/// <param name="guidTypes"></param>
 		/// <param name="testCase"></param>
 		/// <param name="expected"></param>
-		[DataRow("WindowsForms", "WinForms", true)]
+		[DataRow("WindowsForms", "WinForms", false)]
 		[DataRow("", "Other", false)]
 		[TestMethod]
 		public void CheckAnUnsupportedProjectOutputReturnsCorrectResult(string outputType, string testCase, bool expected)


### PR DESCRIPTION
* Detect WPF, Windows Forms, UWP and Xamarin (last 2 are disabled until simplification PR is merged)
* Remove newly detected project types from list of unsupported ones
* Add XamlPagesTransformation to prevent duplicated item inclusion (Page & ApplicationDefinition, handled by MSBuild.Sdk.Extras)
* Add MSBuild.Sdk.Extras SDK usage to ProjectWriter
* Add IsWindowsFormsProject & IsWindowsPresentationFoundationProject to Project model

XamlTransformationTest.cs was originally part of this commit, removed due to dependency on simplification PR. Will be pushed as soon as simplification PR is merged, either in this or separate PR.