### PR TITLE
Remove default Version properties

### DIFF
--- a/Project2015To2017/ProjectConverter.cs
+++ b/Project2015To2017/ProjectConverter.cs
@@ -177,7 +177,6 @@ namespace Project2015To2017
 			return new ITransformation[]
 			{
 				targetFrameworkTransformation,
-				new PropertySimplificationTransformation(),
 				new PropertyDeduplicationTransformation(),
 				new TestProjectPackageReferenceTransformation(this.logger),
 				new AssemblyReferenceTransformation(),
@@ -189,6 +188,7 @@ namespace Project2015To2017
 				new AssemblyAttributeTransformation(this.logger, this.conversionOptions.KeepAssemblyInfo),
 				new XamlPagesTransformation(this.logger),
 				new PrimaryUnconditionalPropertyTransformation(),
+				new PropertySimplificationTransformation(),
 				new EmptyGroupRemoveTransformation(),
 			};
 		}

--- a/Project2015To2017/Transforms/PropertySimplificationTransformation.cs
+++ b/Project2015To2017/Transforms/PropertySimplificationTransformation.cs
@@ -152,6 +152,9 @@ namespace Project2015To2017.Transforms
 					                         ):
 					case "RestorePackages" when ValidateDefaultValue("true"):
 					case "SchemaVersion" when ValidateDefaultValue("2.0"):
+					case "AssemblyVersion" when ValidateDefaultValue("1.0.0.0"):
+					case "FileVersion" when ValidateDefaultValue("1.0.0.0"):
+					case "Version" when ValidateDefaultValue("1.0.0"):
 					// Conditional platform default values
 					case "PlatformTarget" when parentConditionHasPlatform
 					                           && child.Value == parentConditionPlatform

--- a/Project2015To2017Tests/PropertySimplificationTransformationTest.cs
+++ b/Project2015To2017Tests/PropertySimplificationTransformationTest.cs
@@ -46,6 +46,9 @@ namespace Project2015To2017Tests
     </SccProvider>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
+    <Version>1.0.0</Version>
   </PropertyGroup>
   <PropertyGroup Condition="" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' "">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
This removes any of the 3 possible Version properties if they are set to the default. Sometimes people set the version in CI or just never change it, so this leads to a simpler project file.

@andrew-boyarshin to get this new simplification to take advantage of your existing property simplicification I have moved the `PropertySimplificationTransformation` to later in the list of transforms. This seemed to have a knock-on effect on [this project](https://github.com/mungojam/Force.com-Toolkit-for-NET/blob/with-versions-cleared/src/ChatterToolkitForNET/ChatterToolkitForNET.csproj) which no longer has `<OutputPath>` in the unconditional property group, which it did have before [here](https://github.com/mungojam/Force.com-Toolkit-for-NET/blob/rc-fixes/src/ChatterToolkitForNET/ChatterToolkitForNET.csproj). Any idea which one is correct?