### PR TITLE
Refactoring of PropertyGroups and bugfixes

### DIFF
--- a/Project2015To2017.Console/Program.cs
+++ b/Project2015To2017.Console/Program.cs
@@ -49,13 +49,6 @@ namespace Project2015To2017.Console
 			var writer = new Writing.ProjectWriter(logger, x => x.Delete(), _ => { });
 			foreach (var project in convertedProjects)
 			{
-				if (project.IsModernProject)
-				{
-					logger.LogInformation($"Skipping CPS project '{project.FilePath.Name}'...");
-
-					continue;
-				}
-
 				writer.Write(project, doBackup);
 			}
 
@@ -63,10 +56,7 @@ namespace Project2015To2017.Console
 
 			logger.LogInformation("### Performing 2nd pass to analyze converted projects...");
 
-			if (conversionOptions.ProjectCache != null)
-			{
-				conversionOptions.ProjectCache.Purge();
-			}
+			conversionOptions.ProjectCache?.Purge();
 
 			convertedProjects.Clear();
 

--- a/Project2015To2017/Definition/Project.cs
+++ b/Project2015To2017/Definition/Project.cs
@@ -24,6 +24,7 @@ namespace Project2015To2017.Definition
 		public IReadOnlyList<string> Configurations { get; set; }
 		public IReadOnlyList<string> Platforms { get; set; }
 		public IList<XElement> ItemGroups { get; set; }
+		public XElement PrimaryPropertyGroup { get; set; }
 
 		public XDocument ProjectDocument { get; set; }
 		public string ProjectName { get; set; }

--- a/Project2015To2017/ProjectConverter.cs
+++ b/Project2015To2017/ProjectConverter.cs
@@ -18,17 +18,8 @@ namespace Project2015To2017
 		private readonly ConversionOptions conversionOptions;
 		private readonly ProjectReader projectReader;
 
-		private static IReadOnlyCollection<ITransformation> TransformationsToApply(ConversionOptions conversionOptions,
-			Project project)
+		private static IReadOnlyCollection<ITransformation> TransformationsToApply(ConversionOptions conversionOptions)
 		{
-			if (project.IsModernProject)
-			{
-				return new ITransformation[]
-				{
-					new FileTransformation(),
-				};
-			}
-
 			return new ITransformation[]
 			{
 				new TargetFrameworkTransformation(
@@ -44,7 +35,8 @@ namespace Project2015To2017
 				new FileTransformation(),
 				new NugetPackageTransformation(),
 				new AssemblyAttributeTransformation(conversionOptions.KeepAssemblyInfo),
-				new XamlPagesTransformation()
+				new XamlPagesTransformation(),
+				new PrimaryUnconditionalPropertyTransformation(),
 			};
 		}
 
@@ -110,7 +102,7 @@ namespace Project2015To2017
 			}
 
 			this.logger.LogInformation(string.Join(Environment.NewLine, projectFiles));
-			
+
 			foreach (var projectFile in projectFiles)
 			{
 				// todo: rewrite both directory enumerations to use FileInfo instead of raw strings
@@ -162,7 +154,7 @@ namespace Project2015To2017
 				transform.Transform(project, this.logger);
 			}
 
-			foreach (var transform in TransformationsToApply(this.conversionOptions, project))
+			foreach (var transform in TransformationsToApply(this.conversionOptions))
 			{
 				transform.Transform(project, this.logger);
 			}

--- a/Project2015To2017/Transforms/Helpers.cs
+++ b/Project2015To2017/Transforms/Helpers.cs
@@ -38,5 +38,37 @@ namespace Project2015To2017.Transforms
 
 			return (@true, @false);
 		}
+
+		public static bool ValidateChildren(IEnumerable<XElement> value, params string[] expected)
+		{
+			var defines = value.Select(x => x.Name.LocalName);
+			return ValidateSet(defines, expected);
+		}
+
+		public static bool ValidateSet(IEnumerable<string> items, IEnumerable<string> expected)
+		{
+			var set = new HashSet<string>(items);
+			foreach (var expecto in expected)
+			{
+				if (!set.Remove(expecto))
+				{
+					return false;
+				}
+			}
+
+			return set.Count == 0;
+		}
+
+		public static XElement RemoveAllNamespaces(XElement e)
+		{
+			return new XElement(e.Name.LocalName,
+				(from n in e.Nodes()
+					select ((n is XElement) ? RemoveAllNamespaces((XElement) n) : n)),
+				(e.HasAttributes)
+					? (from a in e.Attributes()
+						where (!a.IsNamespaceDeclaration)
+						select new XAttribute(a.Name.LocalName, a.Value))
+					: null);
+		}
 	}
 }

--- a/Project2015To2017/Transforms/PrimaryUnconditionalPropertyTransformation.cs
+++ b/Project2015To2017/Transforms/PrimaryUnconditionalPropertyTransformation.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.Extensions.Logging;
+using Project2015To2017.Definition;
+
+namespace Project2015To2017.Transforms
+{
+	public class PrimaryUnconditionalPropertyTransformation : ITransformation
+	{
+		public void Transform(Project project, ILogger logger)
+		{
+			var propertyGroup = project.PrimaryPropertyGroup;
+
+			AddTargetFrameworks(propertyGroup, project.TargetFrameworks);
+
+			var configurations = project.Configurations ?? Array.Empty<string>();
+			if (configurations.Count != 0)
+				// ignore default "Debug;Release" configuration set
+				if (configurations.Count != 2 || !configurations.Contains("Debug") ||
+				    !configurations.Contains("Release"))
+					AddIfNotNull(propertyGroup, "Configurations", string.Join(";", configurations));
+
+			var platforms = project.Platforms ?? Array.Empty<string>();
+			if (platforms.Count != 0)
+				// ignore default "AnyCPU" platform set
+				if (platforms.Count != 1 || !platforms.Contains("AnyCPU"))
+					AddIfNotNull(propertyGroup, "Platforms", string.Join(";", platforms));
+
+			var outputProjectName = Path.GetFileNameWithoutExtension(project.FilePath.Name);
+
+			AddIfNotNull(propertyGroup, "RootNamespace",
+				project.RootNamespace != outputProjectName ? project.RootNamespace : null);
+			AddIfNotNull(propertyGroup, "AssemblyName",
+				project.AssemblyName != outputProjectName ? project.AssemblyName : null);
+			AddIfNotNull(propertyGroup, "AppendTargetFrameworkToOutputPath",
+				project.AppendTargetFrameworkToOutputPath ? null : "false");
+
+			AddIfNotNull(propertyGroup, "ExtrasEnableWpfProjectSetup",
+				project.IsWindowsPresentationFoundationProject ? "true" : null);
+			AddIfNotNull(propertyGroup, "ExtrasEnableWinFormsProjectSetup",
+				project.IsWindowsFormsProject ? "true" : null);
+
+			string outputType;
+			switch (project.Type)
+			{
+				case ApplicationType.ConsoleApplication:
+					outputType = "Exe";
+					break;
+				case ApplicationType.WindowsApplication:
+					outputType = "WinExe";
+					break;
+				default:
+					outputType = null;
+					break;
+			}
+			AddIfNotNull(propertyGroup, "OutputType", outputType);
+
+			propertyGroup.Add(project.AssemblyAttributeProperties);
+
+			AddPackageNodes(propertyGroup, project.PackageConfiguration);
+
+			if (project.BuildEvents != null && project.BuildEvents.Any())
+			{
+				foreach (var buildEvent in project.BuildEvents.Select(Helpers.RemoveAllNamespaces))
+				{
+					propertyGroup.Add(buildEvent);
+				}
+			}
+		}
+
+		private void AddPackageNodes(XElement mainPropertyGroup, PackageConfiguration packageConfiguration)
+		{
+			if (packageConfiguration == null)
+			{
+				return;
+			}
+
+			//Add those properties not already covered by the project properties
+
+			AddIfNotNull(mainPropertyGroup, "Authors", packageConfiguration.Authors);
+			AddIfNotNull(mainPropertyGroup, "PackageIconUrl", packageConfiguration.IconUrl);
+			AddIfNotNull(mainPropertyGroup, "PackageId", packageConfiguration.Id);
+			AddIfNotNull(mainPropertyGroup, "PackageLicenseUrl", packageConfiguration.LicenseUrl);
+			AddIfNotNull(mainPropertyGroup, "PackageProjectUrl", packageConfiguration.ProjectUrl);
+			AddIfNotNull(mainPropertyGroup, "PackageReleaseNotes", packageConfiguration.ReleaseNotes);
+			AddIfNotNull(mainPropertyGroup, "PackageTags", packageConfiguration.Tags);
+
+			if (packageConfiguration.Id != null && packageConfiguration.Tags == null)
+				mainPropertyGroup.Add(new XElement("PackageTags", "Library"));
+
+			if (packageConfiguration.RequiresLicenseAcceptance)
+			{
+				mainPropertyGroup.Add(new XElement("PackageRequireLicenseAcceptance", "true"));
+			}
+		}
+
+		private static void AddIfNotNull(XElement node, string elementName, string value)
+		{
+			XElement newElement = null;
+			if (!string.IsNullOrWhiteSpace(value))
+			{
+				newElement = new XElement(elementName, value);
+			}
+
+			ReplaceAnyWith(newElement, node, elementName);
+		}
+
+		private void AddTargetFrameworks(XElement mainPropertyGroup, IList<string> targetFrameworks)
+		{
+			if (targetFrameworks == null || targetFrameworks.Count == 0)
+			{
+				return;
+			}
+
+			var newElement = targetFrameworks.Count > 1
+				? new XElement("TargetFrameworks", string.Join(";", targetFrameworks))
+				: new XElement("TargetFramework", targetFrameworks[0]);
+
+			ReplaceAnyWith(newElement, mainPropertyGroup,
+				"TargetFrameworks", "TargetFramework", "TargetFrameworkVersion");
+		}
+
+		private static (XElement, IReadOnlyCollection<XElement>) FindExistingElements(XElement node,
+			params string[] names)
+		{
+			XElement bestMatch = null;
+			var other = new List<XElement>();
+
+			foreach (var name in names)
+			{
+				foreach (var child in node.ElementsAnyNamespace(name))
+				{
+					if (bestMatch == null)
+					{
+						bestMatch = child;
+						continue;
+					}
+
+					other.Add(child);
+				}
+			}
+
+			return (bestMatch, other);
+		}
+
+		private static void ReplaceAnyWith(XElement newElement, XElement parent, params string[] names)
+		{
+			var (existingElement, others) = FindExistingElements(parent, names);
+
+			if (newElement != null)
+			{
+				if (existingElement == null)
+				{
+					parent.Add(newElement);
+				}
+				else
+				{
+					existingElement.ReplaceWith(newElement);
+				}
+			}
+			else
+			{
+				existingElement?.Remove();
+			}
+
+			foreach (var child in others)
+			{
+				child.Remove();
+			}
+		}
+	}
+}

--- a/Project2015To2017/Transforms/PropertySimplificationTransformation.cs
+++ b/Project2015To2017/Transforms/PropertySimplificationTransformation.cs
@@ -14,189 +14,185 @@ namespace Project2015To2017.Transforms
 	{
 		public void Transform(Project definition, ILogger logger)
 		{
-			FilterUnneededProperties(definition, definition.AdditionalPropertyGroups);
-		}
+			if (definition.PrimaryPropertyGroup == null)
+			{
+				throw new InvalidOperationException("Unable to do property simplification pass due to lack of primary PropertyGroup.");
+			}
 
-		private static void FilterUnneededProperties(Project project,
-			IReadOnlyCollection<XElement> additionalPropertyGroups)
-		{
 			// special case handling for when condition-guarded props override global props not set to their defaults
-			var globalOverrides = RetrieveGlobalOverrides(additionalPropertyGroups);
+			var globalOverrides = RetrieveGlobalOverrides(definition.PrimaryPropertyGroup);
 
-			if (string.IsNullOrEmpty(project.ProjectName))
+			if (string.IsNullOrEmpty(definition.ProjectName))
 			{
 				if (!globalOverrides.TryGetValue("ProjectName", out var projectName))
 					if (!globalOverrides.TryGetValue("AssemblyName", out projectName))
-						projectName = Path.GetFileNameWithoutExtension(project.FilePath.Name);
-				project.ProjectName = projectName;
+						projectName = Path.GetFileNameWithoutExtension(definition.FilePath.Name);
+				definition.ProjectName = projectName;
 			}
 
+			FilterUnneededProperties(definition, definition.PrimaryPropertyGroup, globalOverrides);
+			foreach (var propertyGroup in definition.AdditionalPropertyGroups)
+			{
+				FilterUnneededProperties(definition, propertyGroup, globalOverrides);
+			}
+		}
+
+		private static void FilterUnneededProperties(Project project,
+			XElement propertyGroup,
+			IDictionary<string, string> globalOverrides)
+		{
 			var removeQueue = new List<XElement>();
 
-			foreach (var propertyGroup in additionalPropertyGroups)
+			foreach (var child in propertyGroup.Elements())
 			{
-				foreach (var child in propertyGroup.Elements())
+				var parentCondition = propertyGroup.Attribute("Condition")?.Value.Trim() ?? "";
+				var hasParentCondition = parentCondition.Length > 1; // no sane condition is 1 char long
+				var parentConditionEvaluated =
+					ConditionEvaluator.GetNonAmbiguousConditionContracts(parentCondition);
+				var parentConditionHasPlatform =
+					parentConditionEvaluated.TryGetValue("Platform", out var parentConditionPlatform);
+				var parentConditionHasConfiguration =
+					parentConditionEvaluated.TryGetValue("Configuration", out var parentConditionConfiguration);
+				var parentConditionPlatformLower = parentConditionPlatform?.ToLowerInvariant();
+				var parentConditionConfigurationLower = parentConditionConfiguration?.ToLowerInvariant();
+				var isDebugOnly = parentConditionHasConfiguration && parentConditionConfigurationLower == "debug";
+				var isReleaseOnly = parentConditionHasConfiguration &&
+				                    parentConditionConfigurationLower == "release";
+
+				var tagLocalName = child.Name.LocalName;
+				var valueLower = child.Value.ToLowerInvariant();
+				var valueLowerTrim = valueLower.Trim();
+				var emptyValue = valueLowerTrim.Length == 0;
+				var hasGlobalOverride = globalOverrides.TryGetValue(tagLocalName, out var globalOverride);
+				var globalOverrideLower = globalOverride?.ToLowerInvariant();
+
+				// Regex is the easiest way to replace string between two unknown chars preserving both as is
+				// so that bin\Debug\net472 is turned into bin\$(Configuration)\net472
+				// and bin/Debug\net472 is turned into bin/$(Configuration)\net472, preserving path separators
+				var configurationPathRegex = parentConditionHasConfiguration
+					? new Regex($@"([\\/]){parentConditionConfiguration}([\\/])")
+					: null;
+				var platformPathRegex = parentConditionHasPlatform
+					? new Regex($@"([\\/]){parentConditionPlatform}([\\/])")
+					: null;
+
+				var childCondition = child.Attribute("Condition");
+				switch (tagLocalName)
 				{
-					var parentCondition = propertyGroup.Attribute("Condition")?.Value.Trim() ?? "";
-					var hasParentCondition = parentCondition.Length > 1; // no sane condition is 1 char long
-					var parentConditionEvaluated =
-						ConditionEvaluator.GetNonAmbiguousConditionContracts(parentCondition);
-					var parentConditionHasPlatform =
-						parentConditionEvaluated.TryGetValue("Platform", out var parentConditionPlatform);
-					var parentConditionHasConfiguration =
-						parentConditionEvaluated.TryGetValue("Configuration", out var parentConditionConfiguration);
-					var parentConditionPlatformLower = parentConditionPlatform?.ToLowerInvariant();
-					var parentConditionConfigurationLower = parentConditionConfiguration?.ToLowerInvariant();
-					var isDebugOnly = parentConditionHasConfiguration && parentConditionConfigurationLower == "debug";
-					var isReleaseOnly = parentConditionHasConfiguration &&
-					                    parentConditionConfigurationLower == "release";
+					// VS2013 NuGet bugs workaround
+					case "NuGetPackageImportStamp":
+					// used by Project2015To2017 and not needed anymore
+					case "OutputType" when !hasParentCondition:
+					case "Platforms" when !hasParentCondition:
+					case "Configurations" when !hasParentCondition:
+					case "TargetFrameworkVersion" when !hasParentCondition:
+					case "TargetFrameworkIdentifier" when !hasParentCondition:
+					case "TargetFrameworkProfile" when !hasParentCondition && emptyValue:
+					// VCS properties
+					case "SccProjectName" when !hasParentCondition && emptyValue:
+					case "SccLocalPath" when !hasParentCondition && emptyValue:
+					case "SccAuxPath" when !hasParentCondition && emptyValue:
+					case "SccProvider" when !hasParentCondition && emptyValue:
+					// Project properties set to defaults (Microsoft.NET.Sdk)
+					case "OutputType" when ValidateDefaultValue("Library"):
+					case "FileAlignment" when ValidateDefaultValue("512"):
+					case "ErrorReport" when ValidateDefaultValue("prompt"):
+					case "Deterministic" when ValidateDefaultValue("true"):
+					case "WarningLevel" when ValidateDefaultValue("4"):
+					case "DebugType" when ValidateDefaultValue("portable"):
+					case "ResolveNuGetPackages" when ValidateDefaultValue("false"):
+					case "SkipImportNuGetProps" when ValidateDefaultValue("true"):
+					case "SkipImportNuGetBuildTargets" when ValidateDefaultValue("true"):
+					case "RestoreProjectStyle" when ValidateDefaultValue("packagereference"):
+					case "AllowUnsafeBlocks" when ValidateDefaultValue("false"):
+					case "TreatWarningsAsErrors" when ValidateDefaultValue("false"):
+					case "Prefer32Bit" when ValidateDefaultValue("false"):
+					case "SignAssembly" when ValidateDefaultValue("false"):
+					case "DelaySign" when ValidateDefaultValue("false"):
+					case "GeneratePackageOnBuild" when ValidateDefaultValue("false"):
+					case "PackageRequireLicenseAcceptance" when ValidateDefaultValue("false"):
+					case "DebugSymbols" when ValidateDefaultValue("false"):
+					case "CheckForOverflowUnderflow" when ValidateDefaultValue("false"):
+					case "AppendTargetFrameworkToOutputPath" when ValidateDefaultValue("true"):
+					case "AppDesignerFolder" when ValidateDefaultValue("properties"):
+					case "DefaultProjectTypeGuid"
+						when ValidateDefaultValue("{fae04ec0-301f-11d3-bf4b-00c04f79efbc}"):
+					case "DefaultLanguageSourceExtension" when ValidateDefaultValue(".cs"):
+					case "Language" when ValidateDefaultValue("C#"):
+					case "TargetRuntime" when ValidateDefaultValue("managed"):
+					case "Utf8Output" when ValidateDefaultValue("true"):
+					case "PlatformName" when ValidateDefaultValue("$(platform)")
+					                         || (parentConditionHasPlatform &&
+					                             ValidateDefaultValue(parentConditionPlatformLower)):
+					// Conditional platform default values
+					case "PlatformTarget" when parentConditionHasPlatform && child.Value == parentConditionPlatform
+					                                                      && !hasGlobalOverride:
+					// Conditional configuration (Debug/Release) default values
+					case "DefineConstants"
+						when isDebugOnly && ValidateDefaultConstants(valueLower, "debug", "trace") &&
+						     !hasGlobalOverride:
+					case "DefineConstants" when isReleaseOnly && ValidateDefaultConstants(valueLower, "trace") &&
+					                            !hasGlobalOverride:
+					case "Optimize" when isDebugOnly && valueLower == "false" && !hasGlobalOverride:
+					case "Optimize" when isReleaseOnly && valueLower == "true" && !hasGlobalOverride:
+					case "DebugSymbols" when isDebugOnly && valueLower == "true" && !hasGlobalOverride:
+					// Default project values for Platform and Configuration
+					case "Platform" when !hasParentCondition && ValidateEmptyConditionValue(childCondition) &&
+					                     valueLower == "anycpu":
+					case "Configuration" when !hasParentCondition && ValidateEmptyConditionValue(childCondition) &&
+					                          valueLower == "debug":
+					// Extra ProjectName duplicates
+					case "RootNamespace" when !hasParentCondition && ValidateEmptyConditionValue(childCondition) &&
+					                          child.Value == project.ProjectName:
+					case "AssemblyName" when !hasParentCondition && ValidateEmptyConditionValue(childCondition) &&
+					                         child.Value == project.ProjectName:
+					{
+						removeQueue.Add(child);
+						break;
+					}
+				}
 
-					var tagLocalName = child.Name.LocalName;
-					var valueLower = child.Value.ToLowerInvariant();
-					var valueLowerTrim = valueLower.Trim();
-					var hasGlobalOverride = globalOverrides.TryGetValue(tagLocalName, out var globalOverride);
-					var globalOverrideLower = globalOverride?.ToLowerInvariant();
-
-					// Regex is the easiest way to replace string between two unknown chars preserving both as is
-					// so that bin\Debug\net472 is turned into bin\$(Configuration)\net472
-					// and bin/Debug\net472 is turned into bin/$(Configuration)\net472, preserving path separators
-					var configurationPathRegex = parentConditionHasConfiguration
-						? new Regex($@"([\\/]){parentConditionConfiguration}([\\/])")
-						: null;
-					var platformPathRegex = parentConditionHasPlatform
-						? new Regex($@"([\\/]){parentConditionPlatform}([\\/])")
-						: null;
-
-					var childCondition = child.Attribute("Condition");
+				if (parentConditionHasConfiguration || parentConditionHasPlatform)
+				{
 					switch (tagLocalName)
 					{
-						// VS2013 NuGet bugs workaround
-						case "NuGetPackageImportStamp":
-						// used by Project2015To2017 and not needed anymore
-						case "OutputType" when !hasParentCondition:
-						case "Platforms" when !hasParentCondition:
-						case "Configurations" when !hasParentCondition:
-						case "TargetFrameworkVersion" when !hasParentCondition:
-						case "TargetFrameworkIdentifier" when !hasParentCondition:
-						case "TargetFrameworkProfile" when !hasParentCondition && valueLowerTrim.Length == 0:
-						// VCS properties
-						case "SccProjectName" when !hasParentCondition && valueLowerTrim.Length == 0:
-						case "SccLocalPath" when !hasParentCondition && valueLowerTrim.Length == 0:
-						case "SccAuxPath" when !hasParentCondition && valueLowerTrim.Length == 0:
-						case "SccProvider" when !hasParentCondition && valueLowerTrim.Length == 0:
-						// Project properties set to defaults (Microsoft.NET.Sdk)
-						case "OutputType" when ValidateDefaultValue("Library"):
-						case "FileAlignment" when ValidateDefaultValue("512"):
-						case "ErrorReport" when ValidateDefaultValue("prompt"):
-						case "Deterministic" when ValidateDefaultValue("true"):
-						case "WarningLevel" when ValidateDefaultValue("4"):
-						case "DebugType" when ValidateDefaultValue("portable"):
-						case "ResolveNuGetPackages" when ValidateDefaultValue("false"):
-						case "SkipImportNuGetProps" when ValidateDefaultValue("true"):
-						case "SkipImportNuGetBuildTargets" when ValidateDefaultValue("true"):
-						case "RestoreProjectStyle" when ValidateDefaultValue("packagereference"):
-						case "AllowUnsafeBlocks" when ValidateDefaultValue("false"):
-						case "TreatWarningsAsErrors" when ValidateDefaultValue("false"):
-						case "Prefer32Bit" when ValidateDefaultValue("false"):
-						case "SignAssembly" when ValidateDefaultValue("false"):
-						case "DelaySign" when ValidateDefaultValue("false"):
-						case "GeneratePackageOnBuild" when ValidateDefaultValue("false"):
-						case "PackageRequireLicenseAcceptance" when ValidateDefaultValue("false"):
-						case "DebugSymbols" when ValidateDefaultValue("false"):
-						case "CheckForOverflowUnderflow" when ValidateDefaultValue("false"):
-						case "AppendTargetFrameworkToOutputPath" when ValidateDefaultValue("true"):
-						case "AppDesignerFolder" when ValidateDefaultValue("properties"):
-						case "DefaultProjectTypeGuid"
-							when ValidateDefaultValue("{fae04ec0-301f-11d3-bf4b-00c04f79efbc}"):
-						case "DefaultLanguageSourceExtension" when ValidateDefaultValue(".cs"):
-						case "Language" when ValidateDefaultValue("C#"):
-						case "TargetRuntime" when ValidateDefaultValue("managed"):
-						case "Utf8Output" when ValidateDefaultValue("true"):
-						case "PlatformName" when ValidateDefaultValue("$(platform)")
-						                         || (parentConditionHasPlatform &&
-						                             ValidateDefaultValue(parentConditionPlatformLower)):
-						// Conditional platform default values
-						case "PlatformTarget" when parentConditionHasPlatform && child.Value == parentConditionPlatform
-						                                                      && !hasGlobalOverride:
-						// Conditional configuration (Debug/Release) default values
-						case "DefineConstants"
-							when isDebugOnly && ValidateDefaultConstants(valueLower, "debug", "trace") &&
-							     !hasGlobalOverride:
-						case "DefineConstants" when isReleaseOnly && ValidateDefaultConstants(valueLower, "trace") &&
-						                            !hasGlobalOverride:
-						case "Optimize" when isDebugOnly && valueLower == "false" && !hasGlobalOverride:
-						case "Optimize" when isReleaseOnly && valueLower == "true" && !hasGlobalOverride:
-						case "DebugSymbols" when isDebugOnly && valueLower == "true" && !hasGlobalOverride:
-						// Default project values for Platform and Configuration
-						case "Platform" when !hasParentCondition && ValidateEmptyConditionValue(childCondition) &&
-						                     valueLower == "anycpu":
-						case "Configuration" when !hasParentCondition && ValidateEmptyConditionValue(childCondition) &&
-						                          valueLower == "debug":
-						// Extra ProjectName duplicates
-						case "RootNamespace" when !hasParentCondition && ValidateEmptyConditionValue(childCondition) &&
-						                          child.Value == project.ProjectName:
-						case "AssemblyName" when !hasParentCondition && ValidateEmptyConditionValue(childCondition) &&
-						                         child.Value == project.ProjectName:
+						case "OutputPath":
+						case "IntermediateOutputPath":
+						case "DocumentationFile":
+						case "CodeAnalysisRuleSet":
 						{
-							removeQueue.Add(child);
-							break;
-						}
-
-						// Default configuration-specific paths
-						case "OutputPath" when parentConditionHasConfiguration || parentConditionHasPlatform:
-						{
-							if (parentConditionHasConfiguration)
-							{
-								child.Value = configurationPathRegex.Replace(child.Value, "$1$(Configuration)$2");
-							}
-
-							if (parentConditionHasPlatform)
-							{
-								child.Value = platformPathRegex.Replace(child.Value, "$1$(Platform)$2");
-							}
+							child.Value = ReplaceWithPlaceholders(child.Value);
 
 							break;
 						}
 					}
+				}
 
-					// following local methods will capture parent scope
-					bool ValidateDefaultValue(string @default)
+				// following local methods will capture parent scope
+				bool ValidateDefaultValue(string @default)
+				{
+					return (!hasParentCondition && valueLower == @default) ||
+					       (hasParentCondition && ValidateConditionedDefaultValue(@default));
+				}
+
+				bool ValidateConditionedDefaultValue(string @default)
+				{
+					return (valueLower == @default) && (!hasGlobalOverride || globalOverrideLower == @default);
+				}
+
+				string ReplaceWithPlaceholders(string value)
+				{
+					if (parentConditionHasConfiguration)
 					{
-						return (!hasParentCondition && valueLower == @default) ||
-						       (hasParentCondition && ValidateConditionedDefaultValue(@default));
+						value = configurationPathRegex.Replace(value, "$1$(Configuration)$2");
 					}
 
-					bool ValidateConditionedDefaultValue(string @default)
+					if (parentConditionHasPlatform)
 					{
-						return (valueLower == @default) && (!hasGlobalOverride || globalOverrideLower == @default);
+						value = platformPathRegex.Replace(value, "$1$(Platform)$2");
 					}
 
-					// following local methods will not capture parent scope
-					bool ValidateEmptyConditionValue(XAttribute condition)
-					{
-						if (condition == null)
-						{
-							return true;
-						}
-
-						var value = condition.Value;
-						return (value.Count(x => x == '=') == 2) && value.Contains("''");
-					}
-
-					bool ValidateDefaultConstants(string value, params string[] expected)
-					{
-						var defines = value.Split(new[] {';'}, StringSplitOptions.RemoveEmptyEntries);
-						var set = new HashSet<string>(defines);
-						foreach (var expecto in expected)
-						{
-							if (!set.Remove(expecto))
-							{
-								return false;
-							}
-						}
-
-						return set.Count == 0;
-					}
+					return value;
 				}
 			}
 
@@ -210,28 +206,19 @@ namespace Project2015To2017.Transforms
 		/// <summary>
 		/// Get all non-conditional properties and their respective values
 		/// </summary>
-		/// <param name="additionalPropertyGroups">PropertyGroups to be inspected</param>
+		/// <param name="propertyGroup">Primary unconditional PropertyGroup to be inspected</param>
 		/// <returns>Dictionary of properties' keys and values</returns>
-		private static IDictionary<string, string> RetrieveGlobalOverrides(
-			IEnumerable<XElement> additionalPropertyGroups)
+		private static IDictionary<string, string> RetrieveGlobalOverrides(XElement propertyGroup)
 		{
 			var globalOverrides = new Dictionary<string, string>();
-			foreach (var propertyGroup in additionalPropertyGroups)
+			foreach (var child in propertyGroup.Elements())
 			{
-				if (!HasEmptyCondition(propertyGroup))
+				if (!HasEmptyCondition(child))
 				{
 					continue;
 				}
 
-				foreach (var child in propertyGroup.Elements())
-				{
-					if (!HasEmptyCondition(child))
-					{
-						continue;
-					}
-
-					globalOverrides[child.Name.LocalName] = child.Value.Trim();
-				}
+				globalOverrides[child.Name.LocalName] = child.Value.Trim();
 			}
 
 			return globalOverrides;
@@ -249,6 +236,23 @@ namespace Project2015To2017.Transforms
 				// no sane condition is 1 char long
 				return condition.Length <= 1;
 			}
+		}
+
+		private static bool ValidateEmptyConditionValue(XAttribute condition)
+		{
+			if (condition == null)
+			{
+				return true;
+			}
+
+			var value = condition.Value;
+			return (value.Count(x => x == '=') == 2) && value.Contains("''");
+		}
+
+		private static bool ValidateDefaultConstants(string value, params string[] expected)
+		{
+			var defines = value.Split(new[] {';'}, StringSplitOptions.RemoveEmptyEntries);
+			return Helpers.ValidateSet(defines, expected);
 		}
 	}
 }

--- a/Project2015To2017Tests/FileTransformationTest.cs
+++ b/Project2015To2017Tests/FileTransformationTest.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
@@ -11,85 +9,85 @@ using Project2015To2017;
 namespace Project2015To2017Tests
 {
 	[TestClass]
-    public class FileTransformationTest
-    {
-        [TestMethod]
-        public void TransformsFiles()
-        {
-            var project = new ProjectReader().Read(Path.Combine("TestFiles", "FileInclusion", "fileinclusion.testcsproj"));
-            var transformation = new FileTransformation();
+	public class FileTransformationTest
+	{
+		[TestMethod]
+		public void TransformsFiles()
+		{
+			var project = new ProjectReader().Read(Path.Combine("TestFiles", "FileInclusion", "fileinclusion.testcsproj"));
+			var transformation = new FileTransformation();
 
-	        transformation.Transform(project, NoopLogger.Instance);
+			transformation.Transform(project, NoopLogger.Instance);
 
-	        var includeItems = project.ItemGroups.SelectMany(x => x.Elements()).ToImmutableList();
+			var includeItems = project.ItemGroups.SelectMany(x => x.Elements()).ToImmutableList();
 
-	        Assert.AreEqual(28, includeItems.Count);
+			Assert.AreEqual(29, includeItems.Count);
 
-            Assert.AreEqual(12, includeItems.Count(x => x.Name.LocalName == "Reference"));
-            Assert.AreEqual(2, includeItems.Count(x => x.Name.LocalName == "ProjectReference"));
-            Assert.AreEqual(11, includeItems.Count(x => x.Name.LocalName == "Compile"));
-			Assert.AreEqual(6, includeItems.Count(x => x.Name.LocalName == "Compile" && x.Attribute("Update") != null));
-			Assert.AreEqual(3, includeItems.Count(x => x.Name.LocalName == "Compile" && x.Attribute("Include") != null));
+			Assert.AreEqual(12, includeItems.Count(x => x.Name.LocalName == "Reference"));
+			Assert.AreEqual(2, includeItems.Count(x => x.Name.LocalName == "ProjectReference"));
+			Assert.AreEqual(11, includeItems.Count(x => x.Name.LocalName == "Compile"));
+			Assert.AreEqual(5, includeItems.Count(x => x.Name.LocalName == "Compile" && x.Attribute("Update") != null));
+			Assert.AreEqual(4, includeItems.Count(x => x.Name.LocalName == "Compile" && x.Attribute("Include") != null));
 			Assert.AreEqual(2, includeItems.Count(x => x.Name.LocalName == "Compile" && x.Attribute("Remove") != null));
-			Assert.AreEqual(2, includeItems.Count(x => x.Name.LocalName == "EmbeddedResource")); // #73 inlcude things that are not ending in .resx
-            Assert.AreEqual(0, includeItems.Count(x => x.Name.LocalName == "Content"));
-            Assert.AreEqual(1, includeItems.Count(x => x.Name.LocalName == "None"));
-            Assert.AreEqual(0, includeItems.Count(x => x.Name.LocalName == "Analyzer"));
+			Assert.AreEqual(3, includeItems.Count(x => x.Name.LocalName == "EmbeddedResource")); // #73 include things that are not ending in .resx
+			Assert.AreEqual(0, includeItems.Count(x => x.Name.LocalName == "Content"));
+			Assert.AreEqual(1, includeItems.Count(x => x.Name.LocalName == "None"));
+			Assert.AreEqual(0, includeItems.Count(x => x.Name.LocalName == "Analyzer"));
 
-	        var resourceDesigner = includeItems.Single(
-		        x => x.Name.LocalName == "Compile"
-		             && x.Attribute("Update")?.Value == @"Properties\Resources.Designer.cs"
-	        );
+			var resourceDesigner = includeItems.Single(
+				x => x.Name.LocalName == "Compile"
+				     && x.Attribute("Update")?.Value == @"Properties\Resources.Designer.cs"
+			);
 
 			Assert.AreEqual(3, resourceDesigner.Elements().Count());
-	        var dependentUponElement = resourceDesigner.Elements().Single(x => x.Name.LocalName == "DependentUpon");
+			var dependentUponElement = resourceDesigner.Elements().Single(x => x.Name.LocalName == "DependentUpon");
 
 			Assert.AreEqual("Resources.resx", dependentUponElement.Value);
 
-	        var linkedFile = includeItems.Single(
-		        x => x.Name.LocalName == "Compile"
-		             && x.Attribute("Include")?.Value == @"..\OtherTestProjects\OtherTestClass.cs"
-	        );
+			var linkedFile = includeItems.Single(
+				x => x.Name.LocalName == "Compile"
+				     && x.Attribute("Include")?.Value == @"..\OtherTestProjects\OtherTestClass.cs"
+			);
 			var linkAttribute = linkedFile.Attributes().FirstOrDefault(a => a.Name.LocalName == "Link");
 			Assert.IsNotNull(linkAttribute);
 			Assert.AreEqual("OtherTestClass.cs", linkAttribute.Value);
 
-	        var sourceWithDesigner = includeItems.Single(
-		        x => x.Name.LocalName == "Compile"
-		             && x.Attribute("Update")?.Value == @"SourceFileWithDesigner.cs"
-	        );
+			var sourceWithDesigner = includeItems.Single(
+				x => x.Name.LocalName == "Compile"
+				     && x.Attribute("Update")?.Value == @"SourceFileWithDesigner.cs"
+			);
 
 			var subTypeElement = sourceWithDesigner.Elements().Single();
-	        Assert.AreEqual("SubType", subTypeElement.Name.LocalName);
-	        Assert.AreEqual("Component", subTypeElement.Value);
+			Assert.AreEqual("SubType", subTypeElement.Name.LocalName);
+			Assert.AreEqual("Component", subTypeElement.Value);
 
-	        var designerForSource = includeItems.Single(
-		        x => x.Name.LocalName == "Compile"
-		             && x.Attribute("Update")?.Value == @"SourceFileWithDesigner.Designer.cs"
-	        );
+			var designerForSource = includeItems.Single(
+				x => x.Name.LocalName == "Compile"
+				     && x.Attribute("Update")?.Value == @"SourceFileWithDesigner.Designer.cs"
+			);
 
-	        var dependentUponElement2 = designerForSource.Elements().Single();
+			var dependentUponElement2 = designerForSource.Elements().Single();
 
-	        Assert.AreEqual("DependentUpon", dependentUponElement2.Name.LocalName);
-	        Assert.AreEqual("SourceFileWithDesigner.cs", dependentUponElement2.Value);
+			Assert.AreEqual("DependentUpon", dependentUponElement2.Name.LocalName);
+			Assert.AreEqual("SourceFileWithDesigner.cs", dependentUponElement2.Value);
 
-	        var fileWithAnotherAttribute = includeItems.Single(
-		        x => x.Name.LocalName == "Compile"
-		             && x.Attribute("Update")?.Value == @"AnotherFile.cs"
-	        );
+			var fileWithAnotherAttribute = includeItems.Single(
+				x => x.Name.LocalName == "Compile"
+				     && x.Attribute("Update")?.Value == @"AnotherFile.cs"
+			);
 
 			Assert.AreEqual(2, fileWithAnotherAttribute.Attributes().Count());
 			Assert.AreEqual("AttrValue", fileWithAnotherAttribute.Attribute("AnotherAttribute")?.Value);
 
-	        var removeMatchingWildcard = includeItems.Where(
-			        x => x.Name.LocalName == "Compile"
-			             && x.Attribute("Remove")?.Value != null
-		        )
-		        .ToImmutableList();
+			var removeMatchingWildcard = includeItems.Where(
+					x => x.Name.LocalName == "Compile"
+					     && x.Attribute("Remove")?.Value != null
+				)
+				.ToImmutableList();
 			Assert.IsNotNull(removeMatchingWildcard);
 			Assert.AreEqual(2, removeMatchingWildcard.Count);
 			Assert.IsTrue(removeMatchingWildcard.Any(x => x.Attribute("Remove")?.Value == "SourceFileAsResource.cs"));
 			Assert.IsTrue(removeMatchingWildcard.Any(x => x.Attribute("Remove")?.Value == "Class1.cs"));
-        }
-    }
+		}
+	}
 }

--- a/Project2015To2017Tests/PrimaryUnconditionalPropertyTransformationTest.cs
+++ b/Project2015To2017Tests/PrimaryUnconditionalPropertyTransformationTest.cs
@@ -1,0 +1,50 @@
+using System.IO;
+using System.Xml.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Project2015To2017;
+using Project2015To2017.Definition;
+using Project2015To2017.Transforms;
+
+namespace Project2015To2017Tests
+{
+	[TestClass]
+	public class PrimaryUnconditionalPropertyTransformationTest
+	{
+		[TestMethod]
+		public void OutputAppendTargetFrameworkToOutputPathTrue()
+		{
+			var project = new Project
+			{
+				IsModernProject = true,
+				AppendTargetFrameworkToOutputPath = true,
+				PrimaryPropertyGroup = new XElement("PropertyGroup"),
+				FilePath = new FileInfo("test.cs")
+			};
+
+			new PrimaryUnconditionalPropertyTransformation().Transform(project, NoopLogger.Instance);
+
+			var appendTargetFrameworkToOutputPath = project.PrimaryPropertyGroup
+				.Element("AppendTargetFrameworkToOutputPath");
+			Assert.IsNull(appendTargetFrameworkToOutputPath);
+		}
+
+		[TestMethod]
+		public void OutputAppendTargetFrameworkToOutputPathFalse()
+		{
+			var project = new Project
+			{
+				IsModernProject = true,
+				AppendTargetFrameworkToOutputPath = false,
+				PrimaryPropertyGroup = new XElement("PropertyGroup"),
+				FilePath = new FileInfo("test.cs")
+			};
+
+			new PrimaryUnconditionalPropertyTransformation().Transform(project, NoopLogger.Instance);
+
+			var appendTargetFrameworkToOutputPath = project.PrimaryPropertyGroup
+				.Element("AppendTargetFrameworkToOutputPath");
+			Assert.IsNotNull(appendTargetFrameworkToOutputPath);
+			Assert.AreEqual("false", appendTargetFrameworkToOutputPath.Value);
+		}
+	}
+}

--- a/Project2015To2017Tests/ProjectPropertiesReadTest.cs
+++ b/Project2015To2017Tests/ProjectPropertiesReadTest.cs
@@ -1,11 +1,9 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Threading.Tasks;
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
-using System.Xml.Linq;
 using Project2015To2017.Definition;
 using Project2015To2017.Reading;
 
@@ -49,10 +47,10 @@ namespace Project2015To2017Tests
 			Assert.AreEqual("net46", project.TargetFrameworks[0]);
 		}
 
-        [TestMethod]
-        public async Task ReadsTestProjectGuid()
-        {
-            var xml = @"<?xml version=""1.0"" encoding=""utf-8""?>
+		[TestMethod]
+		public async Task ReadsTestProjectGuid()
+		{
+			var xml = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <Project ToolsVersion=""14.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
   <PropertyGroup>
     <OutputType>Library</OutputType>
@@ -78,13 +76,13 @@ namespace Project2015To2017Tests
   </PropertyGroup>
 </Project>";
 
-            var project = await ParseAndTransform(xml).ConfigureAwait(false);
+			var project = await ParseAndTransform(xml).ConfigureAwait(false);
 
-            Assert.AreEqual(ApplicationType.TestProject, project.Type);
-            Assert.AreEqual("net40", project.TargetFrameworks[0]);
-        }
+			Assert.AreEqual(ApplicationType.TestProject, project.Type);
+			Assert.AreEqual("net40", project.TargetFrameworks[0]);
+		}
 
-        [TestMethod]
+		[TestMethod]
 		public async Task ReadsConsoleApplication()
 		{
 			var xml = @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -99,12 +97,12 @@ namespace Project2015To2017Tests
 
 			Assert.AreEqual(ApplicationType.ConsoleApplication, project.Type);
 			Assert.AreEqual("net46", project.TargetFrameworks[0]);
-        }
+		}
 
-        [TestMethod]
-        public async Task ReadsConsoleApplicationFromConditional()
-        {
-            var xml = @"<?xml version=""1.0"" encoding=""utf-8""?>
+		[TestMethod]
+		public async Task ReadsConsoleApplicationFromConditional()
+		{
+			var xml = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <Project ToolsVersion=""14.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
   <PropertyGroup>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
@@ -117,13 +115,13 @@ namespace Project2015To2017Tests
   </PropertyGroup>
 </Project>";
 
-            var project = await ParseAndTransform(xml).ConfigureAwait(false);
+			var project = await ParseAndTransform(xml).ConfigureAwait(false);
 
-            Assert.AreEqual(ApplicationType.ConsoleApplication, project.Type);
-            Assert.AreEqual("net46", project.TargetFrameworks[0]);
-        }
+			Assert.AreEqual(ApplicationType.ConsoleApplication, project.Type);
+			Assert.AreEqual("net46", project.TargetFrameworks[0]);
+		}
 
-        [TestMethod]
+		[TestMethod]
 		public async Task ReadsClassLibraryApplication()
 		{
 			var xml = @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -246,12 +244,12 @@ namespace Project2015To2017Tests
 
 			Assert.IsNotNull(project.TargetFrameworks);
 			Assert.AreEqual(0, project.TargetFrameworks.Count);
-        }
+		}
 
-        [TestMethod]
-        public async Task ReadsPropertiesWithMultipleUnconditionalPropertyGroups()
-        {
-            var xml = @"
+		[TestMethod]
+		public async Task ReadsPropertiesWithMultipleUnconditionalPropertyGroups()
+		{
+			var xml = @"
 <Project DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"" ToolsVersion=""4.0"">
   <Import Project=""$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props"" Condition=""Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"" />
   <PropertyGroup>
@@ -279,18 +277,18 @@ namespace Project2015To2017Tests
   </PropertyGroup>
 </Project>";
 
-            var project = await ParseAndTransform(xml).ConfigureAwait(false);
+			var project = await ParseAndTransform(xml).ConfigureAwait(false);
 
-            Assert.AreEqual("Croc.XFW3.DomainModelDefinitionLanguage.Dsl", project.AssemblyName);
-            Assert.AreEqual("Croc.XFW3.DomainModelDefinitionLanguage", project.RootNamespace);
-            Assert.AreEqual(ApplicationType.ClassLibrary, project.Type);
-			Assert.AreEqual(1, project.AdditionalPropertyGroups.Count);
-        }
+			Assert.AreEqual("Croc.XFW3.DomainModelDefinitionLanguage.Dsl", project.AssemblyName);
+			Assert.AreEqual("Croc.XFW3.DomainModelDefinitionLanguage", project.RootNamespace);
+			Assert.AreEqual(ApplicationType.ClassLibrary, project.Type);
+			Assert.AreEqual(0, project.AdditionalPropertyGroups.Count);
+		}
 
-        [TestMethod]
-        public async Task ReadsImportsAndTargets()
-        {
-            var xml = @"
+		[TestMethod]
+		public async Task ReadsImportsAndTargets()
+		{
+			var xml = @"
 <Project DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"" ToolsVersion=""4.0"">
   <Import Project=""$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props"" Condition=""Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"" />
   <PropertyGroup>
@@ -324,10 +322,10 @@ namespace Project2015To2017Tests
   </Target>
  </Project>";
 
-            var project = await ParseAndTransform(xml).ConfigureAwait(false);
+			var project = await ParseAndTransform(xml).ConfigureAwait(false);
 
-            Assert.AreEqual(1, project.Imports.Count);
-            Assert.AreEqual(2, project.Targets.Count);
+			Assert.AreEqual(1, project.Imports.Count);
+			Assert.AreEqual(2, project.Targets.Count);
 		}
 
 		[TestMethod]
@@ -378,8 +376,8 @@ namespace Project2015To2017Tests
 
 			var project = await ParseAndTransform(xml).ConfigureAwait(false);
 
-			Assert.AreEqual(1, project.AdditionalPropertyGroups.Count);
-			var children = project.AdditionalPropertyGroups[0].Elements().ToImmutableArray();
+			Assert.AreEqual(0, project.AdditionalPropertyGroups.Count);
+			var children = project.PrimaryPropertyGroup.Elements().ToImmutableArray();
 			Assert.AreEqual(4, children.Count(x => x.Name.LocalName.StartsWith("Scc")));
 		}
 
@@ -426,7 +424,7 @@ if $(ConfigurationName) == Debug (
 		}
 
 		[TestMethod]
-		public async Task ReadsConfigurations()
+		public async Task UsesDefaultConfigurations()
 		{
 			var xml = @"
 <Project DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"" ToolsVersion=""4.0"">
@@ -493,10 +491,9 @@ if $(ConfigurationName) == Debug (
 
 			var project = await ParseAndTransform(xml).ConfigureAwait(false);
 
-			Assert.AreEqual(3, project.Configurations.Count);
+			Assert.AreEqual(2, project.Configurations.Count);
 			Assert.AreEqual(1, project.Configurations.Count(x => x == "Debug"));
 			Assert.AreEqual(1, project.Configurations.Count(x => x == "Release"));
-			Assert.AreEqual(1, project.Configurations.Count(x => x == "Release_CI"));
 		}
 
 
@@ -544,12 +541,11 @@ if $(ConfigurationName) == Debug (
 			Assert.AreEqual(1, project.Configurations.Count(x => x == "Debug"));
 			Assert.AreEqual(1, project.Configurations.Count(x => x == "Release"));
 
-			Assert.AreEqual(4, project.AdditionalPropertyGroups.Count);
-
-			Assert.IsNotNull(project.AdditionalPropertyGroups[0].Attribute("Condition"));
-			Assert.IsNotNull(project.AdditionalPropertyGroups[1].Attribute("Condition"));
-			Assert.IsNotNull(project.AdditionalPropertyGroups[2].Attribute("Condition"));
-			Assert.IsNull(project.AdditionalPropertyGroups[3].Attribute("Condition"));
+			Assert.AreEqual(3, project.AdditionalPropertyGroups.Count);
+			foreach (var propertyGroup in project.AdditionalPropertyGroups)
+			{
+				Assert.IsNotNull(propertyGroup.Attribute("Condition"));
+			}
 
 			var childrenDebug = project.AdditionalPropertyGroups[0].Elements().ToImmutableArray();
 			Assert.AreEqual(2, childrenDebug.Length);
@@ -560,14 +556,15 @@ if $(ConfigurationName) == Debug (
 			var childrenReleaseCI = project.AdditionalPropertyGroups[2].Elements().ToImmutableArray();
 			Assert.AreEqual(8, childrenReleaseCI.Length);
 
-			var childrenGlobal = project.AdditionalPropertyGroups[3].Elements().ToImmutableArray();
-			Assert.AreEqual(4, childrenGlobal.Length);
+			var childrenGlobal = project.PrimaryPropertyGroup.Elements().ToImmutableArray();
+			Assert.AreEqual(5, childrenGlobal.Length);
 		}
 
 		private static async Task<Project> ParseAndTransform(
-				string xml,
-				[System.Runtime.CompilerServices.CallerMemberName] string memberName = ""
-			)
+			string xml,
+			[System.Runtime.CompilerServices.CallerMemberName]
+			string memberName = ""
+		)
 		{
 			var testCsProjFile = $"{memberName}_test.csproj";
 
@@ -576,16 +573,6 @@ if $(ConfigurationName) == Debug (
 			var project = new ProjectReader().Read(testCsProjFile);
 
 			return project;
-		}
-
-		internal static bool ValidateChildren(IEnumerable<XElement> value, params string[] expected)
-		{
-			var defines = value.Select(x => x.Name.LocalName);
-			var set = new HashSet<string>(defines);
-			foreach (var expecto in expected)
-				if (!set.Remove(expecto))
-					return false;
-			return set.Count == 0;
 		}
 	}
 }

--- a/Project2015To2017Tests/ProjectWriterTest.cs
+++ b/Project2015To2017Tests/ProjectWriterTest.cs
@@ -143,7 +143,7 @@ namespace Project2015To2017Tests
 			var writer = new ProjectWriter();
 			var xmlNode = writer.CreateXml(new Project
 			{
-				AdditionalPropertyGroups = new[] {new XElement("PropertyGroup")},
+				PrimaryPropertyGroup = new XElement("PropertyGroup"),
 				FilePath = new FileInfo("test.cs")
 			});
 
@@ -157,7 +157,7 @@ namespace Project2015To2017Tests
 			var writer = new ProjectWriter();
 			var xmlNode = writer.CreateXml(new Project
 			{
-				AdditionalPropertyGroups = new[] {new XElement("PropertyGroup", new XElement("DelaySign", "true"))},
+				PrimaryPropertyGroup = new XElement("PropertyGroup", new XElement("DelaySign", "true")),
 				FilePath = new FileInfo("test.cs")
 			});
 
@@ -172,7 +172,7 @@ namespace Project2015To2017Tests
 			var writer = new ProjectWriter();
 			var xmlNode = writer.CreateXml(new Project
 			{
-				AdditionalPropertyGroups = new[] {new XElement("PropertyGroup", new XElement("DelaySign", "false"))},
+				PrimaryPropertyGroup = new XElement("PropertyGroup", new XElement("DelaySign", "false")),
 				FilePath = new FileInfo("test.cs")
 			});
 
@@ -364,34 +364,6 @@ namespace Project2015To2017Tests
 			);
 
 			CollectionAssert.AreEqual(new FileSystemInfo[0], actualDeletedFiles);
-		}
-
-		[TestMethod]
-		public void OutputAppendTargetFrameworkToOutputPathTrue()
-		{
-			var writer = new ProjectWriter();
-			var xmlNode = writer.CreateXml(new Project
-			{
-				AppendTargetFrameworkToOutputPath = true,
-				FilePath = new FileInfo("test.cs")
-			});
-
-			var appendTargetFrameworkToOutputPath = xmlNode.Element("PropertyGroup").Element("AppendTargetFrameworkToOutputPath");
-			Assert.IsNull(appendTargetFrameworkToOutputPath);
-		}
-		[TestMethod]
-		public void OutputAppendTargetFrameworkToOutputPathFalse()
-		{
-			var writer = new ProjectWriter();
-			var xmlNode = writer.CreateXml(new Project
-			{
-				AppendTargetFrameworkToOutputPath = false,
-				FilePath = new FileInfo("test.cs")
-			});
-
-			var appendTargetFrameworkToOutputPath = xmlNode.Element("PropertyGroup").Element("AppendTargetFrameworkToOutputPath");
-			Assert.IsNotNull(appendTargetFrameworkToOutputPath);
-			Assert.AreEqual("false", appendTargetFrameworkToOutputPath.Value);
 		}
 	}
 }

--- a/Project2015To2017Tests/PropertySimplificationTransformationTest.cs
+++ b/Project2015To2017Tests/PropertySimplificationTransformationTest.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
@@ -7,7 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Project2015To2017.Reading;
 using Project2015To2017.Transforms;
-using static Project2015To2017Tests.ProjectPropertiesReadTest;
+using static Project2015To2017.Transforms.Helpers;
 using Project2015To2017;
 
 namespace Project2015To2017Tests
@@ -68,11 +67,12 @@ namespace Project2015To2017Tests
 
 			var project = await ParseAndTransform(xml).ConfigureAwait(false);
 
-			Assert.AreEqual(3, project.AdditionalPropertyGroups.Count);
+			Assert.AreEqual(2, project.AdditionalPropertyGroups.Count);
 
-			Assert.IsNotNull(project.AdditionalPropertyGroups[0].Attribute("Condition"));
-			Assert.IsNotNull(project.AdditionalPropertyGroups[1].Attribute("Condition"));
-			Assert.IsNull(project.AdditionalPropertyGroups[2].Attribute("Condition"));
+			foreach (var propertyGroup in project.AdditionalPropertyGroups)
+			{
+				Assert.IsNotNull(propertyGroup.Attribute("Condition"));
+			}
 
 			var childrenDebug = project.AdditionalPropertyGroups[0].Elements().ToImmutableArray();
 			Assert.AreEqual(2, childrenDebug.Length);
@@ -80,7 +80,7 @@ namespace Project2015To2017Tests
 			var childrenRelease = project.AdditionalPropertyGroups[1].Elements().ToImmutableArray();
 			Assert.AreEqual(2, childrenRelease.Length);
 			Assert.IsTrue(ValidateChildren(childrenRelease, "DebugType", "OutputPath"));
-			var childrenGlobal = project.AdditionalPropertyGroups[2].Elements().ToImmutableArray();
+			var childrenGlobal = project.PrimaryPropertyGroup.Elements().ToImmutableArray();
 			Assert.AreEqual(7, childrenGlobal.Length);
 			Assert.IsTrue(ValidateChildren(childrenGlobal,
 				"ProjectGuid", "ProjectTypeGuids", "VisualStudioVersion", "VSToolsPath",
@@ -121,11 +121,12 @@ namespace Project2015To2017Tests
 			Assert.AreEqual(1, project.Platforms.Count);
 			Assert.AreEqual(1, project.Platforms.Count(x => x == "AnyCPU"));
 
-			Assert.AreEqual(3, project.AdditionalPropertyGroups.Count);
+			Assert.AreEqual(2, project.AdditionalPropertyGroups.Count);
 
-			Assert.IsNotNull(project.AdditionalPropertyGroups[0].Attribute("Condition"));
-			Assert.IsNotNull(project.AdditionalPropertyGroups[1].Attribute("Condition"));
-			Assert.IsNull(project.AdditionalPropertyGroups[2].Attribute("Condition"));
+			foreach (var propertyGroup in project.AdditionalPropertyGroups)
+			{
+				Assert.IsNotNull(propertyGroup.Attribute("Condition"));
+			}
 
 			var childrenDebug = project.AdditionalPropertyGroups[0].Elements().ToImmutableArray();
 			Assert.AreEqual(1, childrenDebug.Length);
@@ -135,7 +136,7 @@ namespace Project2015To2017Tests
 			var childrenRelease = project.AdditionalPropertyGroups[1].Elements().ToImmutableArray();
 			Assert.AreEqual(0, childrenRelease.Length);
 
-			var childrenGlobal = project.AdditionalPropertyGroups[2].Elements().ToImmutableArray();
+			var childrenGlobal = project.PrimaryPropertyGroup.Elements().ToImmutableArray();
 			Assert.AreEqual(1, childrenGlobal.Length);
 			Assert.IsTrue(ValidateChildren(childrenGlobal, "ProjectTypeGuids"));
 		}
@@ -173,11 +174,12 @@ namespace Project2015To2017Tests
 			Assert.AreEqual(1, project.Platforms.Count);
 			Assert.AreEqual(1, project.Platforms.Count(x => x == "AnyCPU"));
 
-			Assert.AreEqual(3, project.AdditionalPropertyGroups.Count);
+			Assert.AreEqual(2, project.AdditionalPropertyGroups.Count);
 
-			Assert.IsNotNull(project.AdditionalPropertyGroups[0].Attribute("Condition"));
-			Assert.IsNotNull(project.AdditionalPropertyGroups[1].Attribute("Condition"));
-			Assert.IsNull(project.AdditionalPropertyGroups[2].Attribute("Condition"));
+			foreach (var propertyGroup in project.AdditionalPropertyGroups)
+			{
+				Assert.IsNotNull(propertyGroup.Attribute("Condition"));
+			}
 
 			var childrenDebug = project.AdditionalPropertyGroups[0].Elements().ToImmutableArray();
 			Assert.AreEqual(2, childrenDebug.Length);
@@ -185,7 +187,7 @@ namespace Project2015To2017Tests
 			var childrenRelease = project.AdditionalPropertyGroups[1].Elements().ToImmutableArray();
 			Assert.AreEqual(1, childrenRelease.Length);
 			Assert.IsTrue(ValidateChildren(childrenRelease, "OutputPath"));
-			var childrenGlobal = project.AdditionalPropertyGroups[2].Elements().ToImmutableArray();
+			var childrenGlobal = project.PrimaryPropertyGroup.Elements().ToImmutableArray();
 			Assert.AreEqual(0, childrenGlobal.Length);
 		}
 
@@ -233,12 +235,12 @@ namespace Project2015To2017Tests
 			Assert.AreEqual(1, project.Configurations.Count(x => x == "Debug"));
 			Assert.AreEqual(1, project.Configurations.Count(x => x == "Release"));
 
-			Assert.AreEqual(4, project.AdditionalPropertyGroups.Count);
+			Assert.AreEqual(3, project.AdditionalPropertyGroups.Count);
 
-			Assert.IsNotNull(project.AdditionalPropertyGroups[0].Attribute("Condition"));
-			Assert.IsNotNull(project.AdditionalPropertyGroups[1].Attribute("Condition"));
-			Assert.IsNotNull(project.AdditionalPropertyGroups[2].Attribute("Condition"));
-			Assert.IsNull(project.AdditionalPropertyGroups[3].Attribute("Condition"));
+			foreach (var propertyGroup in project.AdditionalPropertyGroups)
+			{
+				Assert.IsNotNull(propertyGroup.Attribute("Condition"));
+			}
 
 			var childrenDebug = project.AdditionalPropertyGroups[0].Elements().ToImmutableArray();
 			Assert.AreEqual(0, childrenDebug.Length);
@@ -255,7 +257,7 @@ namespace Project2015To2017Tests
 			// check we are keeping original slashes and replacing configuration name with $(Configuration)
 			Assert.AreEqual(@"bin/$(Configuration)\", childrenReleaseCI.First(x => x.Name.LocalName == "OutputPath").Value);
 
-			var childrenGlobal = project.AdditionalPropertyGroups[3].Elements().ToImmutableArray();
+			var childrenGlobal = project.PrimaryPropertyGroup.Elements().ToImmutableArray();
 			Assert.AreEqual(0, childrenGlobal.Length);
 		}
 

--- a/Project2015To2017Tests/XamlTransformationTest.cs
+++ b/Project2015To2017Tests/XamlTransformationTest.cs
@@ -89,7 +89,7 @@ namespace Project2015To2017Tests
 			Assert.AreEqual(1, project.Platforms.Count);
 			Assert.AreEqual(1, project.Platforms.Count(x => x == "AnyCPU"));
 
-			Assert.AreEqual(3, project.AdditionalPropertyGroups.Count);
+			Assert.AreEqual(2, project.AdditionalPropertyGroups.Count);
 
 			var transformation = new XamlPagesTransformation();
 


### PR DESCRIPTION
* Add `PrimaryPropertyGroup` property to `Project` model (stores the only unconditional `PropertyGroup`)
* Add `PrimaryUnconditionalPropertyTransformation` that takes care of the properties in unconditional `PropertyGroup`.
* Move primary property group logic to the newly created transformation
* Try harder at preserving original XML structure
* Make `ProjectPropertiesReader` non-static (like other readers), initialized with logger
* Remove unneeded arguments (like `XElement` when `Definition.Project` is already a parameter)
* Improve `FileTransformation` to be more correct
* Update `SdkExtrasVersion` to `MSBuild.Sdk.Extras/1.6.47`
* Reduce code duplication by moving helpers to Helpers (a surprise for sure, but a welcome one)
* Refactor `PropertySimplificationTransformation` to simplify the code and take other changes into account
* Allow CPS project writing
* Adapt tests to the changes
* Fix `FileTransformationTest` file indentation
* Remove the necessity of `FileTransformation` for CPS projects

Progress for #154.