### PR TITLE
More assembly info filtering

### DIFF
--- a/Project2015To2017/Definition/AssemblyAttributes.cs
+++ b/Project2015To2017/Definition/AssemblyAttributes.cs
@@ -3,6 +3,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Resources;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -60,6 +61,12 @@ namespace Project2015To2017.Definition
 		{
 			get => GetAttribute(typeof(AssemblyCultureAttribute));
 			set => SetAttribute(typeof(AssemblyCultureAttribute), value);
+		}
+
+		public string NeutralLanguage
+		{
+			get => GetAttribute(typeof(NeutralResourcesLanguageAttribute));
+			set => SetAttribute(typeof(NeutralResourcesLanguageAttribute), value);
 		}
 
 		public string Configuration {

--- a/Project2015To2017/Definition/AssemblyAttributes.cs
+++ b/Project2015To2017/Definition/AssemblyAttributes.cs
@@ -50,6 +50,18 @@ namespace Project2015To2017.Definition
 			set => SetAttribute(typeof(AssemblyDescriptionAttribute), value);
 		}
 
+		public string Trademark
+		{
+			get => GetAttribute(typeof(AssemblyTrademarkAttribute));
+			set => SetAttribute(typeof(AssemblyTrademarkAttribute), value);
+		}
+
+		public string Culture
+		{
+			get => GetAttribute(typeof(AssemblyCultureAttribute));
+			set => SetAttribute(typeof(AssemblyCultureAttribute), value);
+		}
+
 		public string Configuration {
 			get => GetAttribute(typeof(AssemblyConfigurationAttribute));
 			set => SetAttribute(typeof(AssemblyConfigurationAttribute), value);

--- a/Project2015To2017/Transforms/AssemblyAttributeTransformation.cs
+++ b/Project2015To2017/Transforms/AssemblyAttributeTransformation.cs
@@ -99,13 +99,13 @@ namespace Project2015To2017.Transforms
 
 			var toReturn = new[]
 			{
-				CreateElementIfNotNull(assemblyAttributes.Title, "AssemblyTitle"),
-				CreateElementIfNotNull(assemblyAttributes.Company, "Company"),
-				CreateElementIfNotNull(assemblyAttributes.Product, "Product"),
+				CreateElementIfNotNullOrEmpty(assemblyAttributes.Title, "AssemblyTitle"),
+				CreateElementIfNotNullOrEmpty(assemblyAttributes.Company, "Company"),
+				CreateElementIfNotNullOrEmpty(assemblyAttributes.Product, "Product"),
 
 				//And a couple of properties which can be superceded by the package config
-				CreateElementIfNotNull(assemblyAttributes.Description, packageConfig?.Description, "Description", logger),
-				CreateElementIfNotNull(assemblyAttributes.Copyright, packageConfig?.Copyright, "Copyright", logger),
+				CreateElementIfNotNullOrEmpty(assemblyAttributes.Description, packageConfig?.Description, "Description", logger),
+				CreateElementIfNotNullOrEmpty(assemblyAttributes.Copyright, packageConfig?.Copyright, "Copyright", logger),
 
 
 				!configCanBeStripped
@@ -131,7 +131,7 @@ namespace Project2015To2017.Transforms
 			return toReturn;
 		}
 
-		private static XElement CreateElementIfNotNull(string assemblyInfoValue, string packageConfigValue, string description, ILogger logger)
+		private static XElement CreateElementIfNotNullOrEmpty(string assemblyInfoValue, string packageConfigValue, string description, ILogger logger)
 		{
 			if (packageConfigValue != null && packageConfigValue != assemblyInfoValue)
 			{
@@ -142,11 +142,11 @@ namespace Project2015To2017.Transforms
 						$"over AssemblyInfo value {assemblyInfoValue}");
 				}
 
-				return CreateElementIfNotNull(packageConfigValue, description);
+				return CreateElementIfNotNullOrEmpty(packageConfigValue, description);
 			}
 			else
 			{
-				return CreateElementIfNotNull(assemblyInfoValue, description);
+				return CreateElementIfNotNullOrEmpty(assemblyInfoValue, description);
 			}
 		}
 
@@ -155,12 +155,12 @@ namespace Project2015To2017.Transforms
 		{
 			var toReturn = new[]
 			{
-				CreateElementIfNotNull(assemblyAttributes.InformationalVersion, packageConfig?.Version, "Version", logger),
-				CreateElementIfNotNull(assemblyAttributes.Version, "AssemblyVersion"),
+				CreateElementIfNotNullOrEmpty(assemblyAttributes.InformationalVersion, packageConfig?.Version, "Version", logger),
+				CreateElementIfNotNullOrEmpty(assemblyAttributes.Version, "AssemblyVersion"),
 
 				//The AssemblyInfo behaviour was to fallback on the AssemblyVersion for the file version
 				//but in the new format, this doesn't happen so we explicitly copy the value across
-				CreateElementIfNotNull(assemblyAttributes.FileVersion, "FileVersion") ?? CreateElementIfNotNull(assemblyAttributes.Version, "FileVersion")
+				CreateElementIfNotNullOrEmpty(assemblyAttributes.FileVersion, "FileVersion") ?? CreateElementIfNotNullOrEmpty(assemblyAttributes.Version, "FileVersion")
 			}.Where(x => x != null).ToArray();
 
 			assemblyAttributes.InformationalVersion = null;
@@ -170,9 +170,9 @@ namespace Project2015To2017.Transforms
 			return toReturn;
 		}
 
-		private static XElement CreateElementIfNotNull(string attribute, string name)
+		private static XElement CreateElementIfNotNullOrEmpty(string attribute, string name)
 		{
-			return attribute != null ? new XElement(name, attribute) : null;
+			return !string.IsNullOrEmpty(attribute) ? new XElement(name, attribute) : null;
 		}
 	}
 }

--- a/Project2015To2017/Transforms/AssemblyAttributeTransformation.cs
+++ b/Project2015To2017/Transforms/AssemblyAttributeTransformation.cs
@@ -47,14 +47,14 @@ namespace Project2015To2017.Transforms
 			{
 				definition.Deletions = definition
 					.Deletions
-					.Concat(new[] { definition.AssemblyAttributes.File })
+					.Concat(new[] {definition.AssemblyAttributes.File})
 					.ToArray();
 
 				if (AssemblyInfoFolderJustAssemblyInfo(definition.AssemblyAttributes))
 				{
 					definition.Deletions = definition
 						.Deletions
-						.Concat(new[] { definition.AssemblyAttributes.File.Directory })
+						.Concat(new[] {definition.AssemblyAttributes.File.Directory})
 						.ToArray();
 				}
 			}
@@ -95,6 +95,8 @@ namespace Project2015To2017.Transforms
 
 		private static IReadOnlyList<XElement> OtherProperties(AssemblyAttributes assemblyAttributes, PackageConfiguration packageConfig, ILogger logger)
 		{
+			var configCanBeStripped = string.IsNullOrEmpty(assemblyAttributes.Configuration);
+
 			var toReturn = new[]
 			{
 				CreateElementIfNotNull(assemblyAttributes.Title, "AssemblyTitle"),
@@ -104,8 +106,8 @@ namespace Project2015To2017.Transforms
 				//And a couple of properties which can be superceded by the package config
 				CreateElementIfNotNull(assemblyAttributes.Description, packageConfig?.Description, "Description", logger),
 				CreateElementIfNotNull(assemblyAttributes.Copyright, packageConfig?.Copyright, "Copyright", logger),
-
-				assemblyAttributes.Configuration != null
+				
+				!configCanBeStripped
 					?
 					//If it is included, chances are that the developer has used
 					//preprocessor flags which we can't yet process
@@ -119,6 +121,11 @@ namespace Project2015To2017.Transforms
 			assemblyAttributes.Description = null;
 			assemblyAttributes.Product = null;
 			assemblyAttributes.Copyright = null;
+
+			if (configCanBeStripped)
+			{
+				assemblyAttributes.Configuration = null;
+			}
 
 			return toReturn;
 		}

--- a/Project2015To2017/Transforms/AssemblyAttributeTransformation.cs
+++ b/Project2015To2017/Transforms/AssemblyAttributeTransformation.cs
@@ -106,7 +106,8 @@ namespace Project2015To2017.Transforms
 				//And a couple of properties which can be superceded by the package config
 				CreateElementIfNotNull(assemblyAttributes.Description, packageConfig?.Description, "Description", logger),
 				CreateElementIfNotNull(assemblyAttributes.Copyright, packageConfig?.Copyright, "Copyright", logger),
-				
+
+
 				!configCanBeStripped
 					?
 					//If it is included, chances are that the developer has used
@@ -145,7 +146,7 @@ namespace Project2015To2017.Transforms
 			}
 			else
 			{
-				return assemblyInfoValue == null ? null : CreateElementIfNotNull(assemblyInfoValue, description);
+				return CreateElementIfNotNull(assemblyInfoValue, description);
 			}
 		}
 

--- a/Project2015To2017/Transforms/AssemblyAttributeTransformation.cs
+++ b/Project2015To2017/Transforms/AssemblyAttributeTransformation.cs
@@ -102,6 +102,7 @@ namespace Project2015To2017.Transforms
 				CreateElementIfNotNullOrEmpty(assemblyAttributes.Title, "AssemblyTitle"),
 				CreateElementIfNotNullOrEmpty(assemblyAttributes.Company, "Company"),
 				CreateElementIfNotNullOrEmpty(assemblyAttributes.Product, "Product"),
+				CreateElementIfNotNullOrEmpty(assemblyAttributes.NeutralLanguage, "NeutralLanguage"),
 
 
 				//And a couple of properties which can be superceded by the package config
@@ -122,6 +123,7 @@ namespace Project2015To2017.Transforms
 			assemblyAttributes.Description = null;
 			assemblyAttributes.Product = null;
 			assemblyAttributes.Copyright = null;
+			assemblyAttributes.NeutralLanguage = null;
 
 			if (assemblyAttributes.Culture == string.Empty)
 			{

--- a/Project2015To2017/Transforms/AssemblyAttributeTransformation.cs
+++ b/Project2015To2017/Transforms/AssemblyAttributeTransformation.cs
@@ -103,10 +103,10 @@ namespace Project2015To2017.Transforms
 				CreateElementIfNotNullOrEmpty(assemblyAttributes.Company, "Company"),
 				CreateElementIfNotNullOrEmpty(assemblyAttributes.Product, "Product"),
 
+
 				//And a couple of properties which can be superceded by the package config
 				CreateElementIfNotNullOrEmpty(assemblyAttributes.Description, packageConfig?.Description, "Description", logger),
 				CreateElementIfNotNullOrEmpty(assemblyAttributes.Copyright, packageConfig?.Copyright, "Copyright", logger),
-
 
 				!configCanBeStripped
 					?
@@ -122,6 +122,16 @@ namespace Project2015To2017.Transforms
 			assemblyAttributes.Description = null;
 			assemblyAttributes.Product = null;
 			assemblyAttributes.Copyright = null;
+
+			if (assemblyAttributes.Culture == string.Empty)
+			{
+				assemblyAttributes.Culture = null;
+			}
+
+			if (assemblyAttributes.Trademark == string.Empty)
+			{
+				assemblyAttributes.Trademark = null;
+			}
 
 			if (configCanBeStripped)
 			{

--- a/Project2015To2017Tests/AssemblyAttributeTransformationTest.cs
+++ b/Project2015To2017Tests/AssemblyAttributeTransformationTest.cs
@@ -26,7 +26,9 @@ namespace Project2015To2017Tests
 				Version = "1.0.4.2",
 				Product = "The Product",
 				Title = "The Title",
-				File = new FileInfo("DummyAssemblyInfo.cs")
+				File = new FileInfo("DummyAssemblyInfo.cs"),
+				Trademark = "A trademark",
+				Culture = "A culture"
 			};
 
 		[TestMethod]
@@ -47,7 +49,7 @@ namespace Project2015To2017Tests
 			Assert.IsNotNull(generateAssemblyInfo);
 			Assert.AreEqual("GenerateAssemblyInfo", generateAssemblyInfo.Name);
 			Assert.AreEqual("false", generateAssemblyInfo.Value);
-			
+
 			CollectionAssert.DoesNotContain(project.Deletions?.ToList(), BaseAssemblyAttributes().File);
 		}
 
@@ -62,7 +64,7 @@ namespace Project2015To2017Tests
 			};
 
 			var transform = new AssemblyAttributeTransformation(true);
-			
+
 			transform.Transform(project, NoopLogger.Instance);
 
 			var generateAssemblyInfo = project.AssemblyAttributeProperties.SingleOrDefault();
@@ -108,12 +110,14 @@ namespace Project2015To2017Tests
 			CollectionAssert.AreEquivalent(expectedProperties, actualProperties);
 
 			var expectedAttributes = new AssemblyAttributes
-									{
-										Configuration = "SomeConfiguration"
-									};
+			{
+				Configuration = "SomeConfiguration",
+				Trademark = "A trademark",
+				Culture = "A culture"
+			};
 
 			Assert.IsTrue(expectedAttributes.Equals(project.AssemblyAttributes));
-			
+
 			CollectionAssert.DoesNotContain(project.Deletions?.ToList(), BaseAssemblyAttributes().File);
 		}
 
@@ -124,6 +128,8 @@ namespace Project2015To2017Tests
 			baseAssemblyAttributes.Company = "";
 			baseAssemblyAttributes.Copyright = "";
 			baseAssemblyAttributes.Description = "";
+			baseAssemblyAttributes.Trademark = "";
+			baseAssemblyAttributes.Culture = "";
 
 			var project = new Project
 			{
@@ -159,11 +165,11 @@ namespace Project2015To2017Tests
 			};
 
 			Assert.IsTrue(expectedAttributes.Equals(project.AssemblyAttributes));
-			
+
 			CollectionAssert.DoesNotContain(project.Deletions?.ToList(), BaseAssemblyAttributes().File);
 		}
 
-		
+
 		[TestMethod]
 		public void BlankConfigurationGetsDeleted()
 		{
@@ -202,8 +208,8 @@ namespace Project2015To2017Tests
 
 			var expectedAttributes = new AssemblyAttributes();
 
-			Assert.IsTrue(expectedAttributes.Equals(project.AssemblyAttributes));
-			
+			Assert.IsNull(project.AssemblyAttributes.Configuration);
+
 			CollectionAssert.DoesNotContain(project.Deletions?.ToList(), BaseAssemblyAttributes().File);
 		}
 
@@ -245,7 +251,7 @@ namespace Project2015To2017Tests
 			var expectedAttributes = new AssemblyAttributes();
 
 			Assert.IsTrue(expectedAttributes.Equals(project.AssemblyAttributes));
-			
+
 			CollectionAssert.DoesNotContain(project.Deletions?.ToList(), BaseAssemblyAttributes().File);
 		}
 
@@ -291,7 +297,9 @@ namespace Project2015To2017Tests
 
 			var expectedAttributes = new AssemblyAttributes
 			{
-				Configuration = "SomeConfiguration"
+				Configuration = "SomeConfiguration",
+				Trademark = "A trademark",
+				Culture = "A culture"
 			};
 
 			Assert.IsTrue(expectedAttributes.Equals(project.AssemblyAttributes));
@@ -316,7 +324,7 @@ namespace Project2015To2017Tests
 
 			transform.Transform(project, NoopLogger.Instance);
 
-		    CollectionAssert.Contains(project.Deletions.ToList(), assemblyInfoFile);
+			CollectionAssert.Contains(project.Deletions.ToList(), assemblyInfoFile);
 		}
 
 		[TestMethod]

--- a/Project2015To2017Tests/AssemblyAttributeTransformationTest.cs
+++ b/Project2015To2017Tests/AssemblyAttributeTransformationTest.cs
@@ -117,6 +117,52 @@ namespace Project2015To2017Tests
 			CollectionAssert.DoesNotContain(project.Deletions?.ToList(), BaseAssemblyAttributes().File);
 		}
 
+		[TestMethod]
+		public void BlankEntriesGetDeleted()
+		{
+			var baseAssemblyAttributes = BaseAssemblyAttributes();
+			baseAssemblyAttributes.Company = "";
+			baseAssemblyAttributes.Copyright = "";
+			baseAssemblyAttributes.Description = "";
+
+			var project = new Project
+			{
+				AssemblyAttributes = baseAssemblyAttributes,
+				Deletions = new List<FileSystemInfo>()
+			};
+
+			var transform = new AssemblyAttributeTransformation();
+
+			transform.Transform(project, NoopLogger.Instance);
+
+			var expectedProperties = new[]
+				{
+					new XElement("AssemblyTitle", "The Title"),
+					new XElement("Product", "The Product"),
+					new XElement("GenerateAssemblyConfigurationAttribute", false),
+					new XElement("Version", "1.8.4.3-beta.1"),
+					new XElement("AssemblyVersion", "1.0.4.2"),
+					new XElement("FileVersion", "1.1.7.9")
+				}
+				.Select(x => x.ToString())
+				.ToList();
+
+			var actualProperties = project.AssemblyAttributeProperties
+				.Select(x => x.ToString())
+				.ToList();
+
+			CollectionAssert.AreEquivalent(expectedProperties, actualProperties);
+
+			var expectedAttributes = new AssemblyAttributes
+			{
+				Configuration = "SomeConfiguration"
+			};
+
+			Assert.IsTrue(expectedAttributes.Equals(project.AssemblyAttributes));
+			
+			CollectionAssert.DoesNotContain(project.Deletions?.ToList(), BaseAssemblyAttributes().File);
+		}
+
 		
 		[TestMethod]
 		public void BlankConfigurationGetsDeleted()

--- a/Project2015To2017Tests/AssemblyAttributeTransformationTest.cs
+++ b/Project2015To2017Tests/AssemblyAttributeTransformationTest.cs
@@ -28,7 +28,8 @@ namespace Project2015To2017Tests
 				Title = "The Title",
 				File = new FileInfo("DummyAssemblyInfo.cs"),
 				Trademark = "A trademark",
-				Culture = "A culture"
+				Culture = "A culture",
+				NeutralLanguage = "someLanguage"
 			};
 
 		[TestMethod]
@@ -98,7 +99,8 @@ namespace Project2015To2017Tests
 				new XElement("GenerateAssemblyConfigurationAttribute", false),
 				new XElement("Version", "1.8.4.3-beta.1"),
 				new XElement("AssemblyVersion", "1.0.4.2"),
-				new XElement("FileVersion", "1.1.7.9")
+				new XElement("FileVersion", "1.1.7.9"),
+				new XElement("NeutralLanguage", "someLanguage"),
 			}
 			.Select(x => x.ToString())
 			.ToList();
@@ -130,6 +132,7 @@ namespace Project2015To2017Tests
 			baseAssemblyAttributes.Description = "";
 			baseAssemblyAttributes.Trademark = "";
 			baseAssemblyAttributes.Culture = "";
+			baseAssemblyAttributes.NeutralLanguage = "";
 
 			var project = new Project
 			{
@@ -195,7 +198,8 @@ namespace Project2015To2017Tests
 					new XElement("Copyright", "A Copyright notice  ©"),
 					new XElement("Version", "1.8.4.3-beta.1"),
 					new XElement("AssemblyVersion", "1.0.4.2"),
-					new XElement("FileVersion", "1.1.7.9")
+					new XElement("FileVersion", "1.1.7.9"),
+					new XElement("NeutralLanguage", "someLanguage")
 				}
 				.Select(x => x.ToString())
 				.ToList();
@@ -284,7 +288,8 @@ namespace Project2015To2017Tests
 					new XElement("GenerateAssemblyConfigurationAttribute", false),
 					new XElement("Version", "1.5.2-otherVersion"),
 					new XElement("AssemblyVersion", "1.0.4.2"),
-					new XElement("FileVersion", "1.1.7.9")
+					new XElement("FileVersion", "1.1.7.9"),
+					new XElement("NeutralLanguage", "someLanguage")
 				}
 				.Select(x => x.ToString())
 				.ToList();

--- a/Project2015To2017Tests/AssemblyAttributeTransformationTest.cs
+++ b/Project2015To2017Tests/AssemblyAttributeTransformationTest.cs
@@ -117,6 +117,50 @@ namespace Project2015To2017Tests
 			CollectionAssert.DoesNotContain(project.Deletions?.ToList(), BaseAssemblyAttributes().File);
 		}
 
+		
+		[TestMethod]
+		public void BlankConfigurationGetsDeleted()
+		{
+			var assemblyAttributes = BaseAssemblyAttributes();
+			assemblyAttributes.Configuration = "";
+
+			var project = new Project
+			{
+				AssemblyAttributes = assemblyAttributes,
+				Deletions = new List<FileSystemInfo>()
+			};
+
+			var transform = new AssemblyAttributeTransformation();
+
+			transform.Transform(project, NoopLogger.Instance);
+
+			var expectedProperties = new[]
+				{
+					new XElement("AssemblyTitle", "The Title"),
+					new XElement("Company", "TheCompany Inc."),
+					new XElement("Description", "A description"),
+					new XElement("Product", "The Product"),
+					new XElement("Copyright", "A Copyright notice  ©"),
+					new XElement("Version", "1.8.4.3-beta.1"),
+					new XElement("AssemblyVersion", "1.0.4.2"),
+					new XElement("FileVersion", "1.1.7.9")
+				}
+				.Select(x => x.ToString())
+				.ToList();
+
+			var actualProperties = project.AssemblyAttributeProperties
+				.Select(x => x.ToString())
+				.ToList();
+
+			CollectionAssert.AreEquivalent(expectedProperties, actualProperties);
+
+			var expectedAttributes = new AssemblyAttributes();
+
+			Assert.IsTrue(expectedAttributes.Equals(project.AssemblyAttributes));
+			
+			CollectionAssert.DoesNotContain(project.Deletions?.ToList(), BaseAssemblyAttributes().File);
+		}
+
 		[TestMethod]
 		public void GeneratesAssemblyFileAttributeInCsProj()
 		{


### PR DESCRIPTION
This clears up the following attributes if they are blank:
```csharp
[assembly: AssemblyConfiguration("")]
[assembly: AssemblyTrademark("")]
[assembly: AssemblyCulture("")]
```

It also pulls the `NeutralLanguage` attribute across into the project file if it is present

Fixes #166