### PR TITLE
Complete refactoring of IncludeItems

### DIFF
--- a/Project2015To2017/Definition/AssemblyReference.cs
+++ b/Project2015To2017/Definition/AssemblyReference.cs
@@ -3,7 +3,7 @@ using System.Xml.Linq;
 namespace Project2015To2017.Definition
 {
 	// Reference
-	public class AssemblyReference
+	public sealed class AssemblyReference : IOriginatedReference
 	{
 		// Attributes
 		public string Include { get; set; }

--- a/Project2015To2017/Definition/IOriginatedReference.cs
+++ b/Project2015To2017/Definition/IOriginatedReference.cs
@@ -1,0 +1,9 @@
+using System.Xml.Linq;
+
+namespace Project2015To2017.Definition
+{
+	public interface IOriginatedReference
+	{
+		XElement DefinitionElement { get; }
+	}
+}

--- a/Project2015To2017/Definition/PackageReference.cs
+++ b/Project2015To2017/Definition/PackageReference.cs
@@ -1,9 +1,13 @@
+using System.Xml.Linq;
+
 namespace Project2015To2017.Definition
 {
-    public sealed class PackageReference
-    {
-	    public string Id { get; set; }
-        public string Version { get; set; }
-        public bool IsDevelopmentDependency { get; set; }
-    }
+	public sealed class PackageReference : IOriginatedReference
+	{
+		public string Id { get; set; }
+		public string Version { get; set; }
+		public bool IsDevelopmentDependency { get; set; }
+
+		public XElement DefinitionElement { get; set; }
+	}
 }

--- a/Project2015To2017/Definition/Project.cs
+++ b/Project2015To2017/Definition/Project.cs
@@ -15,7 +15,6 @@ namespace Project2015To2017.Definition
 		public IReadOnlyList<AssemblyReference> AssemblyReferences { get; set; }
 		public IReadOnlyList<ProjectReference> ProjectReferences { get; set; }
 		public IReadOnlyList<PackageReference> PackageReferences { get; set; }
-		public IReadOnlyList<XElement> IncludeItems { get; set; }
 		public PackageConfiguration PackageConfiguration { get; set; }
 		public AssemblyAttributes AssemblyAttributes { get; set; }
 		public IReadOnlyList<XElement> AdditionalPropertyGroups { get; set; }
@@ -24,6 +23,7 @@ namespace Project2015To2017.Definition
 		public IReadOnlyList<XElement> BuildEvents { get; set; }
 		public IReadOnlyList<string> Configurations { get; set; }
 		public IReadOnlyList<string> Platforms { get; set; }
+		public IList<XElement> ItemGroups { get; set; }
 
 		public XDocument ProjectDocument { get; set; }
 		public string ProjectName { get; set; }

--- a/Project2015To2017/Definition/ProjectReference.cs
+++ b/Project2015To2017/Definition/ProjectReference.cs
@@ -1,13 +1,15 @@
 using System.IO;
+using System.Xml.Linq;
 
 namespace Project2015To2017.Definition
 {
-	public class ProjectReference
+	public sealed class ProjectReference : IOriginatedReference
 	{
 		public string Include { get; set; }
 		public string Aliases { get; set; }
 		public bool EmbedInteropTypes { get; set; }
 
 		public FileInfo ProjectFile { get; set; }
+		public XElement DefinitionElement { get; set; }
 	}
 }

--- a/Project2015To2017/Reading/AssemblyInfoReader.cs
+++ b/Project2015To2017/Reading/AssemblyInfoReader.cs
@@ -14,8 +14,8 @@ namespace Project2015To2017.Reading
 		{
 			var projectPath = project.ProjectFolder.FullName;
 
-			var compileElements = project.IncludeItems
-										 .SelectMany(x => x.Elements(project.XmlNamespace + "Compile"))
+			var compileElements = project.ItemGroups
+										 .SelectMany(x => x.Descendants(project.XmlNamespace + "Compile"))
 										 .ToList();
 
 			var assemblyInfoFiles = compileElements

--- a/Project2015To2017/Reading/ProjectReader.cs
+++ b/Project2015To2017/Reading/ProjectReader.cs
@@ -81,7 +81,7 @@ namespace Project2015To2017.Reading
 			projectDefinition.ProjectReferences = LoadProjectReferences(projectDefinition);
 			projectDefinition.PackagesConfigFile = FindPackagesConfigFile(projectPath);
 			projectDefinition.PackageReferences = LoadPackageReferences(projectDefinition);
-			projectDefinition.IncludeItems = LoadFileIncludes(projectDefinition);
+			projectDefinition.ItemGroups = LoadFileIncludes(projectDefinition);
 
 			ProcessProjectReferences(projectDefinition);
 
@@ -176,7 +176,8 @@ namespace Project2015To2017.Reading
 					{
 						Id = x.Attribute("Include").Value,
 						Version = x.Attribute("Version")?.Value ?? x.Element(project.XmlNamespace + "Version").Value,
-						IsDevelopmentDependency = x.Element(project.XmlNamespace + "PrivateAssets") != null
+						IsDevelopmentDependency = x.Element(project.XmlNamespace + "PrivateAssets") != null,
+						DefinitionElement = x
 					});
 
 				var packageConfigPackages = ExtractReferencesFromPackagesConfig(packagesConfig);
@@ -235,7 +236,8 @@ namespace Project2015To2017.Reading
 				{
 					Include = x.Attribute("Include").Value,
 					Aliases = x.Element(project.XmlNamespace + "Aliases")?.Value,
-					EmbedInteropTypes = string.Equals(x.Element(project.XmlNamespace + "EmbedInteropTypes")?.Value, "true", StringComparison.OrdinalIgnoreCase)
+					EmbedInteropTypes = string.Equals(x.Element(project.XmlNamespace + "EmbedInteropTypes")?.Value, "true", StringComparison.OrdinalIgnoreCase),
+					DefinitionElement = x
 				})
 				.ToList();
 

--- a/Project2015To2017/Transforms/AssemblyReferenceTransformation.cs
+++ b/Project2015To2017/Transforms/AssemblyReferenceTransformation.cs
@@ -16,13 +16,17 @@ namespace Project2015To2017.Transforms
 								.Select(x => x.Id)
 								.ToList();
 
-			var assemblyReferences =
+			var (assemblyReferences, removeQueue) =
 					definition
 						.AssemblyReferences
 						//We don't need to keep any references to package files as these are
 						//now generated dynamically at build time
-						.Where(assemblyReference => !packageIds.Contains(assemblyReference.Include))
-						.ToList();
+						.Split(assemblyReference => !packageIds.Contains(assemblyReference.Include));
+
+			foreach (var assemblyReference in removeQueue)
+			{
+				assemblyReference.DefinitionElement?.Remove();
+			}
 
 			definition.AssemblyReferences = assemblyReferences;
 		}

--- a/Project2015To2017/Transforms/DefaultAssemblyReferenceRemovalTransformation.cs
+++ b/Project2015To2017/Transforms/DefaultAssemblyReferenceRemovalTransformation.cs
@@ -15,15 +15,22 @@ namespace Project2015To2017.Transforms
 				return;
 			}
 
-			definition.AssemblyReferences = definition.AssemblyReferences
-				.SkipWhile(IsDefaultIncludedAssemblyReference).ToImmutableList();
+			var (assemblyReferences, removeQueue) = definition.AssemblyReferences
+				.Split(IsNonDefaultIncludedAssemblyReference);
+
+			foreach (var assemblyReference in removeQueue)
+			{
+				assemblyReference.DefinitionElement?.Remove();
+			}
+
+			definition.AssemblyReferences = assemblyReferences;
 		}
 
 
-		private static bool IsDefaultIncludedAssemblyReference(AssemblyReference assemblyReference)
+		private static bool IsNonDefaultIncludedAssemblyReference(AssemblyReference assemblyReference)
 		{
 			var name = assemblyReference.Include;
-			return new[]
+			return !new[]
 			{
 				"System",
 				"System.Core",

--- a/Project2015To2017/Transforms/Helpers.cs
+++ b/Project2015To2017/Transforms/Helpers.cs
@@ -19,5 +19,24 @@ namespace Project2015To2017.Transforms
 		{
 			return source.Elements().Where(e => e.Name.LocalName == localName);
 		}
+
+		public static (IReadOnlyList<T> @true, IReadOnlyList<T> @false) Split<T>(this IEnumerable<T> source,
+			Func<T, bool> predicate)
+		{
+			List<T> @true = new List<T>(), @false = new List<T>();
+			foreach (var item in source)
+			{
+				if (predicate(item))
+				{
+					@true.Add(item);
+				}
+				else
+				{
+					@false.Add(item);
+				}
+			}
+
+			return (@true, @false);
+		}
 	}
 }

--- a/Project2015To2017/Transforms/PackageReferenceTransformation.cs
+++ b/Project2015To2017/Transforms/PackageReferenceTransformation.cs
@@ -10,33 +10,33 @@ namespace Project2015To2017.Transforms
 		{
 			var existingPackageReferences = definition.PackageReferences;
 
-			var testReferences = Array.Empty<PackageReference>();
-			if (definition.Type == ApplicationType.TestProject && existingPackageReferences.All(x => x.Id != "Microsoft.NET.Test.Sdk"))
+			if (definition.Type != ApplicationType.TestProject ||
+			    existingPackageReferences.Any(x => x.Id == "Microsoft.NET.Test.Sdk")) return;
+
+			var testReferences = new[]
 			{
-				testReferences = new[]
-				{
-						new PackageReference{Id = "Microsoft.NET.Test.Sdk", Version = "15.0.0"},
-						new PackageReference{Id = "MSTest.TestAdapter", Version = "1.1.11"},
-						new PackageReference{Id = "MSTest.TestFramework", Version = "1.1.11"}
-					};
+				new PackageReference {Id = "Microsoft.NET.Test.Sdk", Version = "15.0.0"},
+				new PackageReference {Id = "MSTest.TestAdapter", Version = "1.1.11"},
+				new PackageReference {Id = "MSTest.TestFramework", Version = "1.1.11"}
+			};
 
-				var versions = definition.TargetFrameworks?
-					.Select(f => int.TryParse(f.Replace("net", string.Empty), out int result) ? result : default(int?))
-					.Where(x => x.HasValue)
-					.Select(v => v < 100 ? v * 10 : v);
+			var versions = definition.TargetFrameworks?
+				.Select(f => int.TryParse(f.Replace("net", string.Empty), out int result) ? result : default(int?))
+				.Where(x => x.HasValue)
+				.Select(v => v < 100 ? v * 10 : v);
 
-				if (versions != null)
+			if (versions != null)
+			{
+				if (versions.Any(v => v < 450))
 				{
-					if (versions.Any(v => v < 450))
-					{
-						progress.Report($"Warning - target framework net40 is not compatible with the MSTest NuGet packages. Please consider updating the target framework of your test project(s)");
-					}
+					progress.Report(
+						$"Warning - target framework net40 is not compatible with the MSTest NuGet packages. Please consider updating the target framework of your test project(s)");
 				}
 			}
 
 			var adjustedPackageReferences = existingPackageReferences
-												.Concat(testReferences)
-												.ToArray();
+				.Concat(testReferences)
+				.ToArray();
 
 			foreach (var reference in testReferences)
 			{

--- a/Project2015To2017/Transforms/RemovePackageAssemblyReferencesTransformation.cs
+++ b/Project2015To2017/Transforms/RemovePackageAssemblyReferencesTransformation.cs
@@ -23,12 +23,16 @@ namespace Project2015To2017.Transforms
 			var packagePaths = packageReferenceIds.Select(packageId => Path.Combine(nugetRepositoryPath, packageId).ToLower())
 				.ToArray();
 
-			var filteredAssemblies = definition.AssemblyReferences
-				.Where(assembly => !packagePaths.Any(
+			var (filteredAssemblies, removeQueue) = definition.AssemblyReferences
+				.Split(assembly => !packagePaths.Any(
 						packagePath => AssemblyMatchesPackage(assembly, packagePath)
 					)
-				)
-				.ToList();
+				);
+
+			foreach (var assemblyReference in removeQueue)
+			{
+				assemblyReference.DefinitionElement?.Remove();
+			}
 
 			definition.AssemblyReferences = filteredAssemblies;
 

--- a/Project2015To2017Tests/FileTransformationTest.cs
+++ b/Project2015To2017Tests/FileTransformationTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
 using System.Linq;
@@ -17,86 +18,79 @@ namespace Project2015To2017Tests
             var project = new ProjectReader(Path.Combine("TestFiles", "FileInclusion", "fileinclusion.testcsproj")).Read();
             var transformation = new FileTransformation();
 
-	        var logEntries = new List<string>();
-
-	        var progress = new Progress<string>(x => { logEntries.Add(x); });
+	        var progress = new Progress<string>();
 
             transformation.Transform(project, progress);
 
-	        var includeItems = project.IncludeItems;
+	        var includeItems = project.ItemGroups.SelectMany(x => x.Elements()).ToImmutableList();
 
-	        Assert.AreEqual(13, includeItems.Count);
+	        Assert.AreEqual(29, includeItems.Count);
 
-            Assert.AreEqual(9, includeItems.Count(x => x.Name == project.XmlNamespace + "Compile"));
-			Assert.AreEqual(6, includeItems.Count(x => x.Name == project.XmlNamespace + "Compile" && x.Attribute("Update") != null));
-			Assert.AreEqual(1, includeItems.Count(x => x.Name == project.XmlNamespace + "Compile" && x.Attribute("Include") != null));
-			Assert.AreEqual(2, includeItems.Count(x => x.Name == project.XmlNamespace + "Compile" && x.Attribute("Remove") != null));
-			Assert.AreEqual(2, includeItems.Count(x => x.Name == project.XmlNamespace + "EmbeddedResource")); // #73 inlcude things that are not ending in .resx
-            Assert.AreEqual(0, includeItems.Count(x => x.Name == project.XmlNamespace + "Content"));
-            Assert.AreEqual(2, includeItems.Count(x => x.Name == project.XmlNamespace + "None"));
+            Assert.AreEqual(12, includeItems.Count(x => x.Name.LocalName == "Reference"));
+            Assert.AreEqual(2, includeItems.Count(x => x.Name.LocalName == "ProjectReference"));
+            Assert.AreEqual(11, includeItems.Count(x => x.Name.LocalName == "Compile"));
+			Assert.AreEqual(6, includeItems.Count(x => x.Name.LocalName == "Compile" && x.Attribute("Update") != null));
+			Assert.AreEqual(3, includeItems.Count(x => x.Name.LocalName == "Compile" && x.Attribute("Include") != null));
+			Assert.AreEqual(2, includeItems.Count(x => x.Name.LocalName == "Compile" && x.Attribute("Remove") != null));
+			Assert.AreEqual(2, includeItems.Count(x => x.Name.LocalName == "EmbeddedResource")); // #73 inlcude things that are not ending in .resx
+            Assert.AreEqual(0, includeItems.Count(x => x.Name.LocalName == "Content"));
+            Assert.AreEqual(2, includeItems.Count(x => x.Name.LocalName == "None"));
+            Assert.AreEqual(0, includeItems.Count(x => x.Name.LocalName == "Analyzer"));
 
 	        var resourceDesigner = includeItems.Single(
-								        x => x.Name == project.XmlNamespace + "Compile"
-								             && x.Attribute("Update")?.Value == @"Properties\Resources.Designer.cs"
-							        );
+		        x => x.Name.LocalName == "Compile"
+		             && x.Attribute("Update")?.Value == @"Properties\Resources.Designer.cs"
+	        );
 
 			Assert.AreEqual(3, resourceDesigner.Elements().Count());
-	        var dependentUponElement = resourceDesigner.Elements().Single(x=> x.Name == project.XmlNamespace + "DependentUpon");
-			
+	        var dependentUponElement = resourceDesigner.Elements().Single(x => x.Name.LocalName == "DependentUpon");
+
 			Assert.AreEqual("Resources.resx", dependentUponElement.Value);
 
-			var linkedFile = includeItems.Single(
-										x => x.Name == project.XmlNamespace + "Compile"
-											 && x.Attribute("Include")?.Value == @"..\OtherTestProjects\OtherTestClass.cs"
-									);
-			var linkAttribute = linkedFile.Attributes().FirstOrDefault(a => a.Name == "Link");
+	        var linkedFile = includeItems.Single(
+		        x => x.Name.LocalName == "Compile"
+		             && x.Attribute("Include")?.Value == @"..\OtherTestProjects\OtherTestClass.cs"
+	        );
+			var linkAttribute = linkedFile.Attributes().FirstOrDefault(a => a.Name.LocalName == "Link");
 			Assert.IsNotNull(linkAttribute);
 			Assert.AreEqual("OtherTestClass.cs", linkAttribute.Value);
 
-			var sourceWithDesigner = includeItems.Single(
-								        x => x.Name == project.XmlNamespace + "Compile"
-								             && x.Attribute("Update")?.Value == @"SourceFileWithDesigner.cs"
-							        );
+	        var sourceWithDesigner = includeItems.Single(
+		        x => x.Name.LocalName == "Compile"
+		             && x.Attribute("Update")?.Value == @"SourceFileWithDesigner.cs"
+	        );
 
 			var subTypeElement = sourceWithDesigner.Elements().Single();
-	        Assert.AreEqual(project.XmlNamespace + "SubType", subTypeElement.Name);
+	        Assert.AreEqual("SubType", subTypeElement.Name.LocalName);
 	        Assert.AreEqual("Component", subTypeElement.Value);
 
 	        var designerForSource = includeItems.Single(
-								        x => x.Name == project.XmlNamespace + "Compile"
-								             && x.Attribute("Update")?.Value == @"SourceFileWithDesigner.Designer.cs"
-							        );
+		        x => x.Name.LocalName == "Compile"
+		             && x.Attribute("Update")?.Value == @"SourceFileWithDesigner.Designer.cs"
+	        );
 
 	        var dependentUponElement2 = designerForSource.Elements().Single();
 
-	        Assert.AreEqual(project.XmlNamespace + "DependentUpon", dependentUponElement2.Name);
+	        Assert.AreEqual("DependentUpon", dependentUponElement2.Name.LocalName);
 	        Assert.AreEqual("SourceFileWithDesigner.cs", dependentUponElement2.Value);
 
 	        var fileWithAnotherAttribute = includeItems.Single(
-												x => x.Name == project.XmlNamespace + "Compile"
-													&& x.Attribute("Update")?.Value == @"AnotherFile.cs"
-									        );
+		        x => x.Name.LocalName == "Compile"
+		             && x.Attribute("Update")?.Value == @"AnotherFile.cs"
+	        );
 
 			Assert.AreEqual(2, fileWithAnotherAttribute.Attributes().Count());
 			Assert.AreEqual("AttrValue", fileWithAnotherAttribute.Attribute("AnotherAttribute")?.Value);
 
-			var removeMatchingWildcard = includeItems.Where(
-											x => x.Name == project.XmlNamespace + "Compile"
-												&& x.Attribute("Remove")?.Value != null
-										);
+	        var removeMatchingWildcard = includeItems.Where(
+			        x => x.Name.LocalName == "Compile"
+			             && x.Attribute("Remove")?.Value != null
+		        )
+		        .ToImmutableList();
 			Assert.IsNotNull(removeMatchingWildcard);
-			Assert.AreEqual(2, removeMatchingWildcard.Count());
+			Assert.AreEqual(2, removeMatchingWildcard.Count);
 			Assert.IsTrue(removeMatchingWildcard.Any(x => x.Attribute("Remove")?.Value == "SourceFileAsResource.cs"));
 			Assert.IsTrue(removeMatchingWildcard.Any(x => x.Attribute("Remove")?.Value == "Class1.cs"));
-
-			//<Compile Include="AnotherFile.cs" AnotherAttribute="AttrValue" />
-			var warningLogEntries = logEntries
-								        .Where(x => x.StartsWith("File found") || x.StartsWith("File was included"))
-								        //todo: would be good to be able to remove this condition and not warn on wildcard inclusions
-										//that are covered by main wildcard
-								        .Where(x => !x.ToUpper().Contains("WILDCARD"));
-
-			Assert.IsFalse(warningLogEntries.Any());
         }
     }
 }

--- a/Project2015To2017Tests/XamlTransformationTest.cs
+++ b/Project2015To2017Tests/XamlTransformationTest.cs
@@ -90,34 +90,28 @@ namespace Project2015To2017Tests
 
 			Assert.AreEqual(3, project.AdditionalPropertyGroups.Count);
 
-			var fileTransformation = new FileTransformation();
 			var transformation = new XamlPagesTransformation();
 
 			var progress = new Progress<string>();
 
-			fileTransformation.Transform(project, progress);
 			transformation.Transform(project, progress);
 
-			var includeItems = project.IncludeItems;
+			var includeItems = project.ItemGroups.SelectMany(x => x.Elements()).ToImmutableList();
 
 			// App.xaml is NOT included due to ApplicationDefinition
-			// App.xaml.cs is NOT included due to <SubType>Code</SubType> (FileTransformation)
-			// Views\Shell.xaml.cs is NOT included due to Compile+DependentUpon
-			// .\..\Views\Initialize.xaml.cs is included due to not in project folder
+			// App.xaml.cs is NOT included (.xaml.cs in project folder, verified children)
+			// Views\Shell.xaml.cs is NOT included (.xaml.cs in project folder, verified children)
+			// .\..\Views\Initialize.xaml.cs is included (not in project folder)
 			// Views\Shell.xaml is NOT included due to Page
-			// .\..\Views\Initialize.xaml is included due to Page not in project folder
+			// .\..\Views\Initialize.xaml is included (not in project folder)
 
-			Assert.AreEqual(2, includeItems.Count);
+			Assert.AreEqual(7, includeItems.Count);
 
+			Assert.AreEqual(5, includeItems.Count(x => x.Name == project.XmlNamespace + "Reference"));
 			Assert.AreEqual(1, includeItems.Count(x => x.Name == project.XmlNamespace + "Page"));
 			Assert.AreEqual(0, includeItems.Count(x => x.Name == project.XmlNamespace + "ApplicationDefinition"));
 			Assert.AreEqual(1, includeItems.Count(x => x.Name == project.XmlNamespace + "Compile"));
-			Assert.AreEqual(1,
-				includeItems.Count(x => x.Name == project.XmlNamespace + "Compile" && x.Attribute("Update") != null));
-			Assert.AreEqual(0,
-				includeItems.Count(x => x.Name == project.XmlNamespace + "Compile" && x.Attribute("Include") != null));
-			Assert.AreEqual(0,
-				includeItems.Count(x => x.Name == project.XmlNamespace + "Compile" && x.Attribute("Remove") != null));
+			Assert.AreEqual(1, includeItems.Count(x => x.Name == project.XmlNamespace + "Compile" && x.Attribute("Include") != null));
 		}
 
 		private static async Task<Project> ParseAndTransform(


### PR DESCRIPTION
* Rename `IncludeItems` to `ItemGroups`
* Add `IOriginatedReference` for locating the origin of the reference in XML document
* `AssemblyReference`, `PackageReference` and `ProjectReference` implement `IOriginatedReference`
* Seal more classes in `Project2015To2017.Definition` namespace
* Adapt all code to the changes above
* Update `SdkExtrasVersion` to `MSBuild.Sdk.Extras/1.6.46`
* Preserve original XML elements location as much as possible in `ProjectWriter`
* Huge refactoring of `FileTransformation`, preserve original structure as much as possible
* Reduce `FileTransformation` noise in the output log
* Adapt tests to the changes

Fixes #151.