### PR TITLE
Last bit of fixes before 2.0 release

### DIFF
--- a/Project2015To2017/Analysis/Diagnostics/W001IllegalProjectTypeDiagnostic.cs
+++ b/Project2015To2017/Analysis/Diagnostics/W001IllegalProjectTypeDiagnostic.cs
@@ -27,8 +27,7 @@ namespace Project2015To2017.Analysis.Diagnostics
 			}
 
 			// try to get project type - may not exist
-			var typeElement = project.ProjectDocument.Descendants(project.XmlNamespace + "ProjectTypeGuids")
-				.FirstOrDefault();
+			var typeElement = project.Property("ProjectTypeGuids");
 			if (typeElement == null)
 			{
 				return Array.Empty<IDiagnosticResult>();

--- a/Project2015To2017/Analysis/Diagnostics/W010ConfigurationsMismatchDiagnostic.cs
+++ b/Project2015To2017/Analysis/Diagnostics/W010ConfigurationsMismatchDiagnostic.cs
@@ -12,9 +12,6 @@ namespace Project2015To2017.Analysis.Diagnostics
 		/// <inheritdoc />
 		public override IReadOnlyList<IDiagnosticResult> Analyze(Project project)
 		{
-			var propertyGroups = project.ProjectDocument.Element(project.XmlNamespace + "Project")
-				.Elements(project.XmlNamespace + "PropertyGroup").ToArray();
-
 			var configurationSet = new HashSet<string>();
 			var platformSet = new HashSet<string>();
 
@@ -81,9 +78,7 @@ namespace Project2015To2017.Analysis.Diagnostics
 
 			return list;
 
-			string[] ParseFromProperty(string name) => propertyGroups.Where(x => x.Attribute("Condition") == null)
-				.Elements(project.XmlNamespace + name)
-				.FirstOrDefault()
+			string[] ParseFromProperty(string name) => project.Property(name)
 				?.Value
 				.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
 		}

--- a/Project2015To2017/Analysis/Diagnostics/W034ReferenceAliasesDiagnostic.cs
+++ b/Project2015To2017/Analysis/Diagnostics/W034ReferenceAliasesDiagnostic.cs
@@ -18,8 +18,9 @@ namespace Project2015To2017.Analysis.Diagnostics
 			{
 				list.Add(
 					CreateDiagnosticResult(project,
-						$"ProjectReference ['{reference.Include}'] aliases are a feature of low support. Consider dropping their usage.",
-						project.FilePath));
+							$"ProjectReference ['{reference.Include}'] aliases are a feature of low support. Consider dropping their usage.",
+							project.FilePath)
+						.LoadLocationFromElement(reference.DefinitionElement));
 			}
 
 			return list;

--- a/Project2015To2017/Definition/Project.cs
+++ b/Project2015To2017/Definition/Project.cs
@@ -32,8 +32,6 @@ namespace Project2015To2017.Definition
 		public IList<string> TargetFrameworks { get; } = new List<string>();
 		public bool AppendTargetFrameworkToOutputPath { get; set; } = true;
 		public ApplicationType Type { get; set; }
-		public string RootNamespace { get; set; }
-		public string AssemblyName { get; set; }
 		public FileInfo FilePath { get; set; }
 		public DirectoryInfo ProjectFolder => this.FilePath.Directory;
 

--- a/Project2015To2017/Definition/ProjectReference.cs
+++ b/Project2015To2017/Definition/ProjectReference.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Xml.Linq;
 
@@ -5,11 +6,20 @@ namespace Project2015To2017.Definition
 {
 	public sealed class ProjectReference : IReference
 	{
+		public string ProjectName { get; set; }
+		public Guid ProjectGuid { get; set; }
+		public string ProjectTypeGuid { get; set; }
+
 		public string Include { get; set; }
 		public string Aliases { get; set; }
 		public bool EmbedInteropTypes { get; set; }
 
 		public FileInfo ProjectFile { get; set; }
 		public XElement DefinitionElement { get; set; }
+
+		/// <summary>
+		/// Extension of the project file, if any
+		/// </summary>
+		public string Extension => ProjectFile?.Extension ?? Path.GetExtension(Include);
 	}
 }

--- a/Project2015To2017/Extensions.cs
+++ b/Project2015To2017/Extensions.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
 using System.Xml.Linq;
 
 namespace Project2015To2017
@@ -126,6 +128,106 @@ namespace Project2015To2017
 						where (!a.IsNamespaceDeclaration)
 						select new XAttribute(a.Name.LocalName, a.Value))
 					: null);
+		}
+
+		/// <summary>
+		/// If on Unix, convert backslashes to slashes for strings that resemble paths.
+		/// The heuristic is if something resembles paths (contains slashes) check if the
+		/// first segment exists and is a directory.
+		/// Use a native shared method to massage file path. If the file is adjusted,
+		/// that qualifies is as a path.
+		///
+		/// @baseDirectory is just passed to LooksLikeUnixFilePath, to help with the check
+		/// </summary>
+		public static string MaybeAdjustFilePath(string value, string baseDirectory = "")
+		{
+			const StringComparison comparisonType = StringComparison.Ordinal;
+
+			// Don't bother with arrays or properties or network paths, or those that
+			// have no slashes.
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+			    || string.IsNullOrEmpty(value)
+			    || value.StartsWith("$(", comparisonType) || value.StartsWith("@(", comparisonType)
+			    || value.StartsWith("\\\\", comparisonType))
+			{
+				return value;
+			}
+
+			// For Unix-like systems, we may want to convert backslashes to slashes
+			var newValue = ConvertToUnixSlashes(value);
+
+			// Find the part of the name we want to check, that is remove quotes, if present
+			var shouldAdjust = newValue.IndexOf('/') != -1 &&
+			                   LooksLikeUnixFilePath(RemoveQuotes(newValue), baseDirectory);
+			return shouldAdjust ? newValue : value;
+		}
+
+		private static string ConvertToUnixSlashes(string path)
+		{
+			if (path.IndexOf('\\') == -1)
+			{
+				return path;
+			}
+
+			var unixPath = new StringBuilder(path.Length);
+			CopyAndCollapseSlashes(path, unixPath);
+			return unixPath.ToString();
+		}
+
+		private static void CopyAndCollapseSlashes(string str, StringBuilder copy)
+		{
+			// Performs Regex.Replace(str, @"[\\/]+", "/")
+			for (var i = 0; i < str.Length; i++)
+			{
+				var isCurSlash = IsAnySlash(str[i]);
+				var isPrevSlash = i > 0 && IsAnySlash(str[i - 1]);
+
+				if (!isCurSlash || !isPrevSlash)
+				{
+					copy.Append(str[i] == '\\' ? '/' : str[i]);
+				}
+			}
+		}
+
+		private static string RemoveQuotes(string path)
+		{
+			var endId = path.Length - 1;
+			const char singleQuote = '\'';
+			const char doubleQuote = '\"';
+
+			var hasQuotes = path.Length > 2
+			                 && (path[0] == singleQuote && path[endId] == singleQuote
+			                     || path[0] == doubleQuote && path[endId] == doubleQuote);
+
+			return hasQuotes ? path.Substring(1, endId - 1) : path;
+		}
+
+		private static bool IsAnySlash(char c) => c == '/' || c == '\\';
+
+		/// <summary>
+		/// If on Unix, check if the string looks like a file path.
+		/// The heuristic is if something resembles paths (contains slashes) check if the
+		/// first segment exists and is a directory.
+		///
+		/// If @baseDirectory is not null, then look for the first segment exists under
+		/// that
+		/// </summary>
+		private static bool LooksLikeUnixFilePath(string value, string baseDirectory = "")
+		{
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				return false;
+			}
+
+			// The first slash will either be at the beginning of the string or after the first directory name
+			var directoryLength = value.IndexOf('/', 1) + 1;
+			var shouldCheckDirectory = directoryLength != 0;
+
+			// Check for actual files or directories under / that get missed by the above logic
+			var shouldCheckFileOrDirectory = !shouldCheckDirectory && value.Length > 0 && value[0] == '/';
+
+			return shouldCheckDirectory && Directory.Exists(Path.Combine(baseDirectory, value.Substring(0, directoryLength)))
+			       || shouldCheckFileOrDirectory && (File.Exists(value) || Directory.Exists(value));
 		}
 	}
 }

--- a/Project2015To2017/Reading/AssemblyInfoReader.cs
+++ b/Project2015To2017/Reading/AssemblyInfoReader.cs
@@ -26,6 +26,8 @@ namespace Project2015To2017.Reading
 										 .SelectMany(x => x.Descendants(project.XmlNamespace + "Compile"))
 										 .ToList();
 
+			var missingCount = 0u;
+
 			var assemblyInfoFiles = compileElements
 										   .Attributes("Include")
 										   .Select(x => x.Value.ToString())
@@ -43,6 +45,8 @@ namespace Project2015To2017.Reading
 													{
 														return true;
 													}
+
+													missingCount++;
 													this.logger.LogWarning($@"AssemblyInfo file '{x.FullName}' not found");
 													return false;
 												}
@@ -56,7 +60,7 @@ namespace Project2015To2017.Reading
 				return null;
 			}
 
-			if (assemblyInfoFiles.Count > 1)
+			if (assemblyInfoFiles.Count + missingCount > 1)
 			{
 				var fileList = string.Join($",{Environment.NewLine}", assemblyInfoFiles.Select(x => x.FullName));
 				this.logger.LogWarning($@"Could not read from assemblyinfo, multiple assemblyinfo files found:{Environment.NewLine}{fileList}");

--- a/Project2015To2017/Reading/ConditionEvaluator.cs
+++ b/Project2015To2017/Reading/ConditionEvaluator.cs
@@ -113,15 +113,21 @@ namespace Project2015To2017.Reading
 
 		public static Dictionary<string, string> GetNonAmbiguousConditionContracts(string condition)
 		{
+			var state = GetConditionState(condition);
+			return GetNonAmbiguousConditionContracts(state);
+		}
+
+		public static Dictionary<string, string> GetNonAmbiguousConditionContracts(ConditionEvaluationStateImpl state)
+		{
 			var res = new Dictionary<string, string>();
 
 			// it makes little sense for condition to be that short
-			if (condition.Length < 2)
+			if (state.Condition.Length < 2)
 			{
 				return res;
 			}
 
-			foreach (var keyValuePair in GetConditionValues(condition))
+			foreach (var keyValuePair in GetConditionValues(state))
 			{
 				if (keyValuePair.Value.Count != 1)
 				{
@@ -137,6 +143,11 @@ namespace Project2015To2017.Reading
 		public static Dictionary<string, List<string>> GetConditionValues(string condition)
 		{
 			var state = GetConditionState(condition);
+			return GetConditionValues(state);
+		}
+
+		public static Dictionary<string, List<string>> GetConditionValues(ConditionEvaluationStateImpl state)
+		{
 			if (state.Evaluated)
 			{
 				return state.ConditionedPropertiesInProject;

--- a/Project2015To2017/Reading/ProjectPropertiesReader.cs
+++ b/Project2015To2017/Reading/ProjectPropertiesReader.cs
@@ -28,9 +28,6 @@ namespace Project2015To2017.Reading
 		{
 			ReadPropertyGroups(project);
 
-			project.RootNamespace = project.Property("RootNamespace", tryConditional: true)?.Value;
-			project.AssemblyName = project.Property("AssemblyName", tryConditional: true)?.Value;
-
 			var targetFrameworkVersion = project.Property("TargetFrameworkVersion")?.Value;
 			if (targetFrameworkVersion != null)
 			{
@@ -145,7 +142,7 @@ namespace Project2015To2017.Reading
 				.Split(new[] {';'}, StringSplitOptions.RemoveEmptyEntries);
 		}
 
-		private static void ReadPropertyGroups(Project project)
+		internal static void ReadPropertyGroups(Project project)
 		{
 			project.PropertyGroups = project.ProjectDocument.Root
 				.Elements(project.XmlNamespace + "PropertyGroup")

--- a/Project2015To2017/Reading/SolutionReader.cs
+++ b/Project2015To2017/Reading/SolutionReader.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Project2015To2017.Definition;
 
@@ -11,6 +11,31 @@ namespace Project2015To2017.Reading
 	{
 		public static readonly SolutionReader Instance = new SolutionReader();
 
+		// An example of a project line looks like this:
+		//  Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassLibrary1", "ClassLibrary1\ClassLibrary1.csproj", "{05A5AD00-71B5-4612-AF2F-9EA9121C4111}"
+		private static readonly Lazy<Regex> crackProjectLine = new Lazy<Regex>(
+			() => new Regex
+			(
+				"^" // Beginning of line
+				+ "Project\\(\"(?<PROJECTTYPEGUID>.*)\"\\)"
+				+ "\\s*=\\s*" // Any amount of whitespace plus "=" plus any amount of whitespace
+				+ "\"(?<PROJECTNAME>.*)\""
+				+ "\\s*,\\s*" // Any amount of whitespace plus "," plus any amount of whitespace
+				+ "\"(?<RELATIVEPATH>.*)\""
+				+ "\\s*,\\s*" // Any amount of whitespace plus "," plus any amount of whitespace
+				+ "\"(?<PROJECTGUID>.*)\""
+				+ "$", // End-of-line
+				RegexOptions.Compiled
+			)
+		);
+
+		private const string vbProjectGuid = "{F184B08F-C81C-45F6-A57F-5ABD9991F28F}";
+		private const string csProjectGuid = "{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}";
+		private const string cpsProjectGuid = "{13B669BE-BB05-4DDF-9536-439F39A36129}";
+		private const string cpsCsProjectGuid = "{9A19103F-16F7-4668-BE54-9A1E7A4F7556}";
+		private const string cpsVbProjectGuid = "{778DAE3C-4631-46EA-AA77-85C1314464D9}";
+		private const string fsProjectGuid = "{F2A71F9B-5D33-465A-A702-920D77279786}";
+
 		public Solution Read(string filePath)
 		{
 			return Read(filePath, NoopLogger.Instance);
@@ -18,6 +43,11 @@ namespace Project2015To2017.Reading
 
 		public Solution Read(string filePath, ILogger logger)
 		{
+			if (string.IsNullOrWhiteSpace(filePath))
+			{
+				throw new ArgumentException("Value cannot be null or whitespace.", nameof(filePath));
+			}
+
 			var fileInfo = new FileInfo(filePath);
 			var projectPaths = new List<ProjectReference>();
 			using (var reader = new StreamReader(fileInfo.OpenRead()))
@@ -25,21 +55,30 @@ namespace Project2015To2017.Reading
 				string line;
 				while ((line = reader.ReadLine()) != null)
 				{
-					if (!line.Trim().StartsWith("Project(", StringComparison.Ordinal))
+					line = line.Trim();
+					if (!line.StartsWith("Project(", StringComparison.Ordinal))
 					{
 						continue;
 					}
 
-					var projectPath = line.Split('"').FirstOrDefault(x => x.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase));
-					if (projectPath != null)
+					if (!ParseFirstProjectLine(line,
+						out var projectTypeGuid, out var projectName, out var path, out var projectGuid))
 					{
-						var reference = new ProjectReference
-						{
-							Include = projectPath,
-							ProjectFile = new FileInfo(Path.Combine(fileInfo.Directory.FullName, projectPath)),
-						};
-						projectPaths.Add(reference);
+						logger.LogWarning("Unsupported project[{Name}] type {Type}", projectName, projectTypeGuid);
+						continue;
 					}
+
+					var adjustedPath = Extensions.MaybeAdjustFilePath(path, fileInfo.DirectoryName);
+					var reference = new ProjectReference
+					{
+						Include = path,
+						ProjectFile = new FileInfo(Path.Combine(fileInfo.DirectoryName, adjustedPath)),
+						ProjectGuid = Guid.Parse(projectGuid),
+						ProjectTypeGuid = projectTypeGuid,
+						ProjectName = projectName
+					};
+
+					projectPaths.Add(reference);
 				}
 			}
 
@@ -50,6 +89,45 @@ namespace Project2015To2017.Reading
 			};
 
 			return solutionDefinition;
+		}
+
+		/// <summary>
+		/// Parse the first line of a Project section of a solution file. This line should look like:
+		///
+		///  Project("{Project type GUID}") = "Project name", "Relative path to project file", "{Project GUID}"
+		///
+		/// </summary>
+		/// <returns>true if project type is supported by csproj-to-2017</returns>
+		private bool ParseFirstProjectLine(string firstLine,
+			out string projectTypeGuid,
+			out string projectName,
+			out string path,
+			out string projectGuid)
+		{
+			var match = crackProjectLine.Value.Match(firstLine);
+			if (!match.Success)
+			{
+				throw new ArgumentException("Invalid Project definition line format", nameof(firstLine));
+			}
+
+			projectTypeGuid = match.Groups["PROJECTTYPEGUID"].Value.Trim();
+			projectName = match.Groups["PROJECTNAME"].Value.Trim();
+			path = match.Groups["RELATIVEPATH"].Value.Trim();
+			projectGuid = match.Groups["PROJECTGUID"].Value.Trim();
+
+			// If the project name is empty (as in some bad solutions) set it to some generated generic value.
+			// This allows us to at least generate reasonable target names etc. instead of crashing.
+			if (string.IsNullOrEmpty(projectName))
+			{
+				projectName = "EmptyProjectName." + Guid.NewGuid();
+			}
+
+			return (string.Compare(projectTypeGuid, vbProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
+			       (string.Compare(projectTypeGuid, csProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
+			       (string.Compare(projectTypeGuid, cpsProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
+			       (string.Compare(projectTypeGuid, cpsCsProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
+			       (string.Compare(projectTypeGuid, cpsVbProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
+			       (string.Compare(projectTypeGuid, fsProjectGuid, StringComparison.OrdinalIgnoreCase) == 0);
 		}
 	}
 }

--- a/Project2015To2017/Transforms/EmptyGroupRemoveTransformation.cs
+++ b/Project2015To2017/Transforms/EmptyGroupRemoveTransformation.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+using Microsoft.Extensions.Logging;
+using Project2015To2017.Definition;
+
+namespace Project2015To2017.Transforms
+{
+	public class EmptyGroupRemoveTransformation : ITransformation
+	{
+		public void Transform(Project definition, ILogger logger)
+		{
+			definition.PropertyGroups = FilterNonEmpty(definition.PropertyGroups);
+			definition.ItemGroups = FilterNonEmpty(definition.ItemGroups).ToList();
+		}
+
+		private static IReadOnlyList<XElement> FilterNonEmpty(IEnumerable<XElement> groups)
+		{
+			var (keep, remove) = groups
+				.Split(x => x.HasElements
+				            || (x.HasAttributes && x.Attributes().Any(a => a.Name.LocalName != "Condition")));
+			foreach (var element in remove)
+			{
+				element.Remove();
+			}
+
+			return keep;
+		}
+	}
+}

--- a/Project2015To2017/Transforms/NuGetPackageTransformation.cs
+++ b/Project2015To2017/Transforms/NuGetPackageTransformation.cs
@@ -14,8 +14,8 @@ namespace Project2015To2017.Transforms
 			{
 				return;
 			}
-			
-			var packageConfig = PopulatePlaceHolders(definition.PackageConfiguration, definition);
+
+			var packageConfig = PopulatePlaceHolders(definition);
 
 			ConstrainPackageReferences(definition.PackageReferences, packageConfig);
 
@@ -47,8 +47,9 @@ namespace Project2015To2017.Transforms
 			}
 		}
 
-		private PackageConfiguration PopulatePlaceHolders(PackageConfiguration rawPackageConfig, Project project)
+		private PackageConfiguration PopulatePlaceHolders(Project project)
 		{
+			var rawPackageConfig = project.PackageConfiguration;
 			var assemblyAttributes = project.AssemblyAttributes;
 
 			return new PackageConfiguration
@@ -76,10 +77,8 @@ namespace Project2015To2017.Transforms
 			{
 				return assemblyAttributeValue ?? nuSpecValue;
 			}
-			else
-			{
-				return nuSpecValue;
-			}
+
+			return nuSpecValue;
 		}
 	}
 }

--- a/Project2015To2017/Transforms/PrimaryUnconditionalPropertyTransformation.cs
+++ b/Project2015To2017/Transforms/PrimaryUnconditionalPropertyTransformation.cs
@@ -27,12 +27,6 @@ namespace Project2015To2017.Transforms
 				if (platforms.Count != 1 || !platforms.Contains("AnyCPU"))
 					project.SetProperty("Platforms", string.Join(";", platforms));
 
-			var outputProjectName = Path.GetFileNameWithoutExtension(project.FilePath.Name);
-
-			project.SetProperty("RootNamespace",
-				project.RootNamespace != outputProjectName ? project.RootNamespace : null);
-			project.SetProperty("AssemblyName",
-				project.AssemblyName != outputProjectName ? project.AssemblyName : null);
 			project.SetProperty("AppendTargetFrameworkToOutputPath",
 				project.AppendTargetFrameworkToOutputPath ? null : "false");
 

--- a/Project2015To2017/Transforms/PropertySimplificationTransformation.cs
+++ b/Project2015To2017/Transforms/PropertySimplificationTransformation.cs
@@ -7,13 +7,33 @@ using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
 using Project2015To2017.Definition;
 using Project2015To2017.Reading;
+using Project2015To2017.Reading.Conditionals;
 
 namespace Project2015To2017.Transforms
 {
 	public sealed class PropertySimplificationTransformation : ITransformation
 	{
+		private static readonly string[] IgnoreProjectNameValues =
+		{
+			"$(MSBuildProjectName)",
+			"$(ProjectName)"
+		};
+
 		public void Transform(Project definition, ILogger logger)
 		{
+			var msbuildProjectName = definition.FilePath?.Name;
+			if (!string.IsNullOrEmpty(msbuildProjectName))
+			{
+				msbuildProjectName = Path.GetFileNameWithoutExtension(msbuildProjectName);
+			}
+			else
+			{
+				// That's actually not what MSBuild does, but it is done to simplify tests
+				// and has a incredibly low probability of being triggered on real projects
+				// (no project file? empty project filename? seriously?)
+				msbuildProjectName = definition.ProjectName;
+			}
+
 			// special case handling for when condition-guarded props override global props not set to their defaults
 			var globalOverrides = new Dictionary<string, string>();
 			foreach (var group in definition.UnconditionalGroups())
@@ -25,19 +45,20 @@ namespace Project2015To2017.Transforms
 			{
 				if (!globalOverrides.TryGetValue("ProjectName", out var projectName))
 					if (!globalOverrides.TryGetValue("AssemblyName", out projectName))
-						projectName = Path.GetFileNameWithoutExtension(definition.FilePath.Name);
+						projectName = msbuildProjectName;
 				definition.ProjectName = projectName;
 			}
 
 			foreach (var propertyGroup in definition.PropertyGroups)
 			{
-				FilterUnneededProperties(definition, propertyGroup, globalOverrides);
+				FilterUnneededProperties(definition, propertyGroup, globalOverrides, msbuildProjectName);
 			}
 		}
 
 		private static void FilterUnneededProperties(Project project,
 			XElement propertyGroup,
-			IDictionary<string, string> globalOverrides)
+			IDictionary<string, string> globalOverrides,
+			string msbuildProjectName)
 		{
 			var removeQueue = new List<XElement>();
 
@@ -74,20 +95,27 @@ namespace Project2015To2017.Transforms
 					? new Regex($@"([\\/]){parentConditionPlatform}([\\/])")
 					: null;
 
-				var childCondition = child.Attribute("Condition");
+				var hasCondition = child.PropertyCondition(out var fullCondition);
+				var fullState = hasCondition ? ConditionEvaluator.GetConditionState(fullCondition) : null;
+
 				switch (tagLocalName)
 				{
 					// VS2013 NuGet bugs workaround
 					case "NuGetPackageImportStamp":
+					// legacy generic properties
+					case "MinimumVisualStudioVersion":
 					// legacy frameworks
 					case "TargetFrameworkIdentifier" when !hasParentCondition:
 					case "TargetFrameworkProfile" when !hasParentCondition && emptyValue:
 					// VCS properties
-					case "SccProjectName" when !hasParentCondition && emptyValue:
-					case "SccLocalPath" when !hasParentCondition && emptyValue:
-					case "SccAuxPath" when !hasParentCondition && emptyValue:
-					case "SccProvider" when !hasParentCondition && emptyValue:
+					case "SccProjectName" when emptyValue:
+					case "SccLocalPath" when emptyValue:
+					case "SccAuxPath" when emptyValue:
+					case "SccProvider" when emptyValue:
 					// Project properties set to defaults (Microsoft.NET.Sdk)
+					case "SolutionDir" when ValidateSolutionDir()
+					                        && valueLower.StartsWith("..")
+					                        && valueLower.Length <= 3:
 					case "OutputType" when ValidateDefaultValue("library"):
 					case "FileAlignment" when ValidateDefaultValue("512"):
 					case "ErrorReport" when ValidateDefaultValue("prompt"):
@@ -116,34 +144,41 @@ namespace Project2015To2017.Transforms
 					case "TargetRuntime" when ValidateDefaultValue("managed"):
 					case "Utf8Output" when ValidateDefaultValue("true"):
 					case "PlatformName" when ValidateDefaultValue("$(platform)")
-					                         || (parentConditionHasPlatform &&
-					                             ValidateDefaultValue(parentConditionPlatformLower)):
+					                         ||
+					                         (
+						                         parentConditionHasPlatform
+						                         &&
+						                         ValidateDefaultValue(parentConditionPlatformLower)
+					                         ):
+					case "RestorePackages" when ValidateDefaultValue("true"):
+					case "SchemaVersion" when ValidateDefaultValue("2.0"):
 					// Conditional platform default values
-					case "PlatformTarget" when parentConditionHasPlatform && child.Value == parentConditionPlatform
-					                                                      && !hasGlobalOverride:
+					case "PlatformTarget" when parentConditionHasPlatform
+					                           && child.Value == parentConditionPlatform
+					                           && !hasGlobalOverride:
 					// Conditional configuration (Debug/Release) default values
-					case "DefineConstants"
-						when isDebugOnly && ValidateDefaultConstants(valueLower, "debug", "trace") &&
-						     !hasGlobalOverride:
-					case "DefineConstants" when isReleaseOnly && ValidateDefaultConstants(valueLower, "trace") &&
-					                            !hasGlobalOverride:
+					case "DefineConstants" when isDebugOnly
+					                            && ValidateDefaultConstants(valueLower, "debug", "trace")
+					                            && !hasGlobalOverride:
+					case "DefineConstants" when isReleaseOnly
+					                            && ValidateDefaultConstants(valueLower, "trace")
+					                            && !hasGlobalOverride:
 					case "Optimize" when isDebugOnly && valueLower == "false" && !hasGlobalOverride:
 					case "Optimize" when isReleaseOnly && valueLower == "true" && !hasGlobalOverride:
 					case "DebugSymbols" when isDebugOnly && valueLower == "true" && !hasGlobalOverride:
 					// Default project values for Platform and Configuration
-					case "Platform" when !hasParentCondition && ValidateEmptyConditionValue(childCondition) &&
-					                     valueLower == "anycpu":
-					case "Configuration" when !hasParentCondition && ValidateEmptyConditionValue(childCondition) &&
-					                          valueLower == "debug":
+					case "Platform" when ValidateEmptyConditionValue()
+					                     && valueLower == "anycpu":
+					case "Configuration" when ValidateEmptyConditionValue()
+					                          && valueLower == "debug":
 					case "Platforms" when !hasParentCondition
 					                      && ValidateDefaultConstants(valueLower, "anycpu"):
 					case "Configurations" when !hasParentCondition
 					                           && ValidateDefaultConstants(valueLower, "debug", "release"):
 					// Extra ProjectName duplicates
-					case "RootNamespace" when !hasParentCondition && ValidateEmptyConditionValue(childCondition) &&
-					                          child.Value == project.ProjectName:
-					case "AssemblyName" when !hasParentCondition && ValidateEmptyConditionValue(childCondition) &&
-					                         child.Value == project.ProjectName:
+					case "RootNamespace" when IsDefaultProjectNameValued():
+					case "AssemblyName" when IsDefaultProjectNameValued():
+					case "TargetName" when IsDefaultProjectNameValued():
 					{
 						removeQueue.Add(child);
 						break;
@@ -192,6 +227,61 @@ namespace Project2015To2017.Transforms
 
 					return value;
 				}
+
+				bool ValidateEmptyConditionValue()
+				{
+					if (!hasCondition || string.IsNullOrWhiteSpace(fullCondition))
+					{
+						return true;
+					}
+
+					return (fullCondition.Count(x => x == '=') == 2) && fullCondition.Contains("''");
+				}
+
+				bool IsDefaultProjectNameValued()
+				{
+					return ValidateEmptyConditionValue()
+					       && (
+						       child.Value == msbuildProjectName
+						       ||
+						       IgnoreProjectNameValues.Contains(child.Value)
+					       );
+				}
+
+				bool ValidateSolutionDir()
+				{
+					if (!hasCondition || fullState == null)
+					{
+						return false;
+					}
+
+					if (!(fullState.Node is OrExpressionNode or))
+					{
+						return false;
+					}
+
+					if (!(or.LeftChild is EqualExpressionNode left))
+					{
+						return false;
+					}
+
+					if (!(or.RightChild is EqualExpressionNode right))
+					{
+						return false;
+					}
+
+					if (!VerifyEquals(left.LeftChild, left.RightChild, "$(SolutionDir)", ""))
+					{
+						return false;
+					}
+
+					if (!VerifyEquals(right.LeftChild, right.RightChild, "$(SolutionDir)", "*Undefined*"))
+					{
+						return false;
+					}
+
+					return true;
+				}
 			}
 
 			// we cannot remove elements correctly while iterating through elements, 2nd pass is needed
@@ -234,21 +324,30 @@ namespace Project2015To2017.Transforms
 			}
 		}
 
-		private static bool ValidateEmptyConditionValue(XAttribute condition)
-		{
-			if (condition == null)
-			{
-				return true;
-			}
-
-			var value = condition.Value;
-			return (value.Count(x => x == '=') == 2) && value.Contains("''");
-		}
-
 		private static bool ValidateDefaultConstants(string value, params string[] expected)
 		{
 			var defines = value.Split(new[] {';'}, StringSplitOptions.RemoveEmptyEntries);
 			return Extensions.ValidateSet(defines, expected);
+		}
+
+		private static bool VerifyEquals(
+			GenericExpressionNode left,
+			GenericExpressionNode right,
+			string expectedLeft,
+			string expectedRight)
+		{
+			if (!(left is StringExpressionNode leftString))
+			{
+				return false;
+			}
+			if (!(right is StringExpressionNode rightString))
+			{
+				return false;
+			}
+
+			var leftValue = leftString.GetUnexpandedValue(null);
+			var rightValue = rightString.GetUnexpandedValue(null);
+			return (leftValue == expectedLeft) && (rightValue == expectedRight);
 		}
 	}
 }

--- a/Project2015To2017/Transforms/TargetFrameworkTransformation.cs
+++ b/Project2015To2017/Transforms/TargetFrameworkTransformation.cs
@@ -7,11 +7,9 @@ namespace Project2015To2017.Transforms
 {
 	public sealed class TargetFrameworkTransformation : ITransformation
 	{
-		public TargetFrameworkTransformation(IReadOnlyList<string> targetFrameworks)
-			: this(targetFrameworks, true)
-		{
-		}
-		public TargetFrameworkTransformation(IReadOnlyList<string> targetFrameworks, bool appendTargetFrameworkToOutputPath)
+		public TargetFrameworkTransformation(
+			IReadOnlyList<string> targetFrameworks,
+			bool appendTargetFrameworkToOutputPath = true)
 		{
 			this.TargetFrameworks = targetFrameworks;
 			this.AppendTargetFrameworkToOutputPath = appendTargetFrameworkToOutputPath;

--- a/Project2015To2017Tests/NuGetPackageTransformationTest.cs
+++ b/Project2015To2017Tests/NuGetPackageTransformationTest.cs
@@ -17,8 +17,6 @@ namespace Project2015To2017Tests
 		{
 			var project = new ProjectReader().Read(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj"));
 
-			project.AssemblyName = "TestAssembly";
-
 			project.AssemblyAttributes =
 								new AssemblyAttributes {
 									InformationalVersion = "7.0",
@@ -83,7 +81,7 @@ namespace Project2015To2017Tests
 												Version = "1.0.2"
 											}
 										};
-			
+
 			new NugetPackageTransformation().Transform(project, NoopLogger.Instance);
 
 			Assert.AreEqual("[10.0.2,11)", project.PackageReferences.Single(x => x.Id == "Newtonsoft.Json").Version);

--- a/Project2015To2017Tests/ProjectPropertiesReadTest.cs
+++ b/Project2015To2017Tests/ProjectPropertiesReadTest.cs
@@ -140,40 +140,6 @@ namespace Project2015To2017Tests
 		}
 
 		[TestMethod]
-		public async Task ReadsRootNamespace()
-		{
-			var xml = @"<?xml version=""1.0"" encoding=""utf-8""?>
-<Project ToolsVersion=""14.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
-    <RootNamespace>MyProject</RootNamespace>
-  </PropertyGroup>
-</Project>";
-
-			var project = await ParseAndTransform(xml).ConfigureAwait(false);
-
-			Assert.AreEqual("MyProject", project.RootNamespace);
-		}
-
-		[TestMethod]
-		public async Task ReadsAssemblyName()
-		{
-			var xml = @"<?xml version=""1.0"" encoding=""utf-8""?>
-<Project ToolsVersion=""14.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
-    <AssemblyName>MyProject</AssemblyName>
-  </PropertyGroup>
-</Project>";
-
-			var project = await ParseAndTransform(xml).ConfigureAwait(false);
-
-			Assert.AreEqual("MyProject", project.AssemblyName);
-		}
-
-		[TestMethod]
 		[ExpectedException(typeof(NotSupportedException))]
 		public async Task ThrowsOnNoUnconditionalPropertyGroup()
 		{
@@ -280,8 +246,8 @@ namespace Project2015To2017Tests
 
 			var project = await ParseAndTransform(xml).ConfigureAwait(false);
 
-			Assert.AreEqual("Croc.XFW3.DomainModelDefinitionLanguage.Dsl", project.AssemblyName);
-			Assert.AreEqual("Croc.XFW3.DomainModelDefinitionLanguage", project.RootNamespace);
+			Assert.AreEqual("Croc.XFW3.DomainModelDefinitionLanguage.Dsl", project.Property("AssemblyName")?.Value);
+			Assert.AreEqual("Croc.XFW3.DomainModelDefinitionLanguage", project.Property("RootNamespace")?.Value);
 			Assert.AreEqual(ApplicationType.ClassLibrary, project.Type);
 			Assert.AreEqual(2, project.PropertyGroups.Count);
 		}

--- a/Project2015To2017Tests/PropertySimplificationTransformationTest.cs
+++ b/Project2015To2017Tests/PropertySimplificationTransformationTest.cs
@@ -16,9 +16,9 @@ namespace Project2015To2017Tests
 	public class PropertySimplificationTransformationTest
 	{
 		[TestMethod]
-		public async Task SimplifiesProperties1()
+		public void SimplifiesProperties1()
 		{
-			var xml = @"
+			const string xml = @"
 <Project ToolsVersion=""14.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
   <PropertyGroup>
     <Configuration Condition="" '$(Configuration)' == '' "">Debug</Configuration>
@@ -66,10 +66,7 @@ namespace Project2015To2017Tests
   </PropertyGroup>
 </Project>";
 
-			var project = await ParseAndTransform(xml, transform: false).ConfigureAwait(false);
-
-			project.ProjectName = "Dopamine.Tests";
-			Transform(project);
+			var project = ParseAndTransform(xml, projectName: "Dopamine.Tests");
 
 			Assert.AreEqual(3, project.PropertyGroups.Count);
 
@@ -92,9 +89,9 @@ namespace Project2015To2017Tests
 		}
 
 		[TestMethod]
-		public async Task SimplifiesProperties2()
+		public void SimplifiesProperties2()
 		{
-			var project = await ParseAndTransform(@"
+			const string xml = @"
 <Project ToolsVersion=""14.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -110,10 +107,9 @@ namespace Project2015To2017Tests
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
-</Project>", transform: false);
+</Project>";
 
-			project.ProjectName = "Dopamine";
-			Transform(project);
+			var project = ParseAndTransform(xml, projectName: "Dopamine");
 
 			Assert.IsTrue(project.IsWindowsPresentationFoundationProject);
 			Assert.IsFalse(project.IsWindowsFormsProject);
@@ -151,9 +147,9 @@ namespace Project2015To2017Tests
 
 
 		[TestMethod]
-		public async Task HandlesComplexConditions()
+		public void HandlesComplexConditions()
 		{
-			var xml = @"
+			const string xml = @"
 <Project ToolsVersion=""14.0"" DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
   <PropertyGroup>
     <OutputType>Library</OutputType>
@@ -173,10 +169,7 @@ namespace Project2015To2017Tests
   </PropertyGroup>
 </Project>";
 
-			var project = await ParseAndTransform(xml, transform: false).ConfigureAwait(false);
-
-			project.ProjectName = "Dopamine.Tests";
-			Transform(project);
+			var project = ParseAndTransform(xml, projectName: "Dopamine.Tests");
 
 			Assert.AreEqual(2, project.Configurations.Count);
 			Assert.AreEqual(1, project.Configurations.Count(x => x == "Debug"));
@@ -205,9 +198,9 @@ namespace Project2015To2017Tests
 		}
 
 		[TestMethod]
-		public async Task HandlesUnknownConfigurationSimplifications()
+		public void HandlesUnknownConfigurationSimplifications()
 		{
-			var xml = @"
+			const string xml = @"
 <Project DefaultTargets=""Build"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"" ToolsVersion=""4.0"">
   <Import Project=""$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props"" Condition=""Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"" />
   <PropertyGroup>
@@ -238,10 +231,7 @@ namespace Project2015To2017Tests
   </PropertyGroup>
  </Project>";
 
-			var project = await ParseAndTransform(xml, transform: false).ConfigureAwait(false);
-
-			project.ProjectName = "Class1";
-			Transform(project);
+			var project = ParseAndTransform(xml, projectName: "Class1");
 
 			// Configurations property must take precedence
 			// Release_CI will be ignored, but still some transformations will apply
@@ -280,30 +270,24 @@ namespace Project2015To2017Tests
 				childrenReleaseCI.First(x => x.Name.LocalName == "OutputPath").Value);
 		}
 
-		private static async Task<Project> ParseAndTransform(
+		private static Project ParseAndTransform(
 			string xml,
 			[System.Runtime.CompilerServices.CallerMemberName]
 			string memberName = "",
-			bool transform = true
+			string projectName = null
 		)
 		{
 			var testCsProjFile = $"{memberName}_test.csproj";
 
-			await File.WriteAllTextAsync(testCsProjFile, xml);
+			File.WriteAllText(testCsProjFile, xml);
 
 			var project = new ProjectReader().Read(testCsProjFile);
+			project.ProjectName = projectName;
+			project.FilePath = null;
 
-			if (transform)
-			{
-				Transform(project);
-			}
+			new PropertySimplificationTransformation().Transform(project, NoopLogger.Instance);
 
 			return project;
-		}
-
-		private static void Transform(Project project)
-		{
-			new PropertySimplificationTransformation().Transform(project, NoopLogger.Instance);
 		}
 	}
 }

--- a/Project2015To2017Tests/W001IllegalProjectTypeDiagnosticTest.cs
+++ b/Project2015To2017Tests/W001IllegalProjectTypeDiagnosticTest.cs
@@ -2,6 +2,7 @@ using System.Xml.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Project2015To2017.Analysis.Diagnostics;
 using Project2015To2017.Definition;
+using Project2015To2017.Reading;
 
 namespace Project2015To2017Tests
 {
@@ -15,10 +16,13 @@ namespace Project2015To2017Tests
 			{
 				ProjectDocument = new XDocument(
 					new XElement("Project",
-						new XElement(
-							XName.Get("ProjectTypeGuids", Project.XmlLegacyNamespace.NamespaceName),
-							"{EFBA0AD7-5A72-4C68-AF49-83D382785DCF}")))
+						new XElement(Project.XmlLegacyNamespace + "PropertyGroup",
+							new XElement(
+								XName.Get("ProjectTypeGuids", Project.XmlLegacyNamespace.NamespaceName),
+								"{EFBA0AD7-5A72-4C68-AF49-83D382785DCF}"))))
 			};
+
+			ProjectPropertiesReader.ReadPropertyGroups(project);
 
 			var results = new W001IllegalProjectTypeDiagnostic().Analyze(project);
 			Assert.AreEqual(1, results.Count);
@@ -31,10 +35,13 @@ namespace Project2015To2017Tests
 			{
 				ProjectDocument = new XDocument(
 					new XElement("Project",
-						new XElement(
-							XName.Get("ProjectTypeGuids", Project.XmlLegacyNamespace.NamespaceName),
-							"{318C4C53-4319-472D-A480-6540F3D375FD}")))
+						new XElement(Project.XmlLegacyNamespace + "PropertyGroup",
+							new XElement(
+								XName.Get("ProjectTypeGuids", Project.XmlLegacyNamespace.NamespaceName),
+								"{318C4C53-4319-472D-A480-6540F3D375FD}"))))
 			};
+
+			ProjectPropertiesReader.ReadPropertyGroups(project);
 
 			var results = new W001IllegalProjectTypeDiagnostic().Analyze(project);
 			Assert.IsNotNull(results);


### PR DESCRIPTION
* API removal: Remove `RootNamespace` and `AssemblyName` properties from model (it was RC right? one tiny change)
* Extended `ProjectReference` model (and added filling new properties to both `SolutionReader` and `ProjectReader`)
* Use new APIs in diagnostics W001, W010, W034
* Fix AssemblyInfo detection when file is missing (e.g. generated during build from template)
* Extend `ConditionEvaluator` APIs to allow more efficient queries
* Recreate relative path fix set for Unix-like OS closely based on MSBuild sources (works only on non-Windows platforms)
* Rewrite `SolutionReader` to use MSBuild routine for parsing _Project_ definition lines
* Add `EmptyGroupRemoveTransformation` (obvious designation, fixes regression in one of my latest PRs)
* Greatly improve property simplification per issue #165
* Fix regression in one of my latest PRs: applying full set of transformations on CPS projects. Sigh.
* Adapt tests to changes

Closes #161.