### PR TITLE
Improve CLI, fix bugs

### DIFF
--- a/Project2015To2017.Console/Program.cs
+++ b/Project2015To2017.Console/Program.cs
@@ -1,10 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using CommandLine;
 using Microsoft.Extensions.Logging;
 using Project2015To2017.Analysis;
 using Project2015To2017.Definition;
+using Project2015To2017.Reading;
 using Project2015To2017.Transforms;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Project2015To2017.Console
 {
@@ -30,7 +33,7 @@ namespace Project2015To2017.Console
 			foreach (var file in options.Files)
 			{
 				var projects = new ProjectConverter(logger, Vs15TransformationSet.Instance, conversionOptions)
-					.Convert(file)
+					.Convert(file, logger)
 					.Where(x => x != null)
 					.ToList();
 				convertedProjects.AddRange(projects);
@@ -68,7 +71,7 @@ namespace Project2015To2017.Console
 			foreach (var file in options.Files)
 			{
 				var projects = new ProjectConverter(logger, BasicReadTransformationSet.Instance, conversionOptions)
-					.Convert(file)
+					.Convert(file, logger)
 					.Where(x => x != null)
 					.ToList();
 				convertedProjects.AddRange(projects);
@@ -79,6 +82,81 @@ namespace Project2015To2017.Console
 			foreach (var project in convertedProjects)
 			{
 				analyzer.Analyze(project);
+			}
+		}
+
+		private static IEnumerable<Project> Convert(this ProjectConverter self, string target, ILogger logger)
+		{
+			var extension = Path.GetExtension(target) ?? throw new ArgumentNullException(nameof(target));
+			if (extension.Length > 0)
+			{
+				var file = new FileInfo(target);
+
+				switch (extension)
+				{
+					case ".sln":
+					{
+						var solution = SolutionReader.Instance.Read(file, logger);
+						foreach (var project in self.ProcessSolutionFile(solution))
+						{
+							yield return project;
+						}
+						break;
+					}
+					case string s when ProjectConverter.ProjectFileMappings.ContainsKey(extension):
+					{
+						yield return self.ProcessProjectFile(file, null);
+						break;
+					}
+					default:
+						logger.LogCritical("Please specify a project or solution file.");
+						break;
+				}
+
+				yield break;
+			}
+
+			// Process the only solution in given directory
+			var solutionFiles = Directory.EnumerateFiles(target, "*.sln", SearchOption.TopDirectoryOnly).ToArray();
+			if (solutionFiles.Length == 1)
+			{
+				var solution = SolutionReader.Instance.Read(solutionFiles[0], logger);
+				foreach (var project in self.ProcessSolutionFile(solution))
+				{
+					yield return project;
+				}
+
+				yield break;
+			}
+
+			var projectsProcessed = 0;
+			// Process all csprojs found in given directory
+			foreach (var fileExtension in ProjectConverter.ProjectFileMappings.Keys)
+			{
+				var projectFiles = Directory.EnumerateFiles(target, "*" + fileExtension, SearchOption.AllDirectories).ToArray();
+				if (projectFiles.Length == 0)
+				{
+					continue;
+				}
+
+				if (projectFiles.Length > 1)
+				{
+					logger.LogInformation($"Multiple project files found under directory {target}:");
+				}
+
+				logger.LogInformation(string.Join(Environment.NewLine, projectFiles));
+
+				foreach (var projectFile in projectFiles)
+				{
+					// todo: rewrite both directory enumerations to use FileInfo instead of raw strings
+					yield return self.ProcessProjectFile(new FileInfo(projectFile), null);
+					projectsProcessed++;
+				}
+			}
+
+			if (projectsProcessed == 0)
+			{
+				logger.LogCritical("Please specify a project file.");
 			}
 		}
 	}

--- a/Project2015To2017.Migrate2017.Tool/CommandLogic.cs
+++ b/Project2015To2017.Migrate2017.Tool/CommandLogic.cs
@@ -1,48 +1,146 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
+using DotNet.Globbing;
 using Project2015To2017.Analysis;
 using Project2015To2017.Definition;
+using Project2015To2017.Reading;
 using Project2015To2017.Transforms;
 using Project2015To2017.Writing;
+using Serilog;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
 
 namespace Project2015To2017.Migrate2017.Tool
 {
 	public class CommandLogic
 	{
 		private readonly Microsoft.Extensions.Logging.ILogger genericLogger;
+		private ImmutableArray<(string path, string extension)> files;
+		private readonly ImmutableArray<string> extensions;
 
 		public CommandLogic()
 		{
 			this.genericLogger = new Serilog.Extensions.Logging.SerilogLoggerProvider().CreateLogger(nameof(Serilog));
+			extensions = ProjectConverter.ProjectFileMappings.Keys.Concat(new[] {".sln"}).ToImmutableArray();
 		}
 
-		public IReadOnlyCollection<Project> ParseProjects(
+		public void DoProcessableFileSearch(bool force = false)
+		{
+			if (files != null && files.Length > 0 && !force)
+			{
+				Log.Verbose("Glob file list reevaluation skipped");
+				return;
+			}
+
+			Log.Verbose("Glob file list reevaluation started");
+			files = Directory.EnumerateFiles(Directory.GetCurrentDirectory(), "*.*", SearchOption.AllDirectories)
+				.Select(x => (path: x, extension: Path.GetExtension(x)?.ToLowerInvariant()))
+				.Where(x => !string.IsNullOrEmpty(x.extension))
+				.Where(x => extensions.Contains(x.extension))
+				.ToImmutableArray();
+			Log.Verbose("Glob file list reevaluation finished: {Count} items", files.Length);
+		}
+
+		public (IReadOnlyCollection<Project> projects, IReadOnlyCollection<Solution> solutions) ParseProjects(
 			IEnumerable<string> items,
 			ITransformationSet transformationSet,
 			ConversionOptions conversionOptions)
 		{
+			var converter = new ProjectConverter(genericLogger, transformationSet, conversionOptions);
 			var convertedProjects = new List<Project>();
+			var convertedSolutions = new List<Solution>();
 
-			foreach (var file in items)
+			foreach (var pattern in items)
 			{
-				var projects = new ProjectConverter(genericLogger, transformationSet, conversionOptions)
-					.Convert(file)
-					.Where(x => x != null)
-					.ToList();
-				convertedProjects.AddRange(projects);
+				if (File.Exists(pattern))
+				{
+					var file = new FileInfo(pattern);
+					var extension = file.Extension.ToLowerInvariant();
+					ProcessSingleItem(file, extension);
+					continue;
+				}
+
+				if (Directory.Exists(pattern))
+				{
+					var dir = new DirectoryInfo(pattern);
+					var cwdFiles = dir.GetFiles()
+						.Where(x => extensions.Contains(x.Extension.ToLowerInvariant()))
+						.ToImmutableArray();
+					if (cwdFiles.Length == 1)
+					{
+						var file = cwdFiles[0];
+						var extension = file.Extension.ToLowerInvariant();
+						ProcessSingleItem(file, extension);
+					}
+					else
+					{
+						Log.Warning(
+							"Directory {Directory} contains {Count} matching files, specify which project or solution file to use.",
+							dir, cwdFiles.Length);
+					}
+
+					continue;
+				}
+
+				Log.Verbose("Falling back to globbing");
+				DoProcessableFileSearch();
+				var glob = Glob.Parse(pattern);
+				Log.Verbose("Parsed glob {Glob}", glob);
+				foreach (var (path, extension) in files)
+				{
+					if (!glob.IsMatch(path)) continue;
+					var file = new FileInfo(path);
+					ProcessSingleItem(file, extension);
+				}
 			}
 
-			return convertedProjects;
+			return (convertedProjects, convertedSolutions);
+
+			void ProcessSingleItem(FileInfo file, string extension)
+			{
+				Log.Verbose("Processing {Item}", file);
+				switch (extension)
+				{
+					case ".sln":
+					{
+						var solution = SolutionReader.Instance.Read(file, genericLogger);
+						convertedSolutions.Add(solution);
+						convertedProjects.AddRange(converter.ProcessSolutionFile(solution));
+						break;
+					}
+					default:
+					{
+						convertedProjects.Add(converter.ProcessProjectFile(file, null));
+						break;
+					}
+				}
+			}
 		}
 
 		public void ExecuteEvaluate(
 			IReadOnlyCollection<string> items,
 			ConversionOptions conversionOptions)
 		{
-			var convertedProjects = ParseProjects(items, Vs15TransformationSet.Instance, conversionOptions);
+			var (projects, solutions) = ParseProjects(items, Vs15TransformationSet.Instance, conversionOptions);
 
-			DoAnalysis(convertedProjects);
+			if (projects.Count == 0)
+			{
+				return;
+			}
+
+			var diagnosticSet = DiagnosticSet.NoneDefault;
+			diagnosticSet.Add(DiagnosticSet.W001);
+			diagnosticSet.Add(DiagnosticSet.W010);
+			diagnosticSet.Add(DiagnosticSet.W011);
+			DoAnalysis(projects, new AnalysisOptions(diagnosticSet));
+
+			var projectPaths = solutions.SelectMany(x => x.UnsupportedProjectPaths).ToImmutableArray();
+			if (projectPaths.Length <= 0) return;
+			Log.Information("List of unsupported solution projects:");
+			foreach (var projectPath in projectPaths)
+			{
+				Log.Warning("Project {ProjectPath} not supported", projectPath);
+			}
 		}
 
 		public void ExecuteMigrate(
@@ -50,35 +148,46 @@ namespace Project2015To2017.Migrate2017.Tool
 			bool noBackup,
 			ConversionOptions conversionOptions)
 		{
-			var convertedProjects = ParseProjects(items, Vs15TransformationSet.Instance, conversionOptions);
+			var (projects, _) = ParseProjects(items, Vs15TransformationSet.Instance, conversionOptions);
+
+			if (projects.Count == 0)
+			{
+				return;
+			}
 
 			var doBackup = !noBackup;
 
 			var writer = new ProjectWriter(genericLogger, x => x.Delete(), _ => { });
-			foreach (var project in convertedProjects)
+			foreach (var project in projects)
 			{
 				writer.Write(project, doBackup);
 			}
 
 			conversionOptions.ProjectCache?.Purge();
 
-			convertedProjects = ParseProjects(items, BasicReadTransformationSet.Instance, conversionOptions);
+			(projects, _) = ParseProjects(items, BasicReadTransformationSet.Instance, conversionOptions);
 
-			DoAnalysis(convertedProjects);
+			DoAnalysis(projects);
 		}
 
 		public void ExecuteAnalyze(
 			IReadOnlyCollection<string> items,
 			ConversionOptions conversionOptions)
 		{
-			var convertedProjects = ParseProjects(items, BasicReadTransformationSet.Instance, conversionOptions);
+			var (projects, _) = ParseProjects(items, BasicReadTransformationSet.Instance, conversionOptions);
 
-			DoAnalysis(convertedProjects);
+			if (projects.Count == 0)
+			{
+				return;
+			}
+
+			DoAnalysis(projects);
 		}
 
-		private void DoAnalysis(IEnumerable<Project> convertedProjects)
+		private void DoAnalysis(IEnumerable<Project> convertedProjects, AnalysisOptions options = null)
 		{
-			var analyzer = new Analyzer<LoggerReporter, LoggerReporterOptions>(new LoggerReporter(genericLogger));
+			Log.Verbose("Starting analysis...");
+			var analyzer = new Analyzer<LoggerReporter, LoggerReporterOptions>(new LoggerReporter(genericLogger), options);
 
 			foreach (var project in convertedProjects)
 			{

--- a/Project2015To2017.Migrate2017.Tool/Program.cs
+++ b/Project2015To2017.Migrate2017.Tool/Program.cs
@@ -99,6 +99,10 @@ namespace Project2015To2017.Migrate2017.Tool
 			if (frameworks != null)
 				conversionOptions.TargetFrameworks = frameworks;
 
+			var forceTransformations = command.ValueOrDefault<string[]>("force-transformations");
+			if (forceTransformations != null)
+				conversionOptions.ForceDefaultTransforms = forceTransformations;
+
 			var logic = new CommandLogic();
 			switch (command.Name)
 			{
@@ -145,6 +149,12 @@ namespace Project2015To2017.Migrate2017.Tool
 			OneOrMoreArguments()
 				.With("Target frameworks to be used instead of the ones in source projects", "frameworks"));
 
+		private static Option ForceTransformationsOption => Option(
+			"-f|--force-transformations",
+			"Force execution of transformations despite project conversion state by their specified names.",
+			OneOrMoreArguments()
+				.With("Transformation names to enforce execution", "names"));
+
 		private static Command Evaluate() =>
 			Command("evaluate",
 				"Examine the projects potential to be converted before actual migration",
@@ -163,6 +173,7 @@ namespace Project2015To2017.Migrate2017.Tool
 				TargetFrameworksOption,
 				Option("-o|--old-output-path",
 					"Preserve legacy behavior by not creating a subfolder with the target framework in the output path."),
+				ForceTransformationsOption,
 				HelpOption());
 
 		private static Command Analyze() =>

--- a/Project2015To2017.Migrate2017.Tool/Project2015To2017.Migrate2017.Tool.csproj
+++ b/Project2015To2017.Migrate2017.Tool/Project2015To2017.Migrate2017.Tool.csproj
@@ -31,6 +31,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="DotNet.Glob" Version="2.1.0" />
 		<PackageReference Include="Microsoft.DotNet.Cli.CommandLine" Version="0.2.1-alpha-63223-01" />
 		<PackageReference Include="Serilog" Version="2.7.1" />
 		<PackageReference Include="Serilog.Enrichers.Demystify" Version="0.1.0-dev-00016" />

--- a/Project2015To2017.sln.DotSettings
+++ b/Project2015To2017.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String></wpf:ResourceDictionary>

--- a/Project2015To2017/ConversionOptions.cs
+++ b/Project2015To2017/ConversionOptions.cs
@@ -32,5 +32,10 @@ namespace Project2015To2017
 	    /// A collection of transforms executed after the execution of default ones
 	    /// </summary>
 	    public IReadOnlyList<ITransformation> PostDefaultTransforms { get; set; } = ImmutableArray<ITransformation>.Empty;
+	    /// <summary>
+	    /// A collection of transform class names executed despite being intended for different project system,
+	    /// like forcing <see cref="ILegacyOnlyProjectTransformation"/> run on already converted project.
+	    /// </summary>
+	    public IReadOnlyList<string> ForceDefaultTransforms { get; set; } = ImmutableArray<string>.Empty;
 	}
 }

--- a/Project2015To2017/Definition/Solution.cs
+++ b/Project2015To2017/Definition/Solution.cs
@@ -9,6 +9,7 @@ namespace Project2015To2017.Definition
 		public FileInfo FilePath { get; set; }
 		public IReadOnlyList<ProjectReference> ProjectPaths { get; set; }
 		public DirectoryInfo SolutionFolder => this.FilePath.Directory;
+		public IReadOnlyList<string> UnsupportedProjectPaths { get; set; }
 
 		/// <summary>
 		/// The directory where nuget stores its extracted packages for the solution.

--- a/Project2015To2017/Reading/ConditionEvaluator.cs
+++ b/Project2015To2017/Reading/ConditionEvaluator.cs
@@ -127,6 +127,12 @@ namespace Project2015To2017.Reading
 				return res;
 			}
 
+			// in case we don't know what some part of the condition does - don't make any assumptions at all
+			if (state.UnsupportedNodes.Count > 0)
+			{
+				return res;
+			}
+
 			foreach (var keyValuePair in GetConditionValues(state))
 			{
 				if (keyValuePair.Value.Count != 1)
@@ -189,7 +195,11 @@ namespace Project2015To2017.Reading
 			switch (node)
 			{
 				case OrExpressionNode or:
-					yield return or;
+					if (!IsSupportedSolutionDirNode(or))
+					{
+						yield return or;
+					}
+
 					break;
 				case NotExpressionNode not when !IsSupportedFunctionCallNode(not.LeftChild):
 					yield return not;
@@ -228,6 +238,52 @@ namespace Project2015To2017.Reading
 			}
 
 			return false;
+		}
+
+		internal static bool IsSupportedSolutionDirNode(OperatorExpressionNode or)
+		{
+			if (!(or.LeftChild is EqualExpressionNode left))
+			{
+				return false;
+			}
+
+			if (!(or.RightChild is EqualExpressionNode right))
+			{
+				return false;
+			}
+
+			if (!VerifyEquals(left.LeftChild, left.RightChild, "$(SolutionDir)", ""))
+			{
+				return false;
+			}
+
+			if (!VerifyEquals(right.LeftChild, right.RightChild, "$(SolutionDir)", "*Undefined*"))
+			{
+				return false;
+			}
+
+			return true;
+		}
+
+		public static bool VerifyEquals(
+			GenericExpressionNode left,
+			GenericExpressionNode right,
+			string expectedLeft,
+			string expectedRight)
+		{
+			if (!(left is StringExpressionNode leftString))
+			{
+				return false;
+			}
+
+			if (!(right is StringExpressionNode rightString))
+			{
+				return false;
+			}
+
+			var leftValue = leftString.GetUnexpandedValue(null);
+			var rightValue = rightString.GetUnexpandedValue(null);
+			return (leftValue == expectedLeft) && (rightValue == expectedRight);
 		}
 	}
 }

--- a/Project2015To2017/Reading/NuSpecReader.cs
+++ b/Project2015To2017/Reading/NuSpecReader.cs
@@ -24,14 +24,17 @@ namespace Project2015To2017.Reading
 
 			if (nuspecFiles.Length == 0)
 			{
-				this.logger.LogInformation("No nuspec found, skipping package configuration.");
+				this.logger.LogDebug("No nuspec found, skipping package configuration.");
 				return null;
 			}
 
 			if (nuspecFiles.Length > 1)
 			{
-				this.logger.LogError($@"Could not read from nuspec, multiple nuspecs found: 
-{string.Join(Environment.NewLine, nuspecFiles.Select(x => x.FullName))}.");
+				this.logger.LogError(@"Could not read from nuspec, multiple nuspecs found.");
+				foreach (var item in nuspecFiles.Select(x => x.FullName))
+				{
+					this.logger.LogInformation(item);
+				}
 				return null;
 			}
 

--- a/Project2015To2017/Reading/ProjectPropertiesReader.cs
+++ b/Project2015To2017/Reading/ProjectPropertiesReader.cs
@@ -98,7 +98,8 @@ namespace Project2015To2017.Reading
 				.ToArray();
 		}
 
-		private static (List<string>, List<string>) ReadConfigurationPlatformVariants(Project project)
+		private static (List<string> configurations, List<string> platforms)
+			ReadConfigurationPlatformVariants(Project project)
 		{
 			var configurationSet = new HashSet<string>();
 			var platformSet = new HashSet<string>();

--- a/Project2015To2017/Reading/ProjectReader.cs
+++ b/Project2015To2017/Reading/ProjectReader.cs
@@ -168,7 +168,7 @@ namespace Project2015To2017.Reading
 
 			if (!packagesConfig.Exists)
 			{
-				this.logger.LogInformation("Packages.config file not found.");
+				this.logger.LogDebug("Packages.config file not found.");
 				return null;
 			}
 
@@ -199,14 +199,14 @@ namespace Project2015To2017.Reading
 
 				foreach (var reference in packageReferences)
 				{
-					this.logger.LogDebug($"Found nuget reference to {reference.Id}, version {reference.Version}.");
+					this.logger.LogDebug($"Found NuGet reference to {reference.Id}, version {reference.Version}.");
 				}
 
 				return packageReferences;
 			}
 			catch (XmlException e)
 			{
-				this.logger.LogError($"Got xml exception reading packages.config: " + e.Message);
+				this.logger.LogError(default, e, "Got xml exception reading packages.config");
 			}
 
 			return Array.Empty<PackageReference>();

--- a/Project2015To2017/Transforms/AssemblyAttributeTransformation.cs
+++ b/Project2015To2017/Transforms/AssemblyAttributeTransformation.cs
@@ -26,7 +26,7 @@ namespace Project2015To2017.Transforms
 			{
 				if (definition.HasMultipleAssemblyInfoFiles)
 				{
-					definition.AssemblyAttributeProperties = new[] { new XElement("GenerateAssemblyInfo", "false") };
+					definition.SetProperty("GenerateAssemblyInfo", "false");
 				}
 
 				return;

--- a/Project2015To2017/Transforms/FileTransformation.cs
+++ b/Project2015To2017/Transforms/FileTransformation.cs
@@ -85,7 +85,7 @@ namespace Project2015To2017.Transforms
 				return;
 			}
 
-			logger.LogInformation($"Removed {count} include items thanks to Microsoft.NET.Sdk defaults");
+			logger.LogDebug($"Removed {count} include items thanks to Microsoft.NET.Sdk defaults");
 		}
 
 		private static bool KeepFileInclusion(XElement x, Project project)

--- a/Project2015To2017/Transforms/TestProjectPackageReferenceTransformation.cs
+++ b/Project2015To2017/Transforms/TestProjectPackageReferenceTransformation.cs
@@ -46,7 +46,7 @@ namespace Project2015To2017.Transforms
 
 			foreach (var reference in testReferences)
 			{
-				logger.LogInformation($"Adding nuget reference to {reference.Id}, version {reference.Version}.");
+				logger.LogInformation($"Adding NuGet reference to {reference.Id}, version {reference.Version}.");
 			}
 
 			definition.PackageReferences = adjustedPackageReferences;

--- a/Project2015To2017/Transforms/XamlPagesTransformation.cs
+++ b/Project2015To2017/Transforms/XamlPagesTransformation.cs
@@ -41,7 +41,7 @@ namespace Project2015To2017.Transforms
 				return;
 			}
 
-			logger.LogInformation($"Removed {count} XAML items thanks to MSBuild.Sdk.Extras defaults");
+			logger.LogDebug($"Removed {count} XAML items thanks to MSBuild.Sdk.Extras defaults");
 		}
 
 		private static readonly string[] FilteredTags = {"Page", "ApplicationDefinition", "Compile", "None"};

--- a/Project2015To2017Tests/AssemblyAttributeTransformationTest.cs
+++ b/Project2015To2017Tests/AssemblyAttributeTransformationTest.cs
@@ -410,10 +410,8 @@ namespace Project2015To2017Tests
 
 			transform.Transform(project);
 
-			var generateAssemblyInfo = project.AssemblyAttributeProperties.SingleOrDefault();
-			Assert.IsNotNull(generateAssemblyInfo);
-			Assert.AreEqual("GenerateAssemblyInfo", generateAssemblyInfo.Name);
-			Assert.AreEqual("false", generateAssemblyInfo.Value);
+			Assert.AreEqual(0, project.AssemblyAttributeProperties.Count);
+			Assert.AreEqual("false", project.Property("GenerateAssemblyInfo")?.Value);
 
 			CollectionAssert.DoesNotContain(project.Deletions?.ToList(), BaseAssemblyAttributes().File);
 		}

--- a/Project2015To2017Tests/SolutionReaderTests.cs
+++ b/Project2015To2017Tests/SolutionReaderTests.cs
@@ -15,9 +15,7 @@ namespace Project2015To2017Tests
 
 			var logger = new DummyLogger {MinimumLogLevel = LogLevel.Warning};
 
-			var reader = new SolutionReader();
-
-			reader.Read(testFile, logger);
+			SolutionReader.Instance.Read(testFile, logger);
 
 			//Should be no warnings or errors
 			Assert.IsFalse(logger.LogEntries.Any());


### PR DESCRIPTION
* Make specialized `ProjectConverter` methods public
* Rewrite projects selection logic from scratch for modern CLI tool
* Add globbing as a fallback to modern CLI tool
* Reduce default log verbosity (mark common messages as _Debug_ instead of _Informational_)
* Add Trace level logging to modern CLI tool
* Make evaluate command use only _W00x_ and _W01x_ analyzer diagnostic sets
* Print unsupported solution projects in evaluate command
* Add `--force-transformations` CLI option
* Make `ConditionEvaluator` much safer against unknown conditionals
* Revert `<SolutionDir />` removal from `PropertySimplificationTransformation` (it is not the default in CPS, used when running MSBuild on single project instead of solution). Refer to #165.
* Fix NuGet name case in log messages
* Use `FileInfo` as argument in `SolutionReader`
* Fix missing `<GenerateAssemblyInfo>false</GenerateAssemblyInfo>` after #177.
* Save our private field naming convention for JetBrains products

[Good attempt at creating normal changelog](https://github.com/hvanbakel/CsprojToVs2017/wiki/Changelog)