### PR TITLE
Rename transformations for consistency

### DIFF
--- a/Project2015To2017/ProjectConverter.cs
+++ b/Project2015To2017/ProjectConverter.cs
@@ -173,7 +173,7 @@ namespace Project2015To2017
 
 		private IReadOnlyCollection<ITransformation> TransformationsToApply(bool modernProject)
 		{
-			var targetFrameworkTransformation = new TargetFrameworkTransformation(
+			var targetFrameworkTransformation = new TargetFrameworkReplaceTransformation(
 				this.conversionOptions.TargetFrameworks,
 				this.conversionOptions.AppendTargetFrameworkToOutputPath);
 
@@ -193,13 +193,13 @@ namespace Project2015To2017
 				new PropertySimplificationTransformation(),
 				new PropertyDeduplicationTransformation(),
 				new TestProjectPackageReferenceTransformation(this.logger),
-				new AssemblyReferenceTransformation(),
-				new RemovePackageAssemblyReferencesTransformation(),
-				new DefaultAssemblyReferenceRemovalTransformation(),
-				new RemovePackageImportsTransformation(),
+				new AssemblyFilterPackageReferencesTransformation(),
+				new AssemblyFilterHintedPackageReferencesTransformation(),
+				new AssemblyFilterDefaultTransformation(),
+				new ImportsTargetsFilterPackageReferencesTransformation(),
 				new FileTransformation(this.logger),
 				new XamlPagesTransformation(this.logger),
-				new PrimaryUnconditionalPropertyTransformation(),
+				new PrimaryProjectPropertiesUpdateTransformation(),
 				new EmptyGroupRemoveTransformation(),
 			};
 		}

--- a/Project2015To2017/Transforms/AssemblyAttributeTransformation.cs
+++ b/Project2015To2017/Transforms/AssemblyAttributeTransformation.cs
@@ -7,7 +7,7 @@ using Project2015To2017.Definition;
 
 namespace Project2015To2017.Transforms
 {
-	public sealed class AssemblyAttributeTransformation : ITransformation
+	public sealed class AssemblyAttributeTransformation : ILegacyOnlyProjectTransformation
 	{
 		private readonly ILogger logger;
 

--- a/Project2015To2017/Transforms/AssemblyFilterDefaultTransformation.cs
+++ b/Project2015To2017/Transforms/AssemblyFilterDefaultTransformation.cs
@@ -1,12 +1,10 @@
-using System;
 using System.Collections.Immutable;
 using System.Linq;
-using Microsoft.Extensions.Logging;
 using Project2015To2017.Definition;
 
 namespace Project2015To2017.Transforms
 {
-	public sealed class DefaultAssemblyReferenceRemovalTransformation : ITransformation
+	public sealed class AssemblyFilterDefaultTransformation : ILegacyOnlyProjectTransformation
 	{
 		public void Transform(Project definition)
 		{

--- a/Project2015To2017/Transforms/AssemblyFilterHintedPackageReferencesTransformation.cs
+++ b/Project2015To2017/Transforms/AssemblyFilterHintedPackageReferencesTransformation.cs
@@ -1,12 +1,10 @@
-using System;
 using System.IO;
 using System.Linq;
-using Microsoft.Extensions.Logging;
 using Project2015To2017.Definition;
 
 namespace Project2015To2017.Transforms
 {
-	public sealed class RemovePackageAssemblyReferencesTransformation : ITransformation
+	public sealed class AssemblyFilterHintedPackageReferencesTransformation : ILegacyOnlyProjectTransformation
 	{
 		public void Transform(Project definition)
 		{

--- a/Project2015To2017/Transforms/AssemblyFilterPackageReferencesTransformation.cs
+++ b/Project2015To2017/Transforms/AssemblyFilterPackageReferencesTransformation.cs
@@ -1,12 +1,10 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Extensions.Logging;
 using Project2015To2017.Definition;
 
 namespace Project2015To2017.Transforms
 {
-	public sealed class AssemblyReferenceTransformation : ITransformation
+	public sealed class AssemblyFilterPackageReferencesTransformation : ILegacyOnlyProjectTransformation
 	{
 		public void Transform(Project definition)
 		{

--- a/Project2015To2017/Transforms/FileTransformation.cs
+++ b/Project2015To2017/Transforms/FileTransformation.cs
@@ -9,7 +9,7 @@ using Project2015To2017.Definition;
 
 namespace Project2015To2017.Transforms
 {
-	public sealed class FileTransformation : ITransformation
+	public sealed class FileTransformation : ILegacyOnlyProjectTransformation
 	{
 		private static readonly IReadOnlyCollection<string> ItemsToProjectChecked = new[]
 		{

--- a/Project2015To2017/Transforms/ILegacyOnlyProjectTransformation.cs
+++ b/Project2015To2017/Transforms/ILegacyOnlyProjectTransformation.cs
@@ -1,0 +1,11 @@
+namespace Project2015To2017.Transforms
+{
+	/// <summary>
+	/// A transformation implementing this interface is supposed to be executed
+	/// only on projects under legacy project system (in ordinary situations)
+	/// </summary>
+	public interface ILegacyOnlyProjectTransformation : ITransformation
+	{
+
+	}
+}

--- a/Project2015To2017/Transforms/IModernOnlyProjectTransformation.cs
+++ b/Project2015To2017/Transforms/IModernOnlyProjectTransformation.cs
@@ -1,0 +1,11 @@
+namespace Project2015To2017.Transforms
+{
+	/// <summary>
+	/// A transformation implementing this interface is supposed to be executed
+	/// only on projects under CPS (in ordinary situations)
+	/// </summary>
+	public interface IModernOnlyProjectTransformation : ITransformation
+	{
+
+	}
+}

--- a/Project2015To2017/Transforms/ITransformation.cs
+++ b/Project2015To2017/Transforms/ITransformation.cs
@@ -1,5 +1,3 @@
-using System;
-using Microsoft.Extensions.Logging;
 using Project2015To2017.Definition;
 
 namespace Project2015To2017.Transforms

--- a/Project2015To2017/Transforms/ImportsTargetsFilterPackageReferencesTransformation.cs
+++ b/Project2015To2017/Transforms/ImportsTargetsFilterPackageReferencesTransformation.cs
@@ -1,14 +1,12 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
-using Microsoft.Extensions.Logging;
 using Project2015To2017.Definition;
 
 namespace Project2015To2017.Transforms
 {
-	public sealed class RemovePackageImportsTransformation : ITransformation
+	public sealed class ImportsTargetsFilterPackageReferencesTransformation : ILegacyOnlyProjectTransformation
 	{
 		public void Transform(Project definition)
 		{

--- a/Project2015To2017/Transforms/NuGetPackageTransformation.cs
+++ b/Project2015To2017/Transforms/NuGetPackageTransformation.cs
@@ -6,7 +6,7 @@ using Project2015To2017.Definition;
 
 namespace Project2015To2017.Transforms
 {
-	public sealed class NugetPackageTransformation : ITransformation
+	public sealed class NugetPackageTransformation : ILegacyOnlyProjectTransformation
 	{
 		public void Transform(Project definition)
 		{

--- a/Project2015To2017/Transforms/PrimaryProjectPropertiesUpdateTransformation.cs
+++ b/Project2015To2017/Transforms/PrimaryProjectPropertiesUpdateTransformation.cs
@@ -1,14 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Xml.Linq;
-using Microsoft.Extensions.Logging;
 using Project2015To2017.Definition;
 
 namespace Project2015To2017.Transforms
 {
-	public sealed class PrimaryUnconditionalPropertyTransformation : ITransformation
+	public sealed class PrimaryProjectPropertiesUpdateTransformation : ITransformation
 	{
 		public void Transform(Project project)
 		{

--- a/Project2015To2017/Transforms/PropertySimplificationTransformation.cs
+++ b/Project2015To2017/Transforms/PropertySimplificationTransformation.cs
@@ -11,7 +11,7 @@ using Project2015To2017.Reading.Conditionals;
 
 namespace Project2015To2017.Transforms
 {
-	public sealed class PropertySimplificationTransformation : ITransformation
+	public sealed class PropertySimplificationTransformation : ILegacyOnlyProjectTransformation
 	{
 		private static readonly string[] IgnoreProjectNameValues =
 		   {
@@ -215,7 +215,7 @@ namespace Project2015To2017.Transforms
 				{
 					return (valueLower == @default) && (!hasGlobalOverride || globalOverrideLower == @default);
 				}
-				
+
 				bool ValidateDefaultVersion()
 				{
 					return ValidateDefaultValue("1.0.0.0")

--- a/Project2015To2017/Transforms/TargetFrameworkReplaceTransformation.cs
+++ b/Project2015To2017/Transforms/TargetFrameworkReplaceTransformation.cs
@@ -1,13 +1,11 @@
-using System;
 using System.Collections.Generic;
-using Microsoft.Extensions.Logging;
 using Project2015To2017.Definition;
 
 namespace Project2015To2017.Transforms
 {
-	public sealed class TargetFrameworkTransformation : ITransformation
+	public sealed class TargetFrameworkReplaceTransformation : ITransformation
 	{
-		public TargetFrameworkTransformation(
+		public TargetFrameworkReplaceTransformation(
 			IReadOnlyList<string> targetFrameworks,
 			bool appendTargetFrameworkToOutputPath = true)
 		{

--- a/Project2015To2017/Transforms/TestProjectPackageReferenceTransformation.cs
+++ b/Project2015To2017/Transforms/TestProjectPackageReferenceTransformation.cs
@@ -1,11 +1,10 @@
-using System;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 using Project2015To2017.Definition;
 
 namespace Project2015To2017.Transforms
 {
-	public sealed class TestProjectPackageReferenceTransformation : ITransformation
+	public sealed class TestProjectPackageReferenceTransformation : ILegacyOnlyProjectTransformation
 	{
 		private readonly ILogger logger;
 

--- a/Project2015To2017/Transforms/XamlPagesTransformation.cs
+++ b/Project2015To2017/Transforms/XamlPagesTransformation.cs
@@ -8,7 +8,7 @@ using System.Xml.Linq;
 
 namespace Project2015To2017.Transforms
 {
-	public sealed class XamlPagesTransformation : ITransformation
+	public sealed class XamlPagesTransformation : ILegacyOnlyProjectTransformation
 	{
 		public XamlPagesTransformation(ILogger logger = null)
 		{

--- a/Project2015To2017Tests/AssemblyFilterDefaultTransformationTest.cs
+++ b/Project2015To2017Tests/AssemblyFilterDefaultTransformationTest.cs
@@ -1,15 +1,13 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Project2015To2017;
 using Project2015To2017.Definition;
 using Project2015To2017.Transforms;
 
 namespace Project2015To2017Tests
 {
 	[TestClass]
-	public class DefaultAssemblyReferenceRemovalTransformationTest
+	public class AssemblyFilterDefaultTransformationTest
 	{
 		[TestMethod]
 		public void PreventEmptyAssemblyReferences()
@@ -26,7 +24,7 @@ namespace Project2015To2017Tests
 				FilePath = new FileInfo("test.cs")
 			};
 
-			new DefaultAssemblyReferenceRemovalTransformation().Transform(project);
+			new AssemblyFilterDefaultTransformation().Transform(project);
 
 			Assert.AreEqual(0, project.AssemblyReferences.Count);
 		}

--- a/Project2015To2017Tests/AssemblyFilterHintedPackageReferencesTransformationTest.cs
+++ b/Project2015To2017Tests/AssemblyFilterHintedPackageReferencesTransformationTest.cs
@@ -1,24 +1,21 @@
-using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using Project2015To2017.Definition;
 using Project2015To2017.Reading;
 using Project2015To2017.Transforms;
-using Project2015To2017;
 
 namespace Project2015To2017Tests
 {
 	[TestClass]
-	public class RemovePackageAssemblyReferencesTransformationTest
+	public class AssemblyFilterHintedPackageReferencesTransformationTest
 	{
 		[TestMethod]
 		public void HandlesNoPackagesConfig()
 		{
 			var project = new Project();
 
-			var transformation = new RemovePackageAssemblyReferencesTransformation();
+			var transformation = new AssemblyFilterHintedPackageReferencesTransformation();
 			transformation.Transform(project);
 		}
 
@@ -38,7 +35,7 @@ namespace Project2015To2017Tests
 						Include = "System.Data.DataSetExtensions"
 					},
 					new AssemblyReference {
-					
+
 						Include = "Owin",
 						HintPath = @"..\packages\Owin.1.0\lib\net40\Owin.dll"
 					}
@@ -53,7 +50,7 @@ namespace Project2015To2017Tests
 				FilePath = new FileInfo(@".\dummy.csproj")
 			};
 
-			var transformation = new RemovePackageAssemblyReferencesTransformation();
+			var transformation = new AssemblyFilterHintedPackageReferencesTransformation();
 
 			transformation.Transform(project);
 
@@ -67,7 +64,7 @@ namespace Project2015To2017Tests
 
 			var project = new ProjectReader().Read(projFile);
 
-			var transformation = new RemovePackageAssemblyReferencesTransformation();
+			var transformation = new AssemblyFilterHintedPackageReferencesTransformation();
 
 			//Then attempt to clear any referencing the nuget packages folder
 			transformation.Transform(project);
@@ -76,35 +73,5 @@ namespace Project2015To2017Tests
 			Assert.AreEqual(1, project.AssemblyReferences.Count);
 			Assert.IsTrue(project.AssemblyReferences[0].Include.StartsWith("Owin"));
 		}
-
-		[TestMethod]
-		public void DedupeImportsFromPackagesAlternativePackagesFolder()
-		{
-			var projFile = @"TestFiles\AltNugetConfig\ProjectFolder\net46console.testcsproj";
-
-			var project = new ProjectReader().Read(projFile);
-
-			var transformation = new RemovePackageImportsTransformation();
-
-			//Then attempt to clear any referencing the nuget packages folder
-			transformation.Transform(project);
-
-			var expectedRemaining = new []
-			{
-				@"<Import Project=""C:\SomeTargets.props"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"" />",
-				@"<Import Project=""C:\SomeTargets.targets"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"" />"
-			};
-
-			var remainingImports = project.Imports
-										  .Select(x => x.ToString())
-										  .ToList();
-
-			//The only ones left which point to another folder
-			Assert.AreEqual(2, remainingImports.Count);
-			CollectionAssert.AreEqual(expectedRemaining, remainingImports);
-
-			Assert.IsFalse(project.Targets.Any());
-		}
-
 	}
 }

--- a/Project2015To2017Tests/AssemblyFilterPackageReferencesTransformationTest.cs
+++ b/Project2015To2017Tests/AssemblyFilterPackageReferencesTransformationTest.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
@@ -6,19 +5,18 @@ using System.Linq;
 using Project2015To2017.Definition;
 using Project2015To2017.Reading;
 using Project2015To2017.Transforms;
-using Project2015To2017;
 
 namespace Project2015To2017Tests
 {
 	[TestClass]
-	public class AssemblyReferenceTransformationTest
+	public class AssemblyFilterPackageReferencesTransformationTest
 	{
 		[TestMethod]
 		public void TransformsAssemblyReferences()
 		{
 			var project = new ProjectReader().Read(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj"));
-			var transformation = new AssemblyReferenceTransformation();
-			
+			var transformation = new AssemblyFilterPackageReferencesTransformation();
+
 			transformation.Transform(project);
 
 			Assert.AreEqual(12, project.AssemblyReferences.Count);
@@ -69,8 +67,8 @@ namespace Project2015To2017Tests
 				}
 			};
 
-			var transformation = new AssemblyReferenceTransformation();
-			
+			var transformation = new AssemblyFilterPackageReferencesTransformation();
+
 			transformation.Transform(project);
 
 			Assert.AreEqual(1, project.AssemblyReferences.Count);

--- a/Project2015To2017Tests/ImportsTargetsFilterPackageReferencesTransformationTest.cs
+++ b/Project2015To2017Tests/ImportsTargetsFilterPackageReferencesTransformationTest.cs
@@ -1,0 +1,40 @@
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Project2015To2017.Reading;
+using Project2015To2017.Transforms;
+
+namespace Project2015To2017Tests
+{
+	[TestClass]
+	public class ImportsTargetsFilterPackageReferencesTransformationTest
+	{
+		[TestMethod]
+		public void DedupeImportsFromPackagesAlternativePackagesFolder()
+		{
+			var projFile = @"TestFiles\AltNugetConfig\ProjectFolder\net46console.testcsproj";
+
+			var project = new ProjectReader().Read(projFile);
+
+			var transformation = new ImportsTargetsFilterPackageReferencesTransformation();
+
+			//Then attempt to clear any referencing the nuget packages folder
+			transformation.Transform(project);
+
+			var expectedRemaining = new []
+			{
+				@"<Import Project=""C:\SomeTargets.props"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"" />",
+				@"<Import Project=""C:\SomeTargets.targets"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"" />"
+			};
+
+			var remainingImports = project.Imports
+				.Select(x => x.ToString())
+				.ToList();
+
+			//The only ones left which point to another folder
+			Assert.AreEqual(2, remainingImports.Count);
+			CollectionAssert.AreEqual(expectedRemaining, remainingImports);
+
+			Assert.IsFalse(project.Targets.Any());
+		}
+	}
+}

--- a/Project2015To2017Tests/PrimaryProjectPropertiesUpdateTransformationTest.cs
+++ b/Project2015To2017Tests/PrimaryProjectPropertiesUpdateTransformationTest.cs
@@ -1,14 +1,13 @@
 using System.IO;
 using System.Xml.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Project2015To2017;
 using Project2015To2017.Definition;
 using Project2015To2017.Transforms;
 
 namespace Project2015To2017Tests
 {
 	[TestClass]
-	public class PrimaryUnconditionalPropertyTransformationTest
+	public class PrimaryProjectPropertiesUpdateTransformationTest
 	{
 		[TestMethod]
 		public void OutputAppendTargetFrameworkToOutputPathTrue()
@@ -21,7 +20,7 @@ namespace Project2015To2017Tests
 				FilePath = new FileInfo("test.cs")
 			};
 
-			new PrimaryUnconditionalPropertyTransformation().Transform(project);
+			new PrimaryProjectPropertiesUpdateTransformation().Transform(project);
 
 			var appendTargetFrameworkToOutputPath = project.Property("AppendTargetFrameworkToOutputPath");
 			Assert.IsNull(appendTargetFrameworkToOutputPath);
@@ -38,7 +37,7 @@ namespace Project2015To2017Tests
 				FilePath = new FileInfo("test.cs")
 			};
 
-			new PrimaryUnconditionalPropertyTransformation().Transform(project);
+			new PrimaryProjectPropertiesUpdateTransformation().Transform(project);
 
 			var appendTargetFrameworkToOutputPath = project.Property("AppendTargetFrameworkToOutputPath");
 			Assert.IsNotNull(appendTargetFrameworkToOutputPath);

--- a/Project2015To2017Tests/TargetFrameworkReplaceTransformationTest.cs
+++ b/Project2015To2017Tests/TargetFrameworkReplaceTransformationTest.cs
@@ -1,14 +1,12 @@
-using System;
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Project2015To2017;
 using Project2015To2017.Definition;
 using Project2015To2017.Transforms;
 
 namespace Project2015To2017Tests
 {
 	[TestClass]
-	public class TargetFrameworkTransformationTest
+	public class TargetFrameworkReplaceTransformationTest
 	{
 		[TestMethod]
 		public void HandlesProjectNull()
@@ -16,19 +14,19 @@ namespace Project2015To2017Tests
 			Project project = null;
 			var targetFrameworks = new List<string> { "netstandard2.0" };
 
-			var transformation = new TargetFrameworkTransformation(targetFrameworks);
+			var transformation = new TargetFrameworkReplaceTransformation(targetFrameworks);
 			transformation.Transform(project);
 
 			Assert.IsNull(project);
 		}
-		
+
 		[TestMethod]
 		public void HandlesProjectTargetFrameworksEmpty()
 		{
 			var project = new Project();
 			var targetFrameworks = new List<string> { "netstandard2.0" };
 
-			var transformation = new TargetFrameworkTransformation(targetFrameworks);
+			var transformation = new TargetFrameworkReplaceTransformation(targetFrameworks);
 			transformation.Transform(project);
 
 			Assert.AreEqual(1, project.TargetFrameworks.Count);
@@ -42,8 +40,8 @@ namespace Project2015To2017Tests
 			{
 				TargetFrameworks = { "net46" }
 			};
-			
-			var transformation = new TargetFrameworkTransformation(null);
+
+			var transformation = new TargetFrameworkReplaceTransformation(null);
 			transformation.Transform(project);
 
 			Assert.AreEqual(1, project.TargetFrameworks.Count);
@@ -58,7 +56,7 @@ namespace Project2015To2017Tests
 				TargetFrameworks = { "net46" }
 			};
 
-			var transformation = new TargetFrameworkTransformation(new List<string>());
+			var transformation = new TargetFrameworkReplaceTransformation(new List<string>());
 			transformation.Transform(project);
 
 			Assert.AreEqual(1, project.TargetFrameworks.Count);
@@ -74,7 +72,7 @@ namespace Project2015To2017Tests
 			};
 			var targetFrameworks = new List<string> { "netstandard2.0" };
 
-			var transformation = new TargetFrameworkTransformation(targetFrameworks);
+			var transformation = new TargetFrameworkReplaceTransformation(targetFrameworks);
 			transformation.Transform(project);
 
 			Assert.AreEqual(1, project.TargetFrameworks.Count);
@@ -90,7 +88,7 @@ namespace Project2015To2017Tests
 			};
 			var targetFrameworks = new List<string> { "netstandard2.0", "net47" };
 
-			var transformation = new TargetFrameworkTransformation(targetFrameworks);
+			var transformation = new TargetFrameworkReplaceTransformation(targetFrameworks);
 			transformation.Transform(project);
 
 			Assert.AreEqual(2, project.TargetFrameworks.Count);
@@ -103,7 +101,7 @@ namespace Project2015To2017Tests
 		{
 			var project = new Project();
 
-			var transformation = new TargetFrameworkTransformation(null, true);
+			var transformation = new TargetFrameworkReplaceTransformation(null, true);
 			transformation.Transform(project);
 
 			Assert.AreEqual(true, project.AppendTargetFrameworkToOutputPath);
@@ -114,7 +112,7 @@ namespace Project2015To2017Tests
 		{
 			var project = new Project();
 
-			var transformation = new TargetFrameworkTransformation(null, false);
+			var transformation = new TargetFrameworkReplaceTransformation(null, false);
 			transformation.Transform(project);
 
 			Assert.AreEqual(false, project.AppendTargetFrameworkToOutputPath);


### PR DESCRIPTION
* Rename transformations for consistency
* Add `ILegacyOnlyProjectTransformation` and `IModernOnlyProjectTransformation` for future PR
* Rename transformation tests to match
* Move one test to its own `ImportsTargetsFilterPackageReferencesTransformationTest` file
* Remove unused using statements