### PR TITLE
Convert all file writes to output as UTF-8

### DIFF
--- a/Project2015To2017/Writing/ProjectWriter.cs
+++ b/Project2015To2017/Writing/ProjectWriter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Xml.Linq;
 using Microsoft.Extensions.Logging;
 using Project2015To2017.Definition;
@@ -69,7 +70,7 @@ namespace Project2015To2017.Writing
 				return false;
 			}
 
-			File.WriteAllText(projectFile.FullName, projectNode.ToString());
+			File.WriteAllText(projectFile.FullName, projectNode.ToString(), Encoding.UTF8);
 			return true;
 		}
 
@@ -100,7 +101,7 @@ namespace Project2015To2017.Writing
 				return false;
 			}
 
-			File.WriteAllText(file.FullName, newContents);
+			File.WriteAllText(file.FullName, newContents, Encoding.UTF8);
 
 			return true;
 		}

--- a/Project2015To2017Tests/ProjectPropertiesReadTest.cs
+++ b/Project2015To2017Tests/ProjectPropertiesReadTest.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Xml.Linq;
 using Project2015To2017.Definition;
 using Project2015To2017.Reading;
+using System.Text;
 
 namespace Project2015To2017Tests
 {
@@ -541,7 +542,7 @@ if $(ConfigurationName) == Debug (
 		{
 			var testCsProjFile = $"{memberName}_test.csproj";
 
-			await File.WriteAllTextAsync(testCsProjFile, xml);
+			await File.WriteAllTextAsync(testCsProjFile, xml, Encoding.UTF8);
 
 			var project = new ProjectReader().Read(testCsProjFile);
 

--- a/Project2015To2017Tests/ProjectWriterTest.cs
+++ b/Project2015To2017Tests/ProjectWriterTest.cs
@@ -9,6 +9,7 @@ using Project2015To2017.Writing;
 using System.Threading.Tasks;
 using System.Runtime.CompilerServices;
 using System.Xml.Linq;
+using System.Text;
 
 namespace Project2015To2017Tests
 {
@@ -186,7 +187,7 @@ namespace Project2015To2017Tests
 		{
 			var testCsProjFile = $"{memberName}_test.csproj";
 
-			await File.WriteAllTextAsync(testCsProjFile, xml);
+			await File.WriteAllTextAsync(testCsProjFile, xml, Encoding.UTF8);
 
 			var project = new ProjectReader().Read(testCsProjFile);
 

--- a/Project2015To2017Tests/PropertySimplificationTransformationTest.cs
+++ b/Project2015To2017Tests/PropertySimplificationTransformationTest.cs
@@ -9,6 +9,7 @@ using Project2015To2017.Reading;
 using Project2015To2017.Transforms;
 using static Project2015To2017.Extensions;
 using Project2015To2017;
+using System.Text;
 
 namespace Project2015To2017Tests
 {
@@ -279,7 +280,7 @@ namespace Project2015To2017Tests
 		{
 			var testCsProjFile = $"{memberName}_test.csproj";
 
-			File.WriteAllText(testCsProjFile, xml);
+			File.WriteAllText(testCsProjFile, xml, Encoding.UTF8);
 
 			var project = new ProjectReader().Read(testCsProjFile);
 			project.ProjectName = projectName;

--- a/Project2015To2017Tests/XamlTransformationTest.cs
+++ b/Project2015To2017Tests/XamlTransformationTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Project2015To2017;
@@ -121,7 +122,7 @@ namespace Project2015To2017Tests
 		{
 			var testCsProjFile = $"{memberName}_test.csproj";
 
-			await File.WriteAllTextAsync(testCsProjFile, xml);
+			await File.WriteAllTextAsync(testCsProjFile, xml, Encoding.UTF8);
 
 			var project = new ProjectReader().Read(testCsProjFile);
 


### PR DESCRIPTION
A while back in PR #17 the files were written out as UTF-8 which is the default.

The file writing process was changed from a streamwriter with UTF-8 encoding over to File.WriteAllText but UTF-8 seems to have been dropped so this PR adds it back.