### PR TITLE
Minor improvements

### DIFF
--- a/Project2015To2017/Definition/Project.cs
+++ b/Project2015To2017/Definition/Project.cs
@@ -36,6 +36,8 @@ namespace Project2015To2017.Definition
 		public FileInfo FilePath { get; set; }
 		public DirectoryInfo ProjectFolder => FilePath.Directory;
 
+		public bool HasMultipleAssemblyInfoFiles { get; set; }
+
 		/// <summary>
 		/// Files or folders that should be deleted as part of the conversion
 		/// </summary>
@@ -67,7 +69,7 @@ namespace Project2015To2017.Definition
 					return this.Solution.NugetPackagesPath;
 				}
 
-				var path = Path.GetFullPath(Path.Combine(projectFolder, @"..\packages"));
+				var path = Path.GetFullPath(Path.Combine(projectFolder, "..", "packages"));
 
 				return new DirectoryInfo(path);
 			}

--- a/Project2015To2017/Transforms/AssemblyAttributeTransformation.cs
+++ b/Project2015To2017/Transforms/AssemblyAttributeTransformation.cs
@@ -12,6 +12,8 @@ namespace Project2015To2017.Transforms
 		{
 			if (definition.AssemblyAttributes == null)
 			{
+				if (definition.HasMultipleAssemblyInfoFiles)
+					definition.AssemblyAttributeProperties = new[] { new XElement("GenerateAssemblyInfo", "false") };
 				return;
 			}
 
@@ -65,10 +67,8 @@ namespace Project2015To2017.Transforms
 				//convert over if they wish
 				return new[] { new XElement("GenerateAssemblyInfo", "false") };
 			}
-			else
-			{
-				return childNodes;
-			}
+
+			return childNodes;
 		}
 
 		private static IReadOnlyList<XElement> OtherProperties(AssemblyAttributes assemblyAttributes,

--- a/Project2015To2017/Transforms/AssemblyReferenceTransformation.cs
+++ b/Project2015To2017/Transforms/AssemblyReferenceTransformation.cs
@@ -19,8 +19,6 @@ namespace Project2015To2017.Transforms
 			var assemblyReferences =
 					definition
 						.AssemblyReferences
-						//This reference is obsolete.
-						?.Where(x => !x.Include.Equals("Microsoft.CSharp", StringComparison.OrdinalIgnoreCase))
 						//We don't need to keep any references to package files as these are
 						//now generated dynamically at build time
 						.Where(assemblyReference => !packageIds.Contains(assemblyReference.Include))

--- a/Project2015To2017/Writing/ProjectWriter.cs
+++ b/Project2015To2017/Writing/ProjectWriter.cs
@@ -108,7 +108,7 @@ namespace Project2015To2017.Writing
 
 			progress.Report($"Backing up to {backupFolder.FullName}");
 
-			projectFile.CopyTo(Path.Combine(backupFolder.FullName,  $"{projectFile.Name}.old"));
+			projectFile.CopyTo(Path.Combine(backupFolder.FullName, $"{projectFile.Name}.old"));
 
 			var packagesFile = project.PackagesConfigFile;
 			packagesFile?.CopyTo(Path.Combine(backupFolder.FullName, $"{packagesFile.Name}.old"));
@@ -149,8 +149,8 @@ namespace Project2015To2017.Writing
 				var MaxIndex = 100;
 
 				var foundBackupDir = Enumerable.Range(1, MaxIndex)
-											   .Select(x => Path.Combine(baseDir, $"Backup{x}"))
-											   .FirstOrDefault(x => !Directory.Exists(x));
+					.Select(x => Path.Combine(baseDir, $"Backup{x}"))
+					.FirstOrDefault(x => !Directory.Exists(x));
 
 				if (foundBackupDir == null)
 				{
@@ -206,7 +206,7 @@ namespace Project2015To2017.Writing
 				foreach (var projectReference in project.ProjectReferences)
 				{
 					var projectReferenceElement = new XElement("ProjectReference",
-							new XAttribute("Include", projectReference.Include));
+						new XAttribute("Include", projectReference.Include));
 
 					if (!string.IsNullOrWhiteSpace(projectReference.Aliases) && projectReference.Aliases != "global")
 					{
@@ -224,7 +224,8 @@ namespace Project2015To2017.Writing
 				var nugetReferences = new XElement("ItemGroup");
 				foreach (var packageReference in project.PackageReferences)
 				{
-					var reference = new XElement("PackageReference", new XAttribute("Include", packageReference.Id), new XAttribute("Version", packageReference.Version));
+					var reference = new XElement("PackageReference", new XAttribute("Include", packageReference.Id),
+						new XAttribute("Version", packageReference.Version));
 					if (packageReference.IsDevelopmentDependency)
 					{
 						reference.Add(new XElement("PrivateAssets", "all"));
@@ -273,14 +274,17 @@ namespace Project2015To2017.Writing
 			{
 				output.Add(new XElement("HintPath", assemblyReference.HintPath));
 			}
+
 			if (assemblyReference.Private != null)
 			{
 				output.Add(new XElement("Private", assemblyReference.Private));
 			}
+
 			if (assemblyReference.SpecificVersion != null)
 			{
 				output.Add(new XElement("SpecificVersion", assemblyReference.SpecificVersion));
 			}
+
 			if (assemblyReference.EmbedInteropTypes != null)
 			{
 				output.Add(new XElement("EmbedInteropTypes", assemblyReference.EmbedInteropTypes));
@@ -292,12 +296,13 @@ namespace Project2015To2017.Writing
 		private static XElement RemoveAllNamespaces(XElement e)
 		{
 			return new XElement(e.Name.LocalName,
-			  (from n in e.Nodes()
-			   select ((n is XElement) ? RemoveAllNamespaces((XElement)n) : n)),
-				  (e.HasAttributes) ?
-					(from a in e.Attributes()
-					 where (!a.IsNamespaceDeclaration)
-					 select new XAttribute(a.Name.LocalName, a.Value)) : null);
+				(from n in e.Nodes()
+					select ((n is XElement) ? RemoveAllNamespaces((XElement) n) : n)),
+				(e.HasAttributes)
+					? (from a in e.Attributes()
+						where (!a.IsNamespaceDeclaration)
+						select new XAttribute(a.Name.LocalName, a.Value))
+					: null);
 		}
 
 		private bool IsDefaultIncludedAssemblyReference(string assemblyReference)
@@ -402,15 +407,15 @@ namespace Project2015To2017.Writing
 		private void DeleteUnusedFiles(Project project, IProgress<string> progress)
 		{
 			var filesToDelete = new[]
-			{
-				project.PackageConfiguration?.NuspecFile,
-				project.PackagesConfigFile
-			}.Where(x => x != null)
-			.Concat(project.Deletions);
+				{
+					project.PackageConfiguration?.NuspecFile,
+					project.PackagesConfigFile
+				}.Where(x => x != null)
+				.Concat(project.Deletions);
 
 			foreach (var fileInfo in filesToDelete)
 			{
-				if(fileInfo is DirectoryInfo directory && directory.EnumerateFileSystemInfos().Any())
+				if (fileInfo is DirectoryInfo directory && directory.EnumerateFileSystemInfos().Any())
 				{
 					progress.Report($"Directory {fileInfo.FullName} is not empty so will not delete");
 					continue;
@@ -419,6 +424,5 @@ namespace Project2015To2017.Writing
 				this.deleteFileOperation(fileInfo);
 			}
 		}
-
 	}
 }

--- a/Project2015To2017Tests/AssemblyAttributeTransformationTest.cs
+++ b/Project2015To2017Tests/AssemblyAttributeTransformationTest.cs
@@ -253,5 +253,28 @@ namespace Project2015To2017Tests
 
 			CollectionAssert.DoesNotContain(project.Deletions.ToList(), assemblyInfoFile);
 		}
+
+		[TestMethod]
+		public void GenerateAssemblyInfoFromMultipleFilesTest()
+		{
+			var project = new Project
+			{
+				AssemblyAttributes = null,
+				HasMultipleAssemblyInfoFiles = true,
+				FilePath = new FileInfo("test.cs"),
+				Deletions = new List<FileSystemInfo>()
+			};
+
+			var transform = new AssemblyAttributeTransformation();
+
+			transform.Transform(project, new Progress<string>());
+
+			var generateAssemblyInfo = project.AssemblyAttributeProperties.SingleOrDefault();
+			Assert.IsNotNull(generateAssemblyInfo);
+			Assert.AreEqual("GenerateAssemblyInfo", generateAssemblyInfo.Name);
+			Assert.AreEqual("false", generateAssemblyInfo.Value);
+
+			CollectionAssert.DoesNotContain(project.Deletions?.ToList(), BaseAssemblyAttributes().File);
+		}
 	}
 }

--- a/Project2015To2017Tests/AssemblyReferenceTransformationTest.cs
+++ b/Project2015To2017Tests/AssemblyReferenceTransformationTest.cs
@@ -21,9 +21,9 @@ namespace Project2015To2017Tests
 
 			transformation.Transform(project, progress);
 
-			Assert.AreEqual(11, project.AssemblyReferences.Count);
+			Assert.AreEqual(12, project.AssemblyReferences.Count);
 			Assert.IsTrue(project.AssemblyReferences.Any(x => x.Include == @"System.Xml.Linq"));
-			Assert.IsFalse(project.AssemblyReferences.Any(x => x.Include == @"Microsoft.CSharp"));
+			Assert.IsTrue(project.AssemblyReferences.Any(x => x.Include == @"Microsoft.CSharp"));
 		}
 
 		[TestMethod]


### PR DESCRIPTION
* Do not allow generated AssemblyInfo in case more that 1 AssemblyInfo file is found
* Add Project.HasMultipleAssemblyInfos flag
* Add test to ensure GenerateAssemblyInfo is set to false correctly
* Do not remove Microsoft.CSharp assembly reference (#40 is wrong, it is still needed)
* Update tests to reflect changes
* Minor formatting fixes