### PR TITLE
Introduce caching and minor refactorings

### DIFF
--- a/Project2015To2017.Console/Options.cs
+++ b/Project2015To2017.Console/Options.cs
@@ -29,7 +29,7 @@ namespace Project2015To2017.Console
 			{
 				KeepAssemblyInfo = AssemblyInfo,
 				TargetFrameworks = TargetFrameworks?.ToList(),
-				AppendTargetFrameworkToOutputPath = !NoTargetFrameworkToOutputPath
+				AppendTargetFrameworkToOutputPath = !NoTargetFrameworkToOutputPath,
 			};
 	}
 }

--- a/Project2015To2017.Console/Program.cs
+++ b/Project2015To2017.Console/Program.cs
@@ -4,17 +4,19 @@ using System.Diagnostics;
 using System.Linq;
 using CommandLine;
 using Project2015To2017.Definition;
+using Project2015To2017.Reading;
 
 namespace Project2015To2017.Console
 {
-	class Program
+	internal static class Program
 	{
 		static void Main(string[] args)
 		{
+			ProjectReader.EnableCaching = true;
 			Parser.Default.ParseArguments<Options>(args)
 				.WithParsed(ConvertProject);
-
 		}
+
 		private static void ConvertProject(Options options)
 		{
 #if DEBUG
@@ -23,28 +25,33 @@ namespace Project2015To2017.Console
 			var progress = new Progress<string>(System.Console.WriteLine);
 #endif
 
+			var conversionOptions = options.ConversionOptions;
+
 			var convertedProjects = new List<Project>();
 
 			foreach (var file in options.Files)
 			{
 				var projects = ProjectConverter
-					.Convert(file, options.ConversionOptions, progress)
+					.Convert(file, conversionOptions, progress)
 					.Where(x => x != null)
 					.ToList();
 				convertedProjects.AddRange(projects);
 			}
 
-			if (!options.DryRun)
+			if (options.DryRun)
 			{
-				var doBackup = !options.NoBackup;
-
-				var writer = new Writing.ProjectWriter(x => x.Delete(), _ => { });
-				foreach (var project in convertedProjects)
-				{
-					writer.Write(project, doBackup, progress);
-				}
+				return;
 			}
-		}
 
+			var doBackup = !options.NoBackup;
+
+			var writer = new Writing.ProjectWriter(x => x.Delete(), _ => { });
+			foreach (var project in convertedProjects)
+			{
+				writer.Write(project, doBackup, progress);
+			}
+
+			ProjectReader.PurgeCache();
+		}
 	}
 }

--- a/Project2015To2017.Console/Project2015To2017.Console.csproj
+++ b/Project2015To2017.Console/Project2015To2017.Console.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<RootNamespace>Project2015To2017.Console</RootNamespace>
@@ -13,6 +13,7 @@
 		<Copyright>Copyright Hans van Bakel</Copyright>
 		<PackageTags>dotnet csproj conversion vs2015 vs2017</PackageTags>
 		<Version>1.7.0</Version>
+		<OutputType>Exe</OutputType>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="$(Pack) != 'true'">
@@ -22,7 +23,6 @@
 	<PropertyGroup Condition="$(Pack) == 'true'">
 		<ToolCommandName>csproj-to-2017</ToolCommandName>
 		<PackAsTool>True</PackAsTool>
-		<OutputType>Exe</OutputType>
 		<TargetFramework>netcoreapp2.1</TargetFramework>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	</PropertyGroup>

--- a/Project2015To2017/Definition/AssemblyReference.cs
+++ b/Project2015To2017/Definition/AssemblyReference.cs
@@ -1,15 +1,19 @@
+using System.Xml.Linq;
+
 namespace Project2015To2017.Definition
 {
-    // Reference
-    public class AssemblyReference
-    {
+	// Reference
+	public class AssemblyReference
+	{
 		// Attributes
-	    public string Include { get; set; }
+		public string Include { get; set; }
 
-        // Elements
-        public string EmbedInteropTypes { get; set; }
-        public string HintPath { get; set; }
-        public string Private { get; set; }
-        public string SpecificVersion { get; set; }
-    }
+		// Elements
+		public string EmbedInteropTypes { get; set; }
+		public string HintPath { get; set; }
+		public string Private { get; set; }
+		public string SpecificVersion { get; set; }
+
+		public XElement DefinitionElement { get; set; }
+	}
 }

--- a/Project2015To2017/Definition/Project.cs
+++ b/Project2015To2017/Definition/Project.cs
@@ -8,7 +8,8 @@ namespace Project2015To2017.Definition
 {
 	public sealed class Project
 	{
-		public static readonly XNamespace XmlNamespace = "http://schemas.microsoft.com/developer/msbuild/2003";
+		public static readonly XNamespace XmlLegacyNamespace = "http://schemas.microsoft.com/developer/msbuild/2003";
+		public static readonly XNamespace XmlNamespace = XmlLegacyNamespace;
 
 		public IReadOnlyList<AssemblyReference> AssemblyReferences { get; set; }
 		public IReadOnlyList<ProjectReference> ProjectReferences { get; set; }
@@ -23,6 +24,8 @@ namespace Project2015To2017.Definition
 		public IReadOnlyList<string> Configurations { get; set; }
 		public IReadOnlyList<string> Platforms { get; set; }
 		public IReadOnlyList<XElement> OtherPropertyGroups { get; set; }
+
+		public XDocument ProjectDocument { get; set; }
 
 		public IList<string> TargetFrameworks { get; } = new List<string>();
 		public bool AppendTargetFrameworkToOutputPath { get; set; } = true;
@@ -46,11 +49,11 @@ namespace Project2015To2017.Definition
 		public IReadOnlyList<FileSystemInfo> Deletions { get; set; }
 
 		/// <summary>
-		/// The directory where nuget stores its extracted packages for the project.
+		/// The directory where NuGet stores its extracted packages for the project.
 		/// In general this is the 'packages' folder within the parent solution, but
 		/// it can be overridden, which is accounted for here.
 		/// </summary>
-		public DirectoryInfo NugetPackagesPath
+		public DirectoryInfo NuGetPackagesPath
 		{
 			get
 			{
@@ -68,7 +71,7 @@ namespace Project2015To2017.Definition
 
 				if (this.Solution != null)
 				{
-					return this.Solution.NugetPackagesPath;
+					return this.Solution.NuGetPackagesPath;
 				}
 
 				var path = Path.GetFullPath(Path.Combine(projectFolder, "..", "packages"));

--- a/Project2015To2017/Definition/ProjectReference.cs
+++ b/Project2015To2017/Definition/ProjectReference.cs
@@ -1,8 +1,13 @@
+using System.IO;
+
 namespace Project2015To2017.Definition
 {
-    public class ProjectReference
-    {
-	    public string Include { get; set; }
+	public class ProjectReference
+	{
+		public string Include { get; set; }
 		public string Aliases { get; set; }
-    }
+		public bool EmbedInteropTypes { get; set; }
+
+		public FileInfo ProjectFile { get; set; }
+	}
 }

--- a/Project2015To2017/Definition/Solution.cs
+++ b/Project2015To2017/Definition/Solution.cs
@@ -7,7 +7,7 @@ namespace Project2015To2017.Definition
 	public sealed class Solution
 	{
 		public FileInfo FilePath { get; set; }
-		public IReadOnlyList<string> ProjectPaths { get; set; }
+		public IReadOnlyList<ProjectReference> ProjectPaths { get; set; }
 		public DirectoryInfo SolutionFolder => FilePath.Directory;
 
 		/// <summary>
@@ -15,7 +15,7 @@ namespace Project2015To2017.Definition
 		/// In general this is the 'packages' folder within the solution oflder, but
 		/// it can be overridden, which is accounted for here.
 		/// </summary>
-		public DirectoryInfo NugetPackagesPath
+		public DirectoryInfo NuGetPackagesPath
 		{
 			get
 			{

--- a/Project2015To2017/Project2015To2017.csproj
+++ b/Project2015To2017/Project2015To2017.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFrameworks>netstandard1.3;netstandard2.0</TargetFrameworks>
     <RootNamespace>Project2015To2017</RootNamespace>
     <AssemblyName>Project2015To2017</AssemblyName>
 	<Authors>hvanbakel et. al.</Authors>
@@ -21,4 +21,14 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.8.2" />
     <PackageReference Include="NuGet.Configuration" Version="4.6.2" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkVersion)' == 'v2.0'">
+    <PackageReference Include="System.Runtime.Caching" Version="4.5.0" />
+    <Compile Remove="Reading/ConditionEvaluator.LegacyCache.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkVersion)' == 'v1.3'">
+    <Compile Remove="Reading/ConditionEvaluator.ModernCache.cs" />
+  </ItemGroup>
+  
 </Project>

--- a/Project2015To2017/Reading/ConditionEvaluator.LegacyCache.cs
+++ b/Project2015To2017/Reading/ConditionEvaluator.LegacyCache.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+
+namespace Project2015To2017.Reading
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public static partial class ConditionEvaluator
+    {
+        private static readonly Dictionary<string, ConditionEvaluationStateImpl> Cache = new Dictionary<string, ConditionEvaluationStateImpl>();
+
+        private static bool TryGetCachedOrCreateState(string condition, out ConditionEvaluationStateImpl state)
+        {
+            if (Cache.TryGetValue(condition, out state))
+            {
+                return true;
+            }
+
+            state = new ConditionEvaluationStateImpl();
+
+            Cache.Add(condition, state);
+
+            return false;
+        }
+    }
+}

--- a/Project2015To2017/Reading/ConditionEvaluator.ModernCache.cs
+++ b/Project2015To2017/Reading/ConditionEvaluator.ModernCache.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.Caching;
+
+namespace Project2015To2017.Reading
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public static partial class ConditionEvaluator
+    {
+        private static bool TryGetCachedOrCreateState(string condition, out ConditionEvaluationStateImpl state)
+        {
+            state = MemoryCache.Default[condition] as ConditionEvaluationStateImpl;
+
+            if (state != null)
+            {
+                return true;
+            }
+
+            state = new ConditionEvaluationStateImpl();
+
+            MemoryCache.Default.Add(condition, state, ObjectCache.InfiniteAbsoluteExpiration);
+
+            return false;
+        }
+    }
+}

--- a/Project2015To2017/Reading/SolutionReader.cs
+++ b/Project2015To2017/Reading/SolutionReader.cs
@@ -8,6 +8,8 @@ namespace Project2015To2017.Reading
 {
 	public class SolutionReader
 	{
+		public static readonly SolutionReader Instance = new SolutionReader();
+
 		public Solution Read(string filePath)
 		{
 			return Read(filePath, new Progress<string>(_ => { }));
@@ -16,7 +18,7 @@ namespace Project2015To2017.Reading
 		public Solution Read(string filePath, IProgress<string> progress)
 		{
 			var fileInfo = new FileInfo(filePath);
-			var projectPaths = new List<string>();
+			var projectPaths = new List<ProjectReference>();
 			using (var reader = new StreamReader(fileInfo.OpenRead()))
 			{
 				string line;
@@ -30,7 +32,12 @@ namespace Project2015To2017.Reading
 					var projectPath = line.Split('"').FirstOrDefault(x => x.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase));
 					if (projectPath != null)
 					{
-						projectPaths.Add(projectPath);
+						var reference = new ProjectReference
+						{
+							Include = projectPath,
+							ProjectFile = new FileInfo(Path.Combine(fileInfo.Directory.FullName, projectPath)),
+						};
+						projectPaths.Add(reference);
 					}
 				}
 			}

--- a/Project2015To2017/Transforms/FileTransformation.cs
+++ b/Project2015To2017/Transforms/FileTransformation.cs
@@ -156,15 +156,19 @@ namespace Project2015To2017.Transforms
 				knownFullPaths.Add(Path.GetFullPath(Path.Combine(projectFolder.FullName, otherIncludeMatchingWildcard)));
 			}
 
-			foreach (var nonListedFile in filesInFolder.Except(knownFullPaths, StringComparer.OrdinalIgnoreCase))
+			// if (!project.IsModernProject)
 			{
-				if (nonListedFile.StartsWith(Path.Combine(projectFolder.FullName + "\\obj\\"), StringComparison.OrdinalIgnoreCase))
+				foreach (var nonListedFile in filesInFolder.Except(knownFullPaths, StringComparer.OrdinalIgnoreCase))
 				{
-					// skip the generated files in obj
-					continue;
-				}
+					if (nonListedFile.StartsWith(Path.Combine(projectFolder.FullName + "\\obj\\"),
+						StringComparison.OrdinalIgnoreCase))
+					{
+						// skip the generated files in obj
+						continue;
+					}
 
-				progress.Report($"File found which was not included, consider removing {nonListedFile}.");
+					progress.Report($"File found which was not included, consider removing {nonListedFile}.");
+				}
 			}
 
 			foreach (var fileNotOnDisk in knownFullPaths.Except(filesInFolder).Where(x => x.StartsWith(projectFolder.FullName, StringComparison.OrdinalIgnoreCase)))

--- a/Project2015To2017/Transforms/Helpers.cs
+++ b/Project2015To2017/Transforms/Helpers.cs
@@ -1,22 +1,42 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 
 namespace Project2015To2017.Transforms
 {
-    public static class Helpers
-    {
-	    public static IEnumerable<XElement> ElementsAnyNamespace<T>(this IEnumerable<T> source, string localName)
-		    where T : XContainer
-	    {
-		    return source.Elements().Where(e => e.Name.LocalName == localName);
-	    }
+	public static class Helpers
+	{
+		public static IEnumerable<XElement> ElementsAnyNamespace<T>(this IEnumerable<T> source, string localName)
+			where T : XContainer
+		{
+			return source.Elements().Where(e => e.Name.LocalName == localName);
+		}
 
-	    public static IEnumerable<XElement> ElementsAnyNamespace<T>(this T source, string localName)
-		    where T : XContainer
-	    {
-		    return source.Elements().Where(e => e.Name.LocalName == localName);
-	    }
-    }
+		public static IEnumerable<XElement> ElementsAnyNamespace<T>(this T source, string localName)
+			where T : XContainer
+		{
+			return source.Elements().Where(e => e.Name.LocalName == localName);
+		}
+		
+		public static string GetRelativePathTo(this FileSystemInfo from, FileSystemInfo to)
+		{
+			string GetPath(FileSystemInfo fsi)
+			{
+				return (fsi is DirectoryInfo d) ? (d.FullName.TrimEnd('\\') + "\\") : fsi.FullName;
+			}
+
+			var fromPath = GetPath(@from);
+			var toPath = GetPath(to);
+
+			var fromUri = new Uri(fromPath);
+			var toUri = new Uri(toPath);
+
+			var relativeUri = fromUri.MakeRelativeUri(toUri);
+			var relativePath = Uri.UnescapeDataString(relativeUri.ToString());
+
+			return relativePath.Replace('/', Path.DirectorySeparatorChar);
+		}
+	}
 }

--- a/Project2015To2017/Transforms/NuGetPackageTransformation.cs
+++ b/Project2015To2017/Transforms/NuGetPackageTransformation.cs
@@ -29,13 +29,10 @@ namespace Project2015To2017.Transforms
 				return;
 			}
 
-			var packageIdConstraints = dependencies.Select(dependency =>
+			var packageIdConstraints = dependencies.Select(dependency => new
 			{
-				return new
-				{
-					PackageId = dependency.Attribute("id").Value,
-					Version = dependency.Attribute("version").Value
-				};
+				PackageId = dependency.Attribute("id").Value,
+				Version = dependency.Attribute("version").Value
 			}).ToArray();
 
 			foreach (var packageReference in rawPackageReferences)

--- a/Project2015To2017/Transforms/RemovePackageAssemblyReferencesTransformation.cs
+++ b/Project2015To2017/Transforms/RemovePackageAssemblyReferencesTransformation.cs
@@ -16,7 +16,7 @@ namespace Project2015To2017.Transforms
 
 			var projectPath = definition.ProjectFolder.FullName;
 
-			var nugetRepositoryPath = definition.NugetPackagesPath.FullName;
+			var nugetRepositoryPath = definition.NuGetPackagesPath.FullName;
 
 			var packageReferenceIds = definition.PackageReferences.Select(x => x.Id).ToArray();
 

--- a/Project2015To2017/Transforms/RemovePackageImportsTransformation.cs
+++ b/Project2015To2017/Transforms/RemovePackageImportsTransformation.cs
@@ -18,7 +18,7 @@ namespace Project2015To2017.Transforms
 
 			var projectPath = definition.ProjectFolder.FullName;
 
-			var nugetRepositoryPath = definition.NugetPackagesPath.FullName;
+			var nugetRepositoryPath = definition.NuGetPackagesPath.FullName;
 
 			var packageReferenceIds = definition.PackageReferences.Select(x => x.Id).ToArray();
 

--- a/Project2015To2017/Writing/ProjectWriter.cs
+++ b/Project2015To2017/Writing/ProjectWriter.cs
@@ -218,6 +218,11 @@ namespace Project2015To2017.Writing
 						projectReferenceElement.Add(new XElement("Aliases", projectReference.Aliases));
 					}
 
+					if (projectReference.EmbedInteropTypes)
+					{
+						projectReferenceElement.Add(new XElement("EmbedInteropTypes", "true"));
+					}
+
 					itemGroup.Add(projectReferenceElement);
 				}
 

--- a/Project2015To2017Tests/AssemblyInfoReadTest.cs
+++ b/Project2015To2017Tests/AssemblyInfoReadTest.cs
@@ -1,5 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Project2015To2017.Reading;
+using System.IO;
 
 namespace Project2015To2017Tests
 {
@@ -9,7 +10,7 @@ namespace Project2015To2017Tests
         [TestMethod]
         public void FindsAttributes()
         {
-	        var project = new ProjectReader().Read("TestFiles\\OtherTestProjects\\net46console.testcsproj");
+	        var project = new ProjectReader(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj")).Read();
 
             Assert.IsNotNull(project.AssemblyAttributes.Company);
             Assert.IsNotNull(project.AssemblyAttributes.Copyright);

--- a/Project2015To2017Tests/AssemblyReferenceTransformationTest.cs
+++ b/Project2015To2017Tests/AssemblyReferenceTransformationTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
 using System.Linq;
 using Project2015To2017.Definition;
 using Project2015To2017.Reading;
@@ -14,7 +15,7 @@ namespace Project2015To2017Tests
 		[TestMethod]
 		public void TransformsAssemblyReferences()
 		{
-			var project = new ProjectReader().Read("TestFiles\\OtherTestProjects\\net46console.testcsproj");
+			var project = new ProjectReader(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj")).Read();
 			var transformation = new AssemblyReferenceTransformation();
 
 			var progress = new Progress<string>(x => { });

--- a/Project2015To2017Tests/FileTransformationTest.cs
+++ b/Project2015To2017Tests/FileTransformationTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
 using System.Linq;
 using Project2015To2017.Reading;
 using Project2015To2017.Transforms;
@@ -14,7 +15,7 @@ namespace Project2015To2017Tests
         [TestMethod]
         public void TransformsFiles()
         {
-            var project = new ProjectReader().Read("TestFiles\\Fileinclusion\\fileinclusion.testcsproj");
+            var project = new ProjectReader(Path.Combine("TestFiles", "FileInclusion", "fileinclusion.testcsproj")).Read();
             var transformation = new FileTransformation();
 
 	        var logEntries = new List<string>();

--- a/Project2015To2017Tests/NuGetPackageTransformationTest.cs
+++ b/Project2015To2017Tests/NuGetPackageTransformationTest.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
 using System.Linq;
 using Project2015To2017.Definition;
 using Project2015To2017.Reading;
@@ -8,13 +9,12 @@ using Project2015To2017.Transforms;
 namespace Project2015To2017Tests
 {
 	[TestClass]
-	public class NugetPackageTransformationTest
+	public class NuGetPackageTransformationTest
 	{
 		[TestMethod]
 		public void ConvertsNuspec()
 		{
-			var project = new ProjectReader()
-								.Read("TestFiles\\OtherTestProjects\\net46console.testcsproj");
+			var project = new ProjectReader(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj")).Read();
 
 			project.AssemblyName = "TestAssembly";
 
@@ -47,8 +47,7 @@ namespace Project2015To2017Tests
 		[TestMethod]
 		public void ConvertsNuspecWithNoInformationalVersion()
 		{
-			var project = new ProjectReader()
-				.Read("TestFiles\\OtherTestProjects\\net46console.testcsproj");
+			var project = new ProjectReader(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj")).Read();
 
 			project.AssemblyAttributes =
 				new AssemblyAttributes {
@@ -70,8 +69,7 @@ namespace Project2015To2017Tests
 		[TestMethod]
 		public void ConvertsDependencies()
 		{
-			var project = new ProjectReader()
-								.Read("TestFiles\\OtherTestProjects\\net46console.testcsproj");
+			var project = new ProjectReader(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj")).Read();
 
 			project.PackageReferences = new[]
 										{

--- a/Project2015To2017Tests/PackageReferenceTransformationTest.cs
+++ b/Project2015To2017Tests/PackageReferenceTransformationTest.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
+using System.IO;
 using Project2015To2017.Definition;
 using Project2015To2017.Reading;
 using Project2015To2017.Transforms;
@@ -13,7 +14,7 @@ namespace Project2015To2017Tests
         [TestMethod]
         public void AddsTestPackages()
         {
-	        var project = new ProjectReader().Read("TestFiles\\OtherTestProjects\\net46console.testcsproj");
+	        var project = new ProjectReader(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj")).Read();
 
 	        project.Type = ApplicationType.TestProject;
 	        project.TargetFrameworks.Add("net45");
@@ -33,7 +34,7 @@ namespace Project2015To2017Tests
         [TestMethod]
         public void AcceptsNetStandardFramework()
         {
-	        var project = new ProjectReader().Read("TestFiles\\OtherTestProjects\\net46console.testcsproj");
+	        var project = new ProjectReader(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj")).Read();
 
 	        project.Type = ApplicationType.TestProject;
 	        project.TargetFrameworks.Add("netstandard2.0");
@@ -55,8 +56,7 @@ namespace Project2015To2017Tests
         {
             var transformation = new PackageReferenceTransformation();
 
-			var project = new ProjectReader()
-								.Read(@"TestFiles\\OtherTestProjects\\containsTestSDK.testcsproj");
+			var project = new ProjectReader(Path.Combine("TestFiles", "OtherTestProjects", "containsTestSDK.testcsproj")).Read();
 
 	        project.TargetFrameworks.Add("net45");
 
@@ -71,7 +71,7 @@ namespace Project2015To2017Tests
         [TestMethod]
         public void TransformsPackages()
         {
-	        var project = new ProjectReader().Read("TestFiles\\OtherTestProjects\\net46console.testcsproj");
+	        var project = new ProjectReader(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj")).Read();
 
             var transformation = new PackageReferenceTransformation();
 
@@ -87,7 +87,7 @@ namespace Project2015To2017Tests
         [TestMethod]
         public void HandlesNonXml()
         {
-            var project = new ProjectReader().Read("OtherPackagesConfig\\net46console.testcsproj");
+            var project = new ProjectReader(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj")).Read();
             var transformation = new PackageReferenceTransformation();
 
 	        var progress = new Progress<string>(x => { });

--- a/Project2015To2017Tests/ProgramTest.cs
+++ b/Project2015To2017Tests/ProgramTest.cs
@@ -35,8 +35,8 @@ namespace Project2015To2017Tests
 
 			var progress = new SyncProgress(logs.Add);
 
-			var projectFile = "TestFiles\\OtherTestProjects\\readonly.testcsproj";
-			var copiedProjectFile = $"TestFiles\\OtherTestProjects\\{nameof(ValidatesFileIsWritable)}.readonly";
+			var projectFile = Path.Combine("TestFiles", "OtherTestProjects", "readonly.testcsproj");
+			var copiedProjectFile = Path.Combine("TestFiles", "OtherTestProjects", $"{nameof(ValidatesFileIsWritable)}.readonly");
 
 			if (File.Exists(copiedProjectFile))
 			{
@@ -50,7 +50,7 @@ namespace Project2015To2017Tests
 
 				File.SetAttributes(copiedProjectFile, FileAttributes.ReadOnly);
 
-				var project = new ProjectReader().Read(copiedProjectFile, progress);
+				var project = new ProjectReader(copiedProjectFile, progress).Read();
 
 				Assert.IsFalse(logs.Any(x => x.Contains("Aborting as could not write to project file")));
 
@@ -68,7 +68,6 @@ namespace Project2015To2017Tests
 					File.Delete(copiedProjectFile);
 				}
 			}
-
 		}
 
 		[TestMethod]
@@ -78,8 +77,8 @@ namespace Project2015To2017Tests
 
 			var progress = new SyncProgress(logs.Add);
 
-			var projectFile = "TestFiles\\OtherTestProjects\\readonly.testcsproj";
-			var copiedProjectFile = $"TestFiles\\OtherTestProjects\\{nameof(ValidatesFileIsWritableAfterCheckout)}.readonly";
+			var projectFile = Path.Combine("TestFiles", "OtherTestProjects", "readonly.testcsproj");
+			var copiedProjectFile = Path.Combine("TestFiles", "OtherTestProjects", $"{nameof(ValidatesFileIsWritableAfterCheckout)}.readonly");
 
 			if (File.Exists(copiedProjectFile))
 			{
@@ -93,7 +92,7 @@ namespace Project2015To2017Tests
 
 				File.SetAttributes(copiedProjectFile, FileAttributes.ReadOnly);
 
-				var project = new ProjectReader().Read(copiedProjectFile, progress);
+				var project = new ProjectReader(copiedProjectFile, progress).Read();
 
 				var projectWriter = new ProjectWriter(_ => { }, file => File.SetAttributes(file.FullName, FileAttributes.Normal));
 
@@ -114,10 +113,9 @@ namespace Project2015To2017Tests
 		[TestMethod]
 		public void ValidatesFileExists()
 		{
-
 			var progress = new Progress<string>(x => { });
 
-			Assert.IsFalse(ProjectConverter.Validate(new FileInfo("TestFiles\\OtherTestProjects\\nonexistent.testcsproj"), progress));
+			Assert.IsFalse(ProjectConverter.Validate(new FileInfo(Path.Combine("TestFiles", "OtherTestProjects", "nonexistent.testcsproj")), progress));
 		}
 	}
 }

--- a/Project2015To2017Tests/ProjectPropertiesReadTest.cs
+++ b/Project2015To2017Tests/ProjectPropertiesReadTest.cs
@@ -789,7 +789,7 @@ if $(ConfigurationName) == Debug (
 
 			await File.WriteAllTextAsync(testCsProjFile, xml);
 
-			var project = new ProjectReader().Read(testCsProjFile);
+			var project = new ProjectReader(testCsProjFile).Read();
 
 			return project;
 		}

--- a/Project2015To2017Tests/ProjectReferenceReadTest.cs
+++ b/Project2015To2017Tests/ProjectReferenceReadTest.cs
@@ -1,5 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Linq;
+using System.IO;
 using Project2015To2017.Reading;
 
 namespace Project2015To2017Tests
@@ -10,7 +11,7 @@ namespace Project2015To2017Tests
         [TestMethod]
         public void TransformsProjectReferences()
         {
-			var project = new ProjectReader().Read("TestFiles\\OtherTestProjects\\net46console.testcsproj");
+			var project = new ProjectReader(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj")).Read();
 
             Assert.AreEqual(2, project.ProjectReferences.Count);
             Assert.IsTrue(project.ProjectReferences.Any(x => x.Include == @"..\SomeOtherProject\SomeOtherProject.csproj" && x.Aliases == "global,one"));

--- a/Project2015To2017Tests/ProjectWriterTest.cs
+++ b/Project2015To2017Tests/ProjectWriterTest.cs
@@ -4,18 +4,18 @@ using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Project2015To2017.Definition;
-using Project2015To2017.Transforms;
 using Project2015To2017.Reading;
 using Project2015To2017.Writing;
 using System.Threading.Tasks;
 using System.Runtime.CompilerServices;
-using System.Xml.Linq;
 
 namespace Project2015To2017Tests
 {
 	[TestClass]
 	public class ProjectWriterTest
 	{
+        private static readonly string deletionsPath = Path.Combine("TestFiles", "Deletions");
+
 		[TestMethod]
 		public void ValidatesFileIsWritable()
 		{
@@ -23,13 +23,13 @@ namespace Project2015To2017Tests
 			var xmlNode = writer.CreateXml(new Project
 			{
 				AssemblyAttributes = new AssemblyAttributes(),
-				FilePath = new System.IO.FileInfo("test.cs")
+				FilePath = new FileInfo("test.cs")
 			});
 
-			var copiedProjectFile = $"TestFiles\\OtherTestProjects\\{nameof(ValidatesFileIsWritable)}.readonly";
-			File.Copy("TestFiles\\OtherTestProjects\\readonly.testcsproj", copiedProjectFile);
+			var copiedProjectFile = Path.Combine("TestFiles", "OtherTestProjects", $"{nameof(ValidatesFileIsWritable)}.readonly");
+			File.Copy(Path.Combine("TestFiles", "OtherTestProjects", "readonly.testcsproj"), copiedProjectFile);
 			File.SetAttributes(copiedProjectFile, FileAttributes.ReadOnly);
-			var project = new ProjectReader().Read(copiedProjectFile);
+			var project = new ProjectReader(copiedProjectFile).Read();
 
 			var messageNum = 0;
 			var progress = new Progress<string>(x =>
@@ -143,7 +143,7 @@ namespace Project2015To2017Tests
 			var xmlNode = writer.CreateXml(new Project
 			{
 				DelaySign = null,
-				FilePath = new System.IO.FileInfo("test.cs")
+				FilePath = new FileInfo("test.cs")
 			});
 
 			var delaySign = xmlNode.Element("PropertyGroup").Element("DelaySign");
@@ -157,7 +157,7 @@ namespace Project2015To2017Tests
 			var xmlNode = writer.CreateXml(new Project
 			{
 				DelaySign = true,
-				FilePath = new System.IO.FileInfo("test.cs")
+				FilePath = new FileInfo("test.cs")
 			});
 
 			var delaySign = xmlNode.Element("PropertyGroup").Element("DelaySign");
@@ -172,7 +172,7 @@ namespace Project2015To2017Tests
 			var xmlNode = writer.CreateXml(new Project
 			{
 				DelaySign = false,
-				FilePath = new System.IO.FileInfo("test.cs")
+				FilePath = new FileInfo("test.cs")
 			});
 
 			var delaySign = xmlNode.Element("PropertyGroup").Element("DelaySign");
@@ -186,7 +186,7 @@ namespace Project2015To2017Tests
 
 			await File.WriteAllTextAsync(testCsProjFile, xml);
 
-			var project = new ProjectReader().Read(testCsProjFile);
+			var project = new ProjectReader(testCsProjFile).Read();
 
 			return project;
 		}
@@ -196,11 +196,11 @@ namespace Project2015To2017Tests
 		{
 			var filesToDelete = new FileSystemInfo[]
 			{
-				new FileInfo(@"TestFiles\Deletions\a.txt"),
-				new FileInfo(@"TestFiles\Deletions\AssemblyInfo.txt")
+				new FileInfo(Path.Combine(deletionsPath, "a.txt")),
+				new FileInfo(Path.Combine(deletionsPath, "AssemblyInfo.txt"))
 			};
 
-			var assemblyInfoFile = new FileInfo(@"TestFiles\Deletions\AssemblyInfo.txt");
+			var assemblyInfoFile = new FileInfo(Path.Combine(deletionsPath, "AssemblyInfo.txt"));
 
 			var actualDeletedFiles = new List<FileSystemInfo>();
 			var checkedOutFiles = new List<FileSystemInfo>();
@@ -214,7 +214,7 @@ namespace Project2015To2017Tests
 			writer.Write(
 				new Project
 				{
-					FilePath = new FileInfo(@"TestFiles\Deletions\Test1.csproj"),
+					FilePath = new FileInfo(Path.Combine(deletionsPath, "Test1.csproj")),
 					AssemblyAttributes = new AssemblyAttributes
 					{
 						File = assemblyInfoFile,
@@ -377,7 +377,7 @@ namespace Project2015To2017Tests
 						Include = "System"
 					}
 				},
-				FilePath = new System.IO.FileInfo("test.cs")
+				FilePath = new FileInfo("test.cs")
 			};
 
 			var writer = new ProjectWriter(_ => { }, _ => { });
@@ -394,7 +394,7 @@ namespace Project2015To2017Tests
 			var xmlNode = writer.CreateXml(new Project
 			{
 				AppendTargetFrameworkToOutputPath = true,
-				FilePath = new System.IO.FileInfo("test.cs")
+				FilePath = new FileInfo("test.cs")
 			});
 
 			var appendTargetFrameworkToOutputPath = xmlNode.Element("PropertyGroup").Element("AppendTargetFrameworkToOutputPath");
@@ -407,7 +407,7 @@ namespace Project2015To2017Tests
 			var xmlNode = writer.CreateXml(new Project
 			{
 				AppendTargetFrameworkToOutputPath = false,
-				FilePath = new System.IO.FileInfo("test.cs")
+				FilePath = new FileInfo("test.cs")
 			});
 
 			var appendTargetFrameworkToOutputPath = xmlNode.Element("PropertyGroup").Element("AppendTargetFrameworkToOutputPath");

--- a/Project2015To2017Tests/RemovePackageAssemblyReferencesTransformationTest.cs
+++ b/Project2015To2017Tests/RemovePackageAssemblyReferencesTransformationTest.cs
@@ -68,7 +68,7 @@ namespace Project2015To2017Tests
 		{
 			var projFile = @"TestFiles\AltNugetConfig\ProjectFolder\net46console.testcsproj";
 
-			var project = new ProjectReader().Read(projFile);
+			var project = new ProjectReader(projFile).Read();
 
 			var transformation = new RemovePackageAssemblyReferencesTransformation();
 
@@ -87,7 +87,7 @@ namespace Project2015To2017Tests
 		{
 			var projFile = @"TestFiles\AltNugetConfig\ProjectFolder\net46console.testcsproj";
 
-			var project = new ProjectReader().Read(projFile);
+			var project = new ProjectReader(projFile).Read();
 
 			var transformation = new RemovePackageImportsTransformation();
 

--- a/Project2015To2017Tests/TargetFrameworkTransformationTest.cs
+++ b/Project2015To2017Tests/TargetFrameworkTransformationTest.cs
@@ -41,32 +41,31 @@ namespace Project2015To2017Tests
 		[TestMethod]
 		public void HandlesOptionTargetFrameworksNull()
 		{
-			var project = new Project()
+			var project = new Project
 			{
 				TargetFrameworks = { "net46" }
 			};
-			IReadOnlyList<string> targetFrameworks = null;
-
+			
 			var progress = new Progress<string>(x => { });
 
-			var transformation = new TargetFrameworkTransformation(targetFrameworks);
+			var transformation = new TargetFrameworkTransformation(null);
 			transformation.Transform(project, progress);
 
 			Assert.AreEqual(1, project.TargetFrameworks.Count);
 			Assert.AreEqual("net46", project.TargetFrameworks[0]);
 		}
+
 		[TestMethod]
 		public void HandlesOptionTargetFrameworksEmpty()
 		{
-			var project = new Project()
+			var project = new Project
 			{
 				TargetFrameworks = { "net46" }
 			};
-			var targetFrameworks = new List<string>();
 
 			var progress = new Progress<string>(x => { });
 
-			var transformation = new TargetFrameworkTransformation(targetFrameworks);
+			var transformation = new TargetFrameworkTransformation(new List<string>());
 			transformation.Transform(project, progress);
 
 			Assert.AreEqual(1, project.TargetFrameworks.Count);
@@ -76,7 +75,7 @@ namespace Project2015To2017Tests
 		[TestMethod]
 		public void HandlesOptionTargetFrameworks()
 		{
-			var project = new Project()
+			var project = new Project
 			{
 				TargetFrameworks = { "net46" }
 			};
@@ -94,7 +93,7 @@ namespace Project2015To2017Tests
 		[TestMethod]
 		public void HandlesOptionTargetFrameworksMulti()
 		{
-			var project = new Project()
+			var project = new Project
 			{
 				TargetFrameworks = { "net46" }
 			};
@@ -114,26 +113,23 @@ namespace Project2015To2017Tests
 		public void HandlesOptionAppendTargetFrameworkToOutputPathTrue()
 		{
 			var project = new Project();
-			IReadOnlyList<string> targetFrameworks = null;
-			var appendTargetFrameworkToOutputPath = true;
 
 			var progress = new Progress<string>(x => { });
 
-			var transformation = new TargetFrameworkTransformation(targetFrameworks, appendTargetFrameworkToOutputPath);
+			var transformation = new TargetFrameworkTransformation(null, true);
 			transformation.Transform(project, progress);
 
 			Assert.AreEqual(true, project.AppendTargetFrameworkToOutputPath);
 		}
+
 		[TestMethod]
 		public void HandlesOptionAppendTargetFrameworkToOutputPathFalse()
 		{
 			var project = new Project();
-			IReadOnlyList<string> targetFrameworks = null;
-			var appendTargetFrameworkToOutputPath = false;
 
 			var progress = new Progress<string>(x => { });
 
-			var transformation = new TargetFrameworkTransformation(targetFrameworks, appendTargetFrameworkToOutputPath);
+			var transformation = new TargetFrameworkTransformation(null, false);
 			transformation.Transform(project, progress);
 
 			Assert.AreEqual(false, project.AppendTargetFrameworkToOutputPath);

--- a/Project2015To2017Tests/XamlTransformationTest.cs
+++ b/Project2015To2017Tests/XamlTransformationTest.cs
@@ -120,17 +120,17 @@ namespace Project2015To2017Tests
 
 			// App.xaml is NOT included due to ApplicationDefinition
 			// App.xaml.cs is NOT included due to <SubType>Code</SubType> (FileTransformation)
-			// Views\Shell.xaml.cs is included due to DependentUpon
-			// .\..\Views\Initialize.xaml.cs is included due to DependentUpon
+			// Views\Shell.xaml.cs is NOT included due to Compile+DependentUpon
+			// .\..\Views\Initialize.xaml.cs is included due to not in project folder
 			// Views\Shell.xaml is NOT included due to Page
 			// .\..\Views\Initialize.xaml is included due to Page not in project folder
 
-			Assert.AreEqual(3, includeItems.Count);
+			Assert.AreEqual(2, includeItems.Count);
 
 			Assert.AreEqual(1, includeItems.Count(x => x.Name == XmlNamespace + "Page"));
 			Assert.AreEqual(0, includeItems.Count(x => x.Name == XmlNamespace + "ApplicationDefinition"));
-			Assert.AreEqual(2, includeItems.Count(x => x.Name == XmlNamespace + "Compile"));
-			Assert.AreEqual(2,
+			Assert.AreEqual(1, includeItems.Count(x => x.Name == XmlNamespace + "Compile"));
+			Assert.AreEqual(1,
 				includeItems.Count(x => x.Name == XmlNamespace + "Compile" && x.Attribute("Update") != null));
 			Assert.AreEqual(0,
 				includeItems.Count(x => x.Name == XmlNamespace + "Compile" && x.Attribute("Include") != null));
@@ -148,7 +148,7 @@ namespace Project2015To2017Tests
 
 			await File.WriteAllTextAsync(testCsProjFile, xml);
 
-			var project = new ProjectReader().Read(testCsProjFile);
+			var project = new ProjectReader(testCsProjFile).Read();
 
 			return project;
 		}


### PR DESCRIPTION
* Cache loaded projects and condition evaluation states (controlled by switch below)
* Introduce ProjectReader.EnableCaching property that defaults to false (so no surprises in tests, but enabled in Console project)
* Fix Project2015To2017.Console.csproj OutputType
* Store data source XML elements for future changes (to be able later to reference data source precisely)
* Preparation for future PRs (more information to come)
* Nuget -> NuGet
* Use ProjectReference for Solution model (to reduce future code duplication and simplify semantics)
* Add resolved project file path to ProjectReference (to simplify use of ProjectReference in Project creation)
* Refactor solution handling in ProjectConverter.Convert (introduce ConvertSolution method)
* Use the only solution in current directory if present (to match MSBuild behavior)
* Fix indentation according to .editorconfig (tabs instead of spaces, I fixed only files with mixed indent)
* Greatly improve XamlPagesTransformation to account for MSBuild.Sdk.Extras advanced features
* Add Instance fields for SolutionReader and ProjectReader to reduce memory pressure on huge solutions (non-obligatory)

Behavior changes:
* If there is one and only solution in specified directory to convert, use that.
* XamlPagesTransformation now filters more elements

Future work (not this PR):
* Working analysis for common problems in project configuration
* Ability to read (with only FileTransformation enabled) already converted (CPS) projects (no writing of course) to support running analysis again and account for changed line numbers