### PR TITLE
Exclude files when previously excluded and no wildcards are in play

### DIFF
--- a/Project2015To2017/Transforms/FileTransformation.cs
+++ b/Project2015To2017/Transforms/FileTransformation.cs
@@ -58,22 +58,25 @@ namespace Project2015To2017.Transforms
 				.Where(x => !string.IsNullOrEmpty(x))
 				.ToArray();
 
+			var otherIncludeFilesMatchingWildcard = includes
+				.Where(x => x.EndsWith("." + definition.CodeFileExtension, StringComparison.OrdinalIgnoreCase))
+				.ToArray();
+
 			var wildcardIncludes = keepItems.Where(x => x.Name.LocalName == "Compile").Select(x => x.Attribute("Include")?.Value).Where(x => x != null && x.Contains("*")).ToArray();
 			if (wildcardIncludes.Length > 0)
 			{
 				this.logger.LogWarning("Wildcard include detected, please check for erroneous inclusion of additional files.");
 			}
+			else
+			{
+				var removedIncludes = removeQueue
+					.Where(x => x.Name.LocalName == "Compile")
+					.Select(x => x.Attribute("Update")?.Value)
+					.Where(x => !string.IsNullOrEmpty(x))
+					.ToArray();
 
-			var removedIncludes = removeQueue
-				.Where(x => x.Name.LocalName == "Compile")
-				.Select(x => x.Attribute("Update")?.Value)
-				.Where(x => !string.IsNullOrEmpty(x))
-				.ToArray();
-
-			var otherIncludeFilesMatchingWildcard = includes
-				.Where(x => x.EndsWith("." + definition.CodeFileExtension, StringComparison.OrdinalIgnoreCase))
-				.Union(PreviouslyExcludedFiles(definition, removedIncludes))
-				.ToArray();
+				otherIncludeFilesMatchingWildcard = otherIncludeFilesMatchingWildcard.Union(PreviouslyExcludedFiles(definition, removedIncludes)).ToArray();
+			}
 
 			if (otherIncludeFilesMatchingWildcard.Length > 0)
 			{

--- a/Project2015To2017/Transforms/FileTransformation.cs
+++ b/Project2015To2017/Transforms/FileTransformation.cs
@@ -69,13 +69,13 @@ namespace Project2015To2017.Transforms
 			}
 			else
 			{
-				var removedIncludes = removeQueue
+				var referencedItems = removeQueue
 					.Where(x => x.Name.LocalName == "Compile")
 					.Select(x => x.Attribute("Update")?.Value)
 					.Where(x => !string.IsNullOrEmpty(x))
 					.ToArray();
 
-				otherIncludeFilesMatchingWildcard = otherIncludeFilesMatchingWildcard.Union(PreviouslyExcludedFiles(definition, removedIncludes)).ToArray();
+				otherIncludeFilesMatchingWildcard = otherIncludeFilesMatchingWildcard.Union(PreviouslyExcludedFiles(definition, referencedItems)).ToArray();
 			}
 
 			if (otherIncludeFilesMatchingWildcard.Length > 0)
@@ -107,9 +107,9 @@ namespace Project2015To2017.Transforms
 			logger.LogInformation($"Removed {count} include items thanks to Microsoft.NET.Sdk defaults");
 		}
 
-		private static IEnumerable<string> PreviouslyExcludedFiles(Project definition, string[] removedIncludes)
+		private static IEnumerable<string> PreviouslyExcludedFiles(Project definition, string[] referencedItems)
 		{
-			return definition.ProjectFolder.GetFiles("*." + definition.CodeFileExtension, SearchOption.AllDirectories).Select(x => x.FullName.Substring(definition.ProjectFolder.FullName.Length + 1)).Except(removedIncludes);
+			return definition.ProjectFolder.GetFiles("*." + definition.CodeFileExtension, SearchOption.AllDirectories).Select(x => x.FullName.Substring(definition.ProjectFolder.FullName.Length + 1)).Except(referencedItems);
 		}
 
 		private static bool KeepFileInclusion(XElement x, Project project)

--- a/Project2015To2017/Transforms/FileTransformation.cs
+++ b/Project2015To2017/Transforms/FileTransformation.cs
@@ -52,11 +52,27 @@ namespace Project2015To2017.Transforms
 			// For all these paths we add <Compile Remove="(path)" />.
 			// So that there is no wildcard match like <Compile Include="**/*.cs" /> for file test.cs,
 			// already included as (e.g.) Content: <Content Include="test.cs" />
-			var otherIncludeFilesMatchingWildcard = keepItems
+			var includes = keepItems
 				.Where(x => x.Name.LocalName != "Compile")
 				.Select(x => x.Attribute("Include")?.Value)
 				.Where(x => !string.IsNullOrEmpty(x))
+				.ToArray();
+
+			var wildcardIncludes = keepItems.Where(x => x.Name.LocalName == "Compile").Select(x => x.Attribute("Include")?.Value).Where(x => x != null && x.Contains("*")).ToArray();
+			if (wildcardIncludes.Length > 0)
+			{
+				this.logger.LogWarning("Wildcard include detected, please check for erroneous inclusion of additional files.");
+			}
+
+			var removedIncludes = removeQueue
+				.Where(x => x.Name.LocalName == "Compile")
+				.Select(x => x.Attribute("Update")?.Value)
+				.Where(x => !string.IsNullOrEmpty(x))
+				.ToArray();
+
+			var otherIncludeFilesMatchingWildcard = includes
 				.Where(x => x.EndsWith("." + definition.CodeFileExtension, StringComparison.OrdinalIgnoreCase))
+				.Union(PreviouslyExcludedFiles(definition, removedIncludes))
 				.ToArray();
 
 			if (otherIncludeFilesMatchingWildcard.Length > 0)
@@ -86,6 +102,11 @@ namespace Project2015To2017.Transforms
 			}
 
 			logger.LogInformation($"Removed {count} include items thanks to Microsoft.NET.Sdk defaults");
+		}
+
+		private static IEnumerable<string> PreviouslyExcludedFiles(Project definition, string[] removedIncludes)
+		{
+			return definition.ProjectFolder.GetFiles("*." + definition.CodeFileExtension, SearchOption.AllDirectories).Select(x => x.FullName.Substring(definition.ProjectFolder.FullName.Length + 1)).Except(removedIncludes);
 		}
 
 		private static bool KeepFileInclusion(XElement x, Project project)

--- a/Project2015To2017Tests/FileTransformationTest.cs
+++ b/Project2015To2017Tests/FileTransformationTest.cs
@@ -35,14 +35,14 @@ namespace Project2015To2017Tests
 
 			var includeItems = project.ItemGroups.SelectMany(x => x.Elements()).ToImmutableList();
 
-			Assert.AreEqual(36, includeItems.Count);
+			Assert.AreEqual(29, includeItems.Count);
 
 			Assert.AreEqual(12, includeItems.Count(x => x.Name.LocalName == "Reference"));
 			Assert.AreEqual(2, includeItems.Count(x => x.Name.LocalName == "ProjectReference"));
-			Assert.AreEqual(18, includeItems.Count(x => x.Name.LocalName == "Compile"));
+			Assert.AreEqual(11, includeItems.Count(x => x.Name.LocalName == "Compile"));
 			Assert.AreEqual(5, includeItems.Count(x => x.Name.LocalName == "Compile" && x.Attribute("Update") != null));
 			Assert.AreEqual(4, includeItems.Count(x => x.Name.LocalName == "Compile" && x.Attribute("Include") != null));
-			Assert.AreEqual(9, includeItems.Count(x => x.Name.LocalName == "Compile" && x.Attribute("Remove") != null));
+			Assert.AreEqual(2, includeItems.Count(x => x.Name.LocalName == "Compile" && x.Attribute("Remove") != null));
 			Assert.AreEqual(3, includeItems.Count(x => x.Name.LocalName == "EmbeddedResource")); // #73 include things that are not ending in .resx
 			Assert.AreEqual(0, includeItems.Count(x => x.Name.LocalName == "Content"));
 			Assert.AreEqual(1, includeItems.Count(x => x.Name.LocalName == "None"));
@@ -99,7 +99,7 @@ namespace Project2015To2017Tests
 				)
 				.ToImmutableList();
 			Assert.IsNotNull(removeMatchingWildcard);
-			Assert.AreEqual(9, removeMatchingWildcard.Count);
+			Assert.AreEqual(2, removeMatchingWildcard.Count);
 			Assert.IsTrue(removeMatchingWildcard.Any(x => x.Attribute("Remove")?.Value == "SourceFileAsResource.cs"));
 			Assert.IsTrue(removeMatchingWildcard.Any(x => x.Attribute("Remove")?.Value == "Class1.cs"));
 		}

--- a/Project2015To2017Tests/FileTransformationTest.cs
+++ b/Project2015To2017Tests/FileTransformationTest.cs
@@ -12,6 +12,19 @@ namespace Project2015To2017Tests
 	public class FileTransformationTest
 	{
 		[TestMethod]
+		public void TransformsFilesExclude()
+		{
+			var project = new ProjectReader().Read(Path.Combine("TestFiles", "FileInclusion", "fileExclusion.testcsproj"));
+			project.CodeFileExtension = "cs";
+			var transformation = new FileTransformation();
+
+			transformation.Transform(project);
+
+			var includeItems = project.ItemGroups.SelectMany(x => x.Elements()).ToImmutableList();
+			Assert.AreEqual(1, includeItems.Count(x => x.Name.LocalName == "Compile" && x.Attribute("Remove")?.Value == "Program.cs"));
+		}
+
+		[TestMethod]
 		public void TransformsFiles()
 		{
 			var project = new ProjectReader().Read(Path.Combine("TestFiles", "FileInclusion", "fileinclusion.testcsproj"));
@@ -22,14 +35,14 @@ namespace Project2015To2017Tests
 
 			var includeItems = project.ItemGroups.SelectMany(x => x.Elements()).ToImmutableList();
 
-			Assert.AreEqual(29, includeItems.Count);
+			Assert.AreEqual(36, includeItems.Count);
 
 			Assert.AreEqual(12, includeItems.Count(x => x.Name.LocalName == "Reference"));
 			Assert.AreEqual(2, includeItems.Count(x => x.Name.LocalName == "ProjectReference"));
-			Assert.AreEqual(11, includeItems.Count(x => x.Name.LocalName == "Compile"));
+			Assert.AreEqual(18, includeItems.Count(x => x.Name.LocalName == "Compile"));
 			Assert.AreEqual(5, includeItems.Count(x => x.Name.LocalName == "Compile" && x.Attribute("Update") != null));
 			Assert.AreEqual(4, includeItems.Count(x => x.Name.LocalName == "Compile" && x.Attribute("Include") != null));
-			Assert.AreEqual(2, includeItems.Count(x => x.Name.LocalName == "Compile" && x.Attribute("Remove") != null));
+			Assert.AreEqual(9, includeItems.Count(x => x.Name.LocalName == "Compile" && x.Attribute("Remove") != null));
 			Assert.AreEqual(3, includeItems.Count(x => x.Name.LocalName == "EmbeddedResource")); // #73 include things that are not ending in .resx
 			Assert.AreEqual(0, includeItems.Count(x => x.Name.LocalName == "Content"));
 			Assert.AreEqual(1, includeItems.Count(x => x.Name.LocalName == "None"));
@@ -86,7 +99,7 @@ namespace Project2015To2017Tests
 				)
 				.ToImmutableList();
 			Assert.IsNotNull(removeMatchingWildcard);
-			Assert.AreEqual(2, removeMatchingWildcard.Count);
+			Assert.AreEqual(9, removeMatchingWildcard.Count);
 			Assert.IsTrue(removeMatchingWildcard.Any(x => x.Attribute("Remove")?.Value == "SourceFileAsResource.cs"));
 			Assert.IsTrue(removeMatchingWildcard.Any(x => x.Attribute("Remove")?.Value == "Class1.cs"));
 		}

--- a/Project2015To2017Tests/Project2015To2017Tests.csproj
+++ b/Project2015To2017Tests/Project2015To2017Tests.csproj
@@ -73,6 +73,9 @@
     <None Include="TestFiles\FileInclusion\AnotherFile.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="TestFiles\FileInclusion\fileExclusion.testcsproj">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="TestFiles\FileInclusion\SourceFileSubTypeCode.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Project2015To2017Tests/TestFiles/FileInclusion/fileExclusion.testcsproj
+++ b/Project2015To2017Tests/TestFiles/FileInclusion/fileExclusion.testcsproj
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+	<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+	<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+	<ProjectGuid>{62CAD5A7-4966-4289-9203-E6843CDEE4C6}</ProjectGuid>
+	<OutputType>Exe</OutputType>
+	<AppDesignerFolder>Properties</AppDesignerFolder>
+	<RootNamespace>Net46Console</RootNamespace>
+	<AssemblyName>Net46Console</AssemblyName>
+	<TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+	<FileAlignment>512</FileAlignment>
+	<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+	<PlatformTarget>AnyCPU</PlatformTarget>
+	<DebugSymbols>true</DebugSymbols>
+	<DebugType>full</DebugType>
+	<Optimize>false</Optimize>
+	<OutputPath>bin\Debug\</OutputPath>
+	<DefineConstants>DEBUG;TRACE</DefineConstants>
+	<ErrorReport>prompt</ErrorReport>
+	<WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+	<PlatformTarget>AnyCPU</PlatformTarget>
+	<DebugType>pdbonly</DebugType>
+	<Optimize>true</Optimize>
+	<OutputPath>bin\Release\</OutputPath>
+	<DefineConstants>TRACE</DefineConstants>
+	<ErrorReport>prompt</ErrorReport>
+	<WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+	<Reference Include="Microsoft.Owin, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+	  <HintPath>..\packages\Microsoft.Owin.3.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
+	  <Private>True</Private>
+	</Reference>
+	<Reference Include="Microsoft.Owin.Host.SystemWeb, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+	  <HintPath>..\packages\Microsoft.Owin.Host.SystemWeb.3.1.0\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
+	  <Private>True</Private>
+	</Reference>
+	<Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+	  <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+	  <Private>True</Private>
+	</Reference>
+	<Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+	  <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+	  <Private>True</Private>
+	</Reference>
+	<Reference Include="System" />
+	<Reference Include="System.Core" />
+	<Reference Include="System.Xml.Linq" />
+	<Reference Include="System.Data.DataSetExtensions" />
+	<Reference Include="Microsoft.CSharp" />
+	<Reference Include="System.Data" />
+	<Reference Include="System.Net.Http" />
+	<Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+	<Compile Include="Class1.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
It's not pretty because of the wildcard support we currently have. But if the user is not using a wildcard include then we can generate the appropriate exclusions. Having a wildcard include is probably an exception anyway as it was never really supported in any UI and the current wildcard include is automatic.