### PR TITLE
Remove MsTest references [WIP]

### DIFF
--- a/Project2015To2017/Transforms/TestProjectPackageReferenceTransformation.cs
+++ b/Project2015To2017/Transforms/TestProjectPackageReferenceTransformation.cs
@@ -23,9 +23,9 @@ namespace Project2015To2017.Transforms
 
 			var testReferences = new[]
 			{
-				new PackageReference {Id = "Microsoft.NET.Test.Sdk", Version = "15.0.0"},
-				new PackageReference {Id = "MSTest.TestAdapter", Version = "1.1.11"},
-				new PackageReference {Id = "MSTest.TestFramework", Version = "1.1.11"}
+				new PackageReference {Id = "Microsoft.NET.Test.Sdk", Version = "15.8.0"},
+				new PackageReference {Id = "MSTest.TestAdapter", Version = "1.3.2"},
+				new PackageReference {Id = "MSTest.TestFramework", Version = "1.3.2"}
 			};
 
 			var versions = definition.TargetFrameworks?


### PR DESCRIPTION
Attempting to fix #89 

I've found a project that displays the issue [before conversion](https://github.com/mungojam/dotnetrdf-fork/blob/master/Testing/unittest/dotNetRDF.Test.csproj) and [after](https://github.com/mungojam/dotnetrdf-fork/blob/converter-issue-89/Testing/unittest/dotNetRDF.Test.csproj)

I'm a bit confused, because I can't see anywhere in the transforms that removes MS test references, but I thought that I had seen them being dealt with before