### PR TITLE
Real Reporter extensibility

### DIFF
--- a/Project2015To2017.Console/Program.cs
+++ b/Project2015To2017.Console/Program.cs
@@ -41,7 +41,7 @@ namespace Project2015To2017.Console
 
 			System.Console.Out.Flush();
 
-			var analyzer = new Analyzer();
+			var analyzer = new Analyzer<ConsoleReporter, ConsoleReporterOptions>(ConsoleReporter.Instance);
 			foreach (var project in convertedProjects)
 			{
 				analyzer.Analyze(project);

--- a/Project2015To2017/Analysis/ConsoleReporter.cs
+++ b/Project2015To2017/Analysis/ConsoleReporter.cs
@@ -1,17 +1,18 @@
 using System;
-using System.IO;
 using System.Text;
 
 namespace Project2015To2017.Analysis
 {
-	public class ConsoleReporter : ReporterBase
+	public sealed class ConsoleReporter : ReporterBase<ConsoleReporterOptions>
 	{
 		public static readonly ConsoleReporter Instance = new ConsoleReporter();
 
+		public override ConsoleReporterOptions DefaultOptions => new ConsoleReporterOptions();
+
 		/// <inheritdoc />
-		protected override void Report(string code, string message, string source = null, uint sourceLine = uint.MaxValue)
+		protected override void Report(IDiagnosticResult result, ConsoleReporterOptions reporterOptions)
 		{
-			var consoleHeader = $"{code}: ";
+			var consoleHeader = $"{result.Code}: ";
 			string linePadding;
 			{
 				var pad = new StringBuilder(consoleHeader.Length, consoleHeader.Length);
@@ -19,15 +20,17 @@ namespace Project2015To2017.Analysis
 				linePadding = pad.ToString();
 			}
 			Console.Write(consoleHeader);
-			message = message.Trim();
+			var message = result.Message.Trim();
 
-			switch (source)
+			var sourcePath = result.Location.GetSourcePath();
+			var sourceLine = result.Location.SourceLine;
+			switch (sourcePath)
 			{
 				case string _ when sourceLine != uint.MaxValue:
-					message = $"{source}:{sourceLine}: {message}";
+					message = $"{sourcePath}:{sourceLine}: {message}";
 					break;
 				case string _ when sourceLine == uint.MaxValue:
-					message = $"{source}: {message}";
+					message = $"{sourcePath}: {message}";
 					break;
 				case null when sourceLine != uint.MaxValue:
 					message = $"{sourceLine}: {message}";

--- a/Project2015To2017/Analysis/ConsoleReporterOptions.cs
+++ b/Project2015To2017/Analysis/ConsoleReporterOptions.cs
@@ -1,0 +1,6 @@
+namespace Project2015To2017.Analysis
+{
+	public sealed class ConsoleReporterOptions : IReporterOptions
+	{
+	}
+}

--- a/Project2015To2017/Analysis/DiagnosticBase.cs
+++ b/Project2015To2017/Analysis/DiagnosticBase.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Xml;
-using System.Xml.Linq;
 using Project2015To2017.Definition;
 
 namespace Project2015To2017.Analysis
@@ -27,20 +25,15 @@ namespace Project2015To2017.Analysis
 		/// <summary>
 		/// Report found issue using user-selected means of logging
 		/// </summary>
+		/// <param name="project">Project in which the issue was found</param>
 		/// <param name="message">Informative message about the issue</param>
-		/// <param name="element">XML element that is the source of the issue</param>
 		/// <param name="source">File or directory for user reference</param>
 		/// <param name="sourceLine">File line for user reference</param>
-		protected DiagnosticResult CreateDiagnosticResult(string message, XElement element = null, FileSystemInfo source = null, uint sourceLine = uint.MaxValue)
+		protected DiagnosticResult CreateDiagnosticResult(Project project, string message, FileSystemInfo source = null, uint sourceLine = uint.MaxValue)
 		{
 			if (source == null && sourceLine != uint.MaxValue)
 			{
 				throw new ArgumentNullException(nameof(source));
-			}
-
-			if (sourceLine == uint.MaxValue && element is IXmlLineInfo elementOnLine && elementOnLine.HasLineInfo())
-			{
-				sourceLine = (uint) elementOnLine.LineNumber;
 			}
 
 			return new DiagnosticResult
@@ -51,7 +44,8 @@ namespace Project2015To2017.Analysis
 				{
 					Source = source,
 					SourceLine = sourceLine
-				}
+				},
+				Project = project
 			};
 		}
 

--- a/Project2015To2017/Analysis/DiagnosticLocation.cs
+++ b/Project2015To2017/Analysis/DiagnosticLocation.cs
@@ -4,7 +4,19 @@ namespace Project2015To2017.Analysis
 {
 	public class DiagnosticLocation : IDiagnosticLocation
 	{
-		public FileSystemInfo Source { get; set; }
 		public uint SourceLine { get; set; }
+		public FileSystemInfo Source { get; set; }
+		public string SourcePath { get; set; }
+
+		public DiagnosticLocation()
+		{
+		}
+
+		public DiagnosticLocation(IDiagnosticLocation location)
+		{
+			SourceLine = location.SourceLine;
+			Source = location.Source;
+			SourcePath = location.SourcePath;
+		}
 	}
 }

--- a/Project2015To2017/Analysis/DiagnosticResult.cs
+++ b/Project2015To2017/Analysis/DiagnosticResult.cs
@@ -1,9 +1,24 @@
+using Project2015To2017.Definition;
+
 namespace Project2015To2017.Analysis
 {
 	public class DiagnosticResult : IDiagnosticResult
 	{
 		public string Code { get; internal set; }
 		public string Message { get; internal set; }
+		public Project Project { get; internal set; }
 		public IDiagnosticLocation Location { get; internal set; }
+
+		public DiagnosticResult()
+		{
+		}
+
+		public DiagnosticResult(IDiagnosticResult result)
+		{
+			Code = result.Code;
+			Message = result.Message;
+			Project = result.Project;
+			Location = result.Location;
+		}
 	}
 }

--- a/Project2015To2017/Analysis/Diagnostics/W001IllegalProjectTypeDiagnostic.cs
+++ b/Project2015To2017/Analysis/Diagnostics/W001IllegalProjectTypeDiagnostic.cs
@@ -21,11 +21,14 @@ namespace Project2015To2017.Analysis.Diagnostics
 			var list = new List<IDiagnosticResult>(TypeGuids.Count + 1);
 			if (project.IsWindowsFormsProject)
 			{
-				list.Add(CreateDiagnosticResult($"Windows Forms support in CPS is in early stages and support might depend on your working environment.", null, project.FilePath));
+				list.Add(CreateDiagnosticResult(project,
+					"Windows Forms support in CPS is in early stages and support might depend on your working environment.",
+					project.FilePath));
 			}
 
 			// try to get project type - may not exist
-			var typeElement = project.ProjectDocument.Descendants(project.XmlNamespace + "ProjectTypeGuids").FirstOrDefault();
+			var typeElement = project.ProjectDocument.Descendants(project.XmlNamespace + "ProjectTypeGuids")
+				.FirstOrDefault();
 			if (typeElement == null)
 			{
 				return Array.Empty<IDiagnosticResult>();
@@ -41,7 +44,11 @@ namespace Project2015To2017.Analysis.Diagnostics
 			{
 				if (!guidTypes.Contains(item.Key)) continue;
 
-				list.Add(CreateDiagnosticResult($"Project type {item.Value} is not tested thoroughly and support might depend on your working environment.", typeElement, project.FilePath));
+				list.Add(
+					CreateDiagnosticResult(project,
+							$"Project type {item.Value} is not tested thoroughly and support might depend on your working environment.",
+							project.FilePath)
+						.LoadLocationFromElement(typeElement));
 			}
 
 			return list;

--- a/Project2015To2017/Analysis/Diagnostics/W010ConfigurationsMismatchDiagnostic.cs
+++ b/Project2015To2017/Analysis/Diagnostics/W010ConfigurationsMismatchDiagnostic.cs
@@ -12,7 +12,8 @@ namespace Project2015To2017.Analysis.Diagnostics
 		/// <inheritdoc />
 		public override IReadOnlyList<IDiagnosticResult> Analyze(Project project)
 		{
-			var propertyGroups = project.ProjectDocument.Element(project.XmlNamespace + "Project").Elements(project.XmlNamespace + "PropertyGroup").ToArray();
+			var propertyGroups = project.ProjectDocument.Element(project.XmlNamespace + "Project")
+				.Elements(project.XmlNamespace + "PropertyGroup").ToArray();
 
 			var configurationSet = new HashSet<string>();
 			var platformSet = new HashSet<string>();
@@ -53,7 +54,11 @@ namespace Project2015To2017.Analysis.Diagnostics
 					{
 						if (!configurationSet.Contains(configuration))
 						{
-							list.Add(CreateDiagnosticResult($"Configuration '{configuration}' is used in project file but not mentioned in $(Configurations).", x, project.FilePath));
+							list.Add(
+								CreateDiagnosticResult(project,
+										$"Configuration '{configuration}' is used in project file but not mentioned in $(Configurations).",
+										project.FilePath)
+									.LoadLocationFromElement(x));
 						}
 					}
 				}
@@ -64,7 +69,11 @@ namespace Project2015To2017.Analysis.Diagnostics
 					{
 						if (!platformSet.Contains(platform))
 						{
-							list.Add(CreateDiagnosticResult($"Platform '{platform}' is used in project file but not mentioned in $(Platforms).", x, project.FilePath));
+							list.Add(
+								CreateDiagnosticResult(project,
+										$"Platform '{platform}' is used in project file but not mentioned in $(Platforms).",
+										project.FilePath)
+									.LoadLocationFromElement(x));
 						}
 					}
 				}
@@ -72,7 +81,8 @@ namespace Project2015To2017.Analysis.Diagnostics
 
 			return list;
 
-			string[] ParseFromProperty(string name) => propertyGroups.Where(x => x.Attribute("Condition") == null).Elements(project.XmlNamespace + name)
+			string[] ParseFromProperty(string name) => propertyGroups.Where(x => x.Attribute("Condition") == null)
+				.Elements(project.XmlNamespace + name)
 				.FirstOrDefault()
 				?.Value
 				.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);

--- a/Project2015To2017/Analysis/Diagnostics/W020MicrosoftCSharpDiagnostic.cs
+++ b/Project2015To2017/Analysis/Diagnostics/W020MicrosoftCSharpDiagnostic.cs
@@ -36,15 +36,21 @@ namespace Project2015To2017.Analysis.Diagnostics
 						continue;
 					}
 
-					list.Add(CreateDiagnosticResult($"'Microsoft.CSharp' assembly is incompatible with TargetFramework '{incompatiblePrefix}', version no less than 4.0 is expected.",
-						reference.DefinitionElement, project.FilePath));
+					list.Add(
+						CreateDiagnosticResult(project,
+								$"'Microsoft.CSharp' assembly is incompatible with TargetFramework '{incompatiblePrefix}', version no less than 4.0 is expected.",
+								project.FilePath)
+							.LoadLocationFromElement(reference.DefinitionElement));
 				}
 			}
 
 			if (!net40Found)
 			{
-				list.Add(CreateDiagnosticResult($"A better way to reference 'Microsoft.CSharp' assembly is using 'Microsoft.CSharp' NuGet package. It will simplify porting to other runtimes.",
-					reference.DefinitionElement, project.FilePath));
+				list.Add(
+					CreateDiagnosticResult(project,
+							"A better way to reference 'Microsoft.CSharp' assembly is using 'Microsoft.CSharp' NuGet package. It will simplify porting to other runtimes.",
+							project.FilePath)
+						.LoadLocationFromElement(reference.DefinitionElement));
 			}
 
 			return list;

--- a/Project2015To2017/Analysis/ExtensionMethods.cs
+++ b/Project2015To2017/Analysis/ExtensionMethods.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.IO;
+using System.Xml;
+using System.Xml.Linq;
 using Project2015To2017.Definition;
 
 namespace Project2015To2017.Analysis
@@ -30,6 +32,37 @@ namespace Project2015To2017.Analysis
 			if (project == null) throw new ArgumentNullException(nameof(project));
 
 			return project.Solution?.FilePath.Directory ?? project.FilePath.Directory;
+		}
+
+		public static string GetSourcePath(this IDiagnosticLocation self)
+		{
+			if (self == null) throw new ArgumentNullException(nameof(self));
+
+			return self.SourcePath ?? self.Source?.FullName;
+		}
+
+		public static IDiagnosticResult LoadLocationFromElement(this IDiagnosticResult self, XElement element)
+		{
+			if (self == null) throw new ArgumentNullException(nameof(self));
+			if (element == null) throw new ArgumentNullException(nameof(element));
+
+			if (self.Location.SourceLine != uint.MaxValue)
+			{
+				return self;
+			}
+
+			if (element is IXmlLineInfo elementOnLine && elementOnLine.HasLineInfo())
+			{
+				return new DiagnosticResult(self)
+				{
+					Location = new DiagnosticLocation(self.Location)
+					{
+						SourceLine = (uint) elementOnLine.LineNumber
+					}
+				};
+			}
+
+			return self;
 		}
 	}
 }

--- a/Project2015To2017/Analysis/IDiagnosticLocation.cs
+++ b/Project2015To2017/Analysis/IDiagnosticLocation.cs
@@ -6,5 +6,6 @@ namespace Project2015To2017.Analysis
 	{
 		FileSystemInfo Source { get; }
 		uint SourceLine { get; }
+		string SourcePath { get; }
 	}
 }

--- a/Project2015To2017/Analysis/IDiagnosticResult.cs
+++ b/Project2015To2017/Analysis/IDiagnosticResult.cs
@@ -1,3 +1,5 @@
+using Project2015To2017.Definition;
+
 namespace Project2015To2017.Analysis
 {
 	public interface IDiagnosticResult
@@ -5,5 +7,6 @@ namespace Project2015To2017.Analysis
 		string Code { get; }
 		IDiagnosticLocation Location { get; }
 		string Message { get; }
+		Project Project { get; }
 	}
 }

--- a/Project2015To2017/Analysis/IReporter.cs
+++ b/Project2015To2017/Analysis/IReporter.cs
@@ -1,14 +1,22 @@
 using System.Collections.Generic;
+using Project2015To2017.Definition;
 
 namespace Project2015To2017.Analysis
 {
-	public interface IReporter
+	public interface IReporter<TOptions> where TOptions : IReporterOptions
 	{
+		/// <summary>
+		/// Default options for any project
+		/// </summary>
+		TOptions DefaultOptions { get; }
+
 		/// <summary>
 		/// Do the actual issue reporting
 		/// </summary>
 		/// <param name="results">Diagnostics to report</param>
 		/// <param name="reporterOptions">Options for the reporter</param>
-		void Report(IReadOnlyList<IDiagnosticResult> results, IReporterOptions reporterOptions);
+		void Report(IReadOnlyList<IDiagnosticResult> results, TOptions reporterOptions);
+
+		TOptions CreateOptionsForProject(Project project);
 	}
 }

--- a/Project2015To2017/Analysis/IReporterOptions.cs
+++ b/Project2015To2017/Analysis/IReporterOptions.cs
@@ -4,6 +4,5 @@ namespace Project2015To2017.Analysis
 {
 	public interface IReporterOptions
 	{
-		DirectoryInfo RootDirectory { get; }
 	}
 }

--- a/Project2015To2017/Analysis/ReporterOptions.cs
+++ b/Project2015To2017/Analysis/ReporterOptions.cs
@@ -1,9 +1,0 @@
-using System.IO;
-
-namespace Project2015To2017.Analysis
-{
-	internal sealed class ReporterOptions : IReporterOptions
-	{
-		public DirectoryInfo RootDirectory { get; set; }
-	}
-}


### PR DESCRIPTION
* Make `IReporter` and `ReporterBase` generic with `IReporterOptions` type generic parameter
* Make `Analyzer` generic with `TReporter` and `TReporterOptions` generic parameters
* `Analyzer` requests `IReporter` to create suitable options for given project
* `ReporterOptions` -> `ConsoleReporterOptions` (each `IReporter` has its own options)
* Add copy constructors to `DiagnosticResult` & `DiagnosticLocation` (no deep cloning)
* Move `DiagnosticLocation` `XElement` line information assignment to extension method
* Add `Project` property to `DiagnosticResult`
* Add `SourcePath` property to `DiagnosticLocation` that stores human-readable relative path
* Add `GetSourcePath` extension method to retrieve `SourcePath` or default value