### PR TITLE
Refactored ITransformation to not include logger for 2.0

### DIFF
--- a/Project2015To2017/Transforms/AssemblyAttributeTransformation.cs
+++ b/Project2015To2017/Transforms/AssemblyAttributeTransformation.cs
@@ -9,17 +9,21 @@ namespace Project2015To2017.Transforms
 {
 	public sealed class AssemblyAttributeTransformation : ITransformation
 	{
-		public AssemblyAttributeTransformation() : this(false)
+		private readonly ILogger logger;
+
+		public AssemblyAttributeTransformation(ILogger logger) : this(logger, false)
 		{
 		}
-		public AssemblyAttributeTransformation(bool keepAssemblyInfoFile)
+
+		public AssemblyAttributeTransformation(ILogger logger, bool keepAssemblyInfoFile)
 		{
+			this.logger = logger;
 			this.KeepAssemblyInfoFile = keepAssemblyInfoFile;
 		}
 
 		public bool KeepAssemblyInfoFile { get; }
 
-		public void Transform(Project definition, ILogger logger)
+		public void Transform(Project definition)
 		{
 			if (definition.AssemblyAttributes == null)
 			{

--- a/Project2015To2017/Transforms/AssemblyReferenceTransformation.cs
+++ b/Project2015To2017/Transforms/AssemblyReferenceTransformation.cs
@@ -8,7 +8,7 @@ namespace Project2015To2017.Transforms
 {
 	public sealed class AssemblyReferenceTransformation : ITransformation
 	{
-		public void Transform(Project definition, ILogger logger)
+		public void Transform(Project definition)
 		{
 			var packageReferences =
 				definition.PackageReferences ?? new List<PackageReference>();

--- a/Project2015To2017/Transforms/DefaultAssemblyReferenceRemovalTransformation.cs
+++ b/Project2015To2017/Transforms/DefaultAssemblyReferenceRemovalTransformation.cs
@@ -8,7 +8,7 @@ namespace Project2015To2017.Transforms
 {
 	public sealed class DefaultAssemblyReferenceRemovalTransformation : ITransformation
 	{
-		public void Transform(Project definition, ILogger logger)
+		public void Transform(Project definition)
 		{
 			if (definition.AssemblyReferences == null)
 			{

--- a/Project2015To2017/Transforms/FileTransformation.cs
+++ b/Project2015To2017/Transforms/FileTransformation.cs
@@ -35,7 +35,14 @@ namespace Project2015To2017.Transforms
 			"PackageReference",
 		};
 
-		public void Transform(Project definition, ILogger logger)
+		private readonly ILogger logger;
+
+		public FileTransformation(ILogger logger = null)
+		{
+			this.logger = logger ?? NoopLogger.Instance;
+		}
+
+		public void Transform(Project definition)
 		{
 			var (keepItems, removeQueue) = definition.ItemGroups
 				.SelectMany(x => x.Elements())

--- a/Project2015To2017/Transforms/ITransformation.cs
+++ b/Project2015To2017/Transforms/ITransformation.cs
@@ -10,7 +10,6 @@ namespace Project2015To2017.Transforms
 		/// Alter the provided project in some way
 		/// </summary>
 		/// <param name="definition"></param>
-		/// <param name="logger"></param>
-        void Transform(Project definition, ILogger logger);
+        void Transform(Project definition);
     }
 }

--- a/Project2015To2017/Transforms/NuGetPackageTransformation.cs
+++ b/Project2015To2017/Transforms/NuGetPackageTransformation.cs
@@ -8,7 +8,7 @@ namespace Project2015To2017.Transforms
 {
 	public sealed class NugetPackageTransformation : ITransformation
 	{
-		public void Transform(Project definition, ILogger logger)
+		public void Transform(Project definition)
 		{
 			if (definition.PackageConfiguration == null)
 			{

--- a/Project2015To2017/Transforms/PrimaryUnconditionalPropertyTransformation.cs
+++ b/Project2015To2017/Transforms/PrimaryUnconditionalPropertyTransformation.cs
@@ -10,7 +10,7 @@ namespace Project2015To2017.Transforms
 {
 	public sealed class PrimaryUnconditionalPropertyTransformation : ITransformation
 	{
-		public void Transform(Project project, ILogger logger)
+		public void Transform(Project project)
 		{
 			AddTargetFrameworks(project, project.TargetFrameworks);
 

--- a/Project2015To2017/Transforms/PropertyDeduplicationTransformation.cs
+++ b/Project2015To2017/Transforms/PropertyDeduplicationTransformation.cs
@@ -9,7 +9,7 @@ namespace Project2015To2017.Transforms
 {
 	public sealed class PropertyDeduplicationTransformation : ITransformation
 	{
-		public void Transform(Project definition, ILogger logger)
+		public void Transform(Project definition)
 		{
 			var props = definition
 				.ConditionalGroups()

--- a/Project2015To2017/Transforms/PropertySimplificationTransformation.cs
+++ b/Project2015To2017/Transforms/PropertySimplificationTransformation.cs
@@ -12,7 +12,7 @@ namespace Project2015To2017.Transforms
 {
 	public sealed class PropertySimplificationTransformation : ITransformation
 	{
-		public void Transform(Project definition, ILogger logger)
+		public void Transform(Project definition)
 		{
 			// special case handling for when condition-guarded props override global props not set to their defaults
 			var globalOverrides = new Dictionary<string, string>();

--- a/Project2015To2017/Transforms/RemovePackageAssemblyReferencesTransformation.cs
+++ b/Project2015To2017/Transforms/RemovePackageAssemblyReferencesTransformation.cs
@@ -8,7 +8,7 @@ namespace Project2015To2017.Transforms
 {
 	public sealed class RemovePackageAssemblyReferencesTransformation : ITransformation
 	{
-		public void Transform(Project definition, ILogger logger)
+		public void Transform(Project definition)
 		{
 			if (definition.PackageReferences == null || definition.PackageReferences.Count == 0)
 			{

--- a/Project2015To2017/Transforms/RemovePackageImportsTransformation.cs
+++ b/Project2015To2017/Transforms/RemovePackageImportsTransformation.cs
@@ -10,7 +10,7 @@ namespace Project2015To2017.Transforms
 {
 	public sealed class RemovePackageImportsTransformation : ITransformation
 	{
-		public void Transform(Project definition, ILogger logger)
+		public void Transform(Project definition)
 		{
 			if (definition.PackageReferences == null || definition.PackageReferences.Count == 0)
 			{

--- a/Project2015To2017/Transforms/TargetFrameworkTransformation.cs
+++ b/Project2015To2017/Transforms/TargetFrameworkTransformation.cs
@@ -17,7 +17,7 @@ namespace Project2015To2017.Transforms
 			this.AppendTargetFrameworkToOutputPath = appendTargetFrameworkToOutputPath;
 		}
 
-		public void Transform(Project definition, ILogger logger)
+		public void Transform(Project definition)
 		{
 			if (null == definition)
 			{

--- a/Project2015To2017/Transforms/TestProjectPackageReferenceTransformation.cs
+++ b/Project2015To2017/Transforms/TestProjectPackageReferenceTransformation.cs
@@ -7,7 +7,14 @@ namespace Project2015To2017.Transforms
 {
 	public sealed class TestProjectPackageReferenceTransformation : ITransformation
 	{
-		public void Transform(Project definition, ILogger logger)
+		private readonly ILogger logger;
+
+		public TestProjectPackageReferenceTransformation(ILogger logger = null)
+		{
+			this.logger = logger ?? NoopLogger.Instance;
+		}
+
+		public void Transform(Project definition)
 		{
 			var existingPackageReferences = definition.PackageReferences;
 

--- a/Project2015To2017/Transforms/XamlPagesTransformation.cs
+++ b/Project2015To2017/Transforms/XamlPagesTransformation.cs
@@ -10,8 +10,13 @@ namespace Project2015To2017.Transforms
 {
 	public sealed class XamlPagesTransformation : ITransformation
 	{
+		public XamlPagesTransformation(ILogger logger = null)
+		{
+			this.logger = logger ?? NoopLogger.Instance;
+		}
+
 		/// <inheritdoc />
-		public void Transform(Project definition, ILogger logger)
+		public void Transform(Project definition)
 		{
 			if (!definition.IsWindowsPresentationFoundationProject)
 			{
@@ -40,6 +45,7 @@ namespace Project2015To2017.Transforms
 		}
 
 		private static readonly string[] FilteredTags = {"Page", "ApplicationDefinition", "Compile", "None"};
+		private readonly ILogger logger;
 
 		private static bool XamlPageFilter(XElement x, Project definition)
 		{

--- a/Project2015To2017Tests/AssemblyAttributeTransformationTest.cs
+++ b/Project2015To2017Tests/AssemblyAttributeTransformationTest.cs
@@ -42,9 +42,9 @@ namespace Project2015To2017Tests
 				Deletions = new List<FileSystemInfo>()
 			};
 
-			var transform = new AssemblyAttributeTransformation();
+			var transform = new AssemblyAttributeTransformation(NoopLogger.Instance);
 
-			transform.Transform(project, NoopLogger.Instance);
+			transform.Transform(project);
 
 			var generateAssemblyInfo = project.AssemblyAttributeProperties.SingleOrDefault();
 			Assert.IsNotNull(generateAssemblyInfo);
@@ -64,9 +64,9 @@ namespace Project2015To2017Tests
 				Deletions = new List<FileSystemInfo>()
 			};
 
-			var transform = new AssemblyAttributeTransformation(true);
+			var transform = new AssemblyAttributeTransformation(NoopLogger.Instance, true);
 
-			transform.Transform(project, NoopLogger.Instance);
+			transform.Transform(project);
 
 			var generateAssemblyInfo = project.AssemblyAttributeProperties.SingleOrDefault();
 			Assert.IsNotNull(generateAssemblyInfo);
@@ -85,9 +85,9 @@ namespace Project2015To2017Tests
 				Deletions = new List<FileSystemInfo>()
 			};
 
-			var transform = new AssemblyAttributeTransformation();
+			var transform = new AssemblyAttributeTransformation(NoopLogger.Instance);
 
-			transform.Transform(project, NoopLogger.Instance);
+			transform.Transform(project);
 
 			var expectedProperties = new[]
 			{
@@ -140,9 +140,9 @@ namespace Project2015To2017Tests
 				Deletions = new List<FileSystemInfo>()
 			};
 
-			var transform = new AssemblyAttributeTransformation();
+			var transform = new AssemblyAttributeTransformation(NoopLogger.Instance);
 
-			transform.Transform(project, NoopLogger.Instance);
+			transform.Transform(project);
 
 			var expectedProperties = new[]
 				{
@@ -185,9 +185,9 @@ namespace Project2015To2017Tests
 				Deletions = new List<FileSystemInfo>()
 			};
 
-			var transform = new AssemblyAttributeTransformation();
+			var transform = new AssemblyAttributeTransformation(NoopLogger.Instance);
 
-			transform.Transform(project, NoopLogger.Instance);
+			transform.Transform(project);
 
 			var expectedProperties = new[]
 				{
@@ -232,9 +232,9 @@ namespace Project2015To2017Tests
 				Deletions = new List<FileSystemInfo>()
 			};
 
-			var transform = new AssemblyAttributeTransformation();
+			var transform = new AssemblyAttributeTransformation(NoopLogger.Instance);
 
-			transform.Transform(project, NoopLogger.Instance);
+			transform.Transform(project);
 
 			var expectedProperties = new[]
 				{
@@ -274,9 +274,9 @@ namespace Project2015To2017Tests
 				Deletions = new List<FileSystemInfo>()
 			};
 
-			var transform = new AssemblyAttributeTransformation();
+			var transform = new AssemblyAttributeTransformation(NoopLogger.Instance);
 
-			transform.Transform(project, NoopLogger.Instance);
+			transform.Transform(project);
 
 			var expectedProperties = new[]
 				{
@@ -325,9 +325,9 @@ namespace Project2015To2017Tests
 				File = assemblyInfoFile
 			};
 
-			var transform = new AssemblyAttributeTransformation();
+			var transform = new AssemblyAttributeTransformation(NoopLogger.Instance);
 
-			transform.Transform(project, NoopLogger.Instance);
+			transform.Transform(project);
 
 			CollectionAssert.Contains(project.Deletions.ToList(), assemblyInfoFile);
 		}
@@ -349,9 +349,9 @@ namespace Project2015To2017Tests
 								).GetRoot()
 			};
 
-			var transform = new AssemblyAttributeTransformation();
+			var transform = new AssemblyAttributeTransformation(NoopLogger.Instance);
 
-			transform.Transform(project, NoopLogger.Instance);
+			transform.Transform(project);
 
 			CollectionAssert.Contains(project.Deletions.ToList(), assemblyInfoFile);
 		}
@@ -373,9 +373,9 @@ namespace Project2015To2017Tests
 				).GetRoot()
 			};
 
-			var transform = new AssemblyAttributeTransformation();
+			var transform = new AssemblyAttributeTransformation(NoopLogger.Instance);
 
-			transform.Transform(project, NoopLogger.Instance);
+			transform.Transform(project);
 
 			CollectionAssert.DoesNotContain(project.Deletions.ToList(), assemblyInfoFile);
 		}
@@ -391,9 +391,9 @@ namespace Project2015To2017Tests
 				Deletions = new List<FileSystemInfo>()
 			};
 
-			var transform = new AssemblyAttributeTransformation();
+			var transform = new AssemblyAttributeTransformation(NoopLogger.Instance);
 
-			transform.Transform(project, NoopLogger.Instance);
+			transform.Transform(project);
 
 			var generateAssemblyInfo = project.AssemblyAttributeProperties.SingleOrDefault();
 			Assert.IsNotNull(generateAssemblyInfo);

--- a/Project2015To2017Tests/AssemblyReferenceTransformationTest.cs
+++ b/Project2015To2017Tests/AssemblyReferenceTransformationTest.cs
@@ -19,7 +19,7 @@ namespace Project2015To2017Tests
 			var project = new ProjectReader().Read(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj"));
 			var transformation = new AssemblyReferenceTransformation();
 			
-			transformation.Transform(project, NoopLogger.Instance);
+			transformation.Transform(project);
 
 			Assert.AreEqual(12, project.AssemblyReferences.Count);
 			Assert.IsTrue(project.AssemblyReferences.Any(x => x.Include == @"System.Xml.Linq"));
@@ -71,7 +71,7 @@ namespace Project2015To2017Tests
 
 			var transformation = new AssemblyReferenceTransformation();
 			
-			transformation.Transform(project, NoopLogger.Instance);
+			transformation.Transform(project);
 
 			Assert.AreEqual(1, project.AssemblyReferences.Count);
 			Assert.AreEqual(2, project.PackageReferences.Count);

--- a/Project2015To2017Tests/DefaultAssemblyReferenceRemovalTransformationTest.cs
+++ b/Project2015To2017Tests/DefaultAssemblyReferenceRemovalTransformationTest.cs
@@ -26,7 +26,7 @@ namespace Project2015To2017Tests
 				FilePath = new FileInfo("test.cs")
 			};
 
-			new DefaultAssemblyReferenceRemovalTransformation().Transform(project, NoopLogger.Instance);
+			new DefaultAssemblyReferenceRemovalTransformation().Transform(project);
 
 			Assert.AreEqual(0, project.AssemblyReferences.Count);
 		}

--- a/Project2015To2017Tests/FileTransformationTest.cs
+++ b/Project2015To2017Tests/FileTransformationTest.cs
@@ -17,7 +17,7 @@ namespace Project2015To2017Tests
 			var project = new ProjectReader().Read(Path.Combine("TestFiles", "FileInclusion", "fileinclusion.testcsproj"));
 			var transformation = new FileTransformation();
 
-			transformation.Transform(project, NoopLogger.Instance);
+			transformation.Transform(project);
 
 			var includeItems = project.ItemGroups.SelectMany(x => x.Elements()).ToImmutableList();
 

--- a/Project2015To2017Tests/NuGetPackageTransformationTest.cs
+++ b/Project2015To2017Tests/NuGetPackageTransformationTest.cs
@@ -29,7 +29,7 @@ namespace Project2015To2017Tests
 									Company = "assembly author"
 								};
 
-			new NugetPackageTransformation().Transform(project, NoopLogger.Instance);
+			new NugetPackageTransformation().Transform(project);
 
 			var transformedPackageConfig = project.PackageConfiguration;
 
@@ -58,7 +58,7 @@ namespace Project2015To2017Tests
 					Company = "assembly author"
 				};
 
-			new NugetPackageTransformation().Transform(project, NoopLogger.Instance);
+			new NugetPackageTransformation().Transform(project);
 
 			var transformedPackageConfig = project.PackageConfiguration;
 
@@ -84,7 +84,7 @@ namespace Project2015To2017Tests
 											}
 										};
 			
-			new NugetPackageTransformation().Transform(project, NoopLogger.Instance);
+			new NugetPackageTransformation().Transform(project);
 
 			Assert.AreEqual("[10.0.2,11)", project.PackageReferences.Single(x => x.Id == "Newtonsoft.Json").Version);
 			Assert.AreEqual("1.0.2", project.PackageReferences.Single(x => x.Id == "Other.Package").Version);

--- a/Project2015To2017Tests/PrimaryUnconditionalPropertyTransformationTest.cs
+++ b/Project2015To2017Tests/PrimaryUnconditionalPropertyTransformationTest.cs
@@ -21,7 +21,7 @@ namespace Project2015To2017Tests
 				FilePath = new FileInfo("test.cs")
 			};
 
-			new PrimaryUnconditionalPropertyTransformation().Transform(project, NoopLogger.Instance);
+			new PrimaryUnconditionalPropertyTransformation().Transform(project);
 
 			var appendTargetFrameworkToOutputPath = project.Property("AppendTargetFrameworkToOutputPath");
 			Assert.IsNull(appendTargetFrameworkToOutputPath);
@@ -38,7 +38,7 @@ namespace Project2015To2017Tests
 				FilePath = new FileInfo("test.cs")
 			};
 
-			new PrimaryUnconditionalPropertyTransformation().Transform(project, NoopLogger.Instance);
+			new PrimaryUnconditionalPropertyTransformation().Transform(project);
 
 			var appendTargetFrameworkToOutputPath = project.Property("AppendTargetFrameworkToOutputPath");
 			Assert.IsNotNull(appendTargetFrameworkToOutputPath);

--- a/Project2015To2017Tests/PropertySimplificationTransformationTest.cs
+++ b/Project2015To2017Tests/PropertySimplificationTransformationTest.cs
@@ -303,7 +303,7 @@ namespace Project2015To2017Tests
 
 		private static void Transform(Project project)
 		{
-			new PropertySimplificationTransformation().Transform(project, NoopLogger.Instance);
+			new PropertySimplificationTransformation().Transform(project);
 		}
 	}
 }

--- a/Project2015To2017Tests/RemovePackageAssemblyReferencesTransformationTest.cs
+++ b/Project2015To2017Tests/RemovePackageAssemblyReferencesTransformationTest.cs
@@ -19,7 +19,7 @@ namespace Project2015To2017Tests
 			var project = new Project();
 
 			var transformation = new RemovePackageAssemblyReferencesTransformation();
-			transformation.Transform(project, NoopLogger.Instance);
+			transformation.Transform(project);
 		}
 
 		[TestMethod]
@@ -55,7 +55,7 @@ namespace Project2015To2017Tests
 
 			var transformation = new RemovePackageAssemblyReferencesTransformation();
 
-			transformation.Transform(project, NoopLogger.Instance);
+			transformation.Transform(project);
 
 			Assert.AreEqual(2, project.AssemblyReferences.Count);
 		}
@@ -70,7 +70,7 @@ namespace Project2015To2017Tests
 			var transformation = new RemovePackageAssemblyReferencesTransformation();
 
 			//Then attempt to clear any referencing the nuget packages folder
-			transformation.Transform(project, NoopLogger.Instance);
+			transformation.Transform(project);
 
 			//The only one left which points to another folder
 			Assert.AreEqual(1, project.AssemblyReferences.Count);
@@ -87,7 +87,7 @@ namespace Project2015To2017Tests
 			var transformation = new RemovePackageImportsTransformation();
 
 			//Then attempt to clear any referencing the nuget packages folder
-			transformation.Transform(project, NoopLogger.Instance);
+			transformation.Transform(project);
 
 			var expectedRemaining = new []
 			{

--- a/Project2015To2017Tests/TargetFrameworkTransformationTest.cs
+++ b/Project2015To2017Tests/TargetFrameworkTransformationTest.cs
@@ -17,7 +17,7 @@ namespace Project2015To2017Tests
 			var targetFrameworks = new List<string> { "netstandard2.0" };
 
 			var transformation = new TargetFrameworkTransformation(targetFrameworks);
-			transformation.Transform(project, NoopLogger.Instance);
+			transformation.Transform(project);
 
 			Assert.IsNull(project);
 		}
@@ -29,7 +29,7 @@ namespace Project2015To2017Tests
 			var targetFrameworks = new List<string> { "netstandard2.0" };
 
 			var transformation = new TargetFrameworkTransformation(targetFrameworks);
-			transformation.Transform(project, NoopLogger.Instance);
+			transformation.Transform(project);
 
 			Assert.AreEqual(1, project.TargetFrameworks.Count);
 			Assert.AreEqual("netstandard2.0", project.TargetFrameworks[0]);
@@ -44,7 +44,7 @@ namespace Project2015To2017Tests
 			};
 			
 			var transformation = new TargetFrameworkTransformation(null);
-			transformation.Transform(project, NoopLogger.Instance);
+			transformation.Transform(project);
 
 			Assert.AreEqual(1, project.TargetFrameworks.Count);
 			Assert.AreEqual("net46", project.TargetFrameworks[0]);
@@ -59,7 +59,7 @@ namespace Project2015To2017Tests
 			};
 
 			var transformation = new TargetFrameworkTransformation(new List<string>());
-			transformation.Transform(project, NoopLogger.Instance);
+			transformation.Transform(project);
 
 			Assert.AreEqual(1, project.TargetFrameworks.Count);
 			Assert.AreEqual("net46", project.TargetFrameworks[0]);
@@ -75,7 +75,7 @@ namespace Project2015To2017Tests
 			var targetFrameworks = new List<string> { "netstandard2.0" };
 
 			var transformation = new TargetFrameworkTransformation(targetFrameworks);
-			transformation.Transform(project, NoopLogger.Instance);
+			transformation.Transform(project);
 
 			Assert.AreEqual(1, project.TargetFrameworks.Count);
 			Assert.AreEqual("netstandard2.0", project.TargetFrameworks[0]);
@@ -91,7 +91,7 @@ namespace Project2015To2017Tests
 			var targetFrameworks = new List<string> { "netstandard2.0", "net47" };
 
 			var transformation = new TargetFrameworkTransformation(targetFrameworks);
-			transformation.Transform(project, NoopLogger.Instance);
+			transformation.Transform(project);
 
 			Assert.AreEqual(2, project.TargetFrameworks.Count);
 			Assert.AreEqual("netstandard2.0", project.TargetFrameworks[0]);
@@ -104,7 +104,7 @@ namespace Project2015To2017Tests
 			var project = new Project();
 
 			var transformation = new TargetFrameworkTransformation(null, true);
-			transformation.Transform(project, NoopLogger.Instance);
+			transformation.Transform(project);
 
 			Assert.AreEqual(true, project.AppendTargetFrameworkToOutputPath);
 		}
@@ -115,7 +115,7 @@ namespace Project2015To2017Tests
 			var project = new Project();
 
 			var transformation = new TargetFrameworkTransformation(null, false);
-			transformation.Transform(project, NoopLogger.Instance);
+			transformation.Transform(project);
 
 			Assert.AreEqual(false, project.AppendTargetFrameworkToOutputPath);
 		}

--- a/Project2015To2017Tests/TestProjectPackageReferenceTransformationTest.cs
+++ b/Project2015To2017Tests/TestProjectPackageReferenceTransformationTest.cs
@@ -22,7 +22,7 @@ namespace Project2015To2017Tests
 
             var transformation = new TestProjectPackageReferenceTransformation();
 
-            transformation.Transform(project, NoopLogger.Instance);
+            transformation.Transform(project);
 
             Assert.AreEqual(10, project.PackageReferences.Count);
             Assert.AreEqual(1, project.PackageReferences.Count(x => x.Id == "Microsoft.Owin.Host.HttpListener" && x.Version == "3.1.0"));
@@ -40,7 +40,7 @@ namespace Project2015To2017Tests
 
 			var transformation = new TestProjectPackageReferenceTransformation();
 
-            transformation.Transform(project, NoopLogger.Instance);
+            transformation.Transform(project);
 
             Assert.AreEqual(10, project.PackageReferences.Count);
             Assert.AreEqual(1, project.PackageReferences.Count(x => x.Id == "Microsoft.Owin.Host.HttpListener" && x.Version == "3.1.0"));
@@ -57,7 +57,7 @@ namespace Project2015To2017Tests
 
 	        project.TargetFrameworks.Add("net45");
 
-            transformation.Transform(project, NoopLogger.Instance);
+            transformation.Transform(project);
 
             Assert.AreEqual(6, project.PackageReferences.Count);
             Assert.AreEqual(0, project.PackageReferences.Count(x => x.Id == "MSTest.TestAdapter"));
@@ -70,7 +70,7 @@ namespace Project2015To2017Tests
 
             var transformation = new TestProjectPackageReferenceTransformation();
 
-            transformation.Transform(project, NoopLogger.Instance);
+            transformation.Transform(project);
 
             Assert.AreEqual(7, project.PackageReferences.Count);
             Assert.AreEqual(2, project.PackageReferences.Count(x => x.IsDevelopmentDependency));
@@ -83,7 +83,7 @@ namespace Project2015To2017Tests
             var project = new ProjectReader().Read(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj"));
             var transformation = new TestProjectPackageReferenceTransformation();
 
-            transformation.Transform(project, NoopLogger.Instance);
+            transformation.Transform(project);
         }
     }
 }

--- a/Project2015To2017Tests/XamlTransformationTest.cs
+++ b/Project2015To2017Tests/XamlTransformationTest.cs
@@ -93,7 +93,7 @@ namespace Project2015To2017Tests
 
 			var transformation = new XamlPagesTransformation();
 
-			transformation.Transform(project, NoopLogger.Instance);
+			transformation.Transform(project);
 
 			var includeItems = project.ItemGroups.SelectMany(x => x.Elements()).ToImmutableList();
 


### PR DESCRIPTION
Putting `ILogger` as a parameter on the `ITransformation` call never really made sense to me so now that's refactored. Since that's a change to the public API it would need to go in prior to 2.0 non RC.