### PR TITLE
A variety of fixes

### DIFF
--- a/Project2015To2017.Core/Analysis/Diagnostics/W011UnsupportedConditionalDiagnostic.cs
+++ b/Project2015To2017.Core/Analysis/Diagnostics/W011UnsupportedConditionalDiagnostic.cs
@@ -32,9 +32,9 @@ namespace Project2015To2017.Analysis.Diagnostics
 
 				foreach (var (key, value) in pairs)
 				{
-					var countContext = value > 1 ? $"({value} occurrences)" : "";
+					var countContext = value > 1 ? $" ({value} occurrences)" : "";
 					list.Add(CreateDiagnosticResult(project,
-							$"Unsupported '{key}' expression in conditional {countContext}",
+							$"Unsupported '{key}' expression in conditional{countContext}, some simplification opportunities might have been missed.",
 							project.FilePath)
 						.LoadLocationFromElement(x));
 				}

--- a/Project2015To2017.Core/Definition/Project.cs
+++ b/Project2015To2017.Core/Definition/Project.cs
@@ -36,6 +36,7 @@ namespace Project2015To2017.Definition
 		public string CodeFileExtension { get; set; } = "cs";
 		public DirectoryInfo ProjectFolder => this.FilePath.Directory;
 		public Guid? ProjectGuid { get; set; }
+		public string ProjectSdk { get; set; } = "Microsoft.NET.Sdk";
 
 		public bool HasMultipleAssemblyInfoFiles { get; set; }
 
@@ -84,9 +85,6 @@ namespace Project2015To2017.Definition
 		public Solution Solution { get; set; }
 
 		public IReadOnlyList<XElement> AssemblyAttributeProperties { get; set; } = Array.Empty<XElement>();
-
-		public bool IsWindowsFormsProject { get; set; }
-		public bool IsWindowsPresentationFoundationProject { get; set; }
 
 		public IReadOnlyList<string> IntermediateOutputPaths { get; set; }
 	}

--- a/Project2015To2017.Core/Definition/ProjectExtensions.cs
+++ b/Project2015To2017.Core/Definition/ProjectExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
@@ -9,6 +10,8 @@ namespace Project2015To2017.Definition
 {
 	public static class ProjectExtensions
 	{
+		private static readonly Guid WpfGuid = Guid.ParseExact("60DC8134-EBA5-43B8-BCC9-BB4BC16C2548", "D");
+
 		public static IEnumerable<XElement> UnconditionalGroups(this Project project)
 		{
 			return project.PropertyGroups.Where(x => x.Attribute("Condition") == null);
@@ -27,6 +30,9 @@ namespace Project2015To2017.Definition
 		public static (IReadOnlyList<XElement> unconditional, IReadOnlyList<(string condition, XElement element)> conditional)
 			PropertyAll(this Project project, string name)
 		{
+			if (name == null) throw new ArgumentNullException(nameof(name));
+			if (project.PropertyGroups == null) throw new ArgumentNullException(nameof(project.PropertyGroups));
+
 			var unconditional = new List<XElement>();
 			var conditional = new List<(string condition, XElement element)>();
 			foreach (var element in project.PropertyGroups.ElementsAnyNamespace(name))
@@ -45,9 +51,37 @@ namespace Project2015To2017.Definition
 
 		public static XElement Property(this Project project, string name, bool tryConditional = false)
 		{
+			if (name == null) throw new ArgumentNullException(nameof(name));
+
 			var (unconditional, conditional) = project.PropertyAll(name);
 			return unconditional.LastOrDefault()
 			       ?? (tryConditional ? conditional.Select(x => x.element).LastOrDefault() : null);
+		}
+
+		public static IEnumerable<(Guid guid, XElement source)> IterateProjectTypeGuids(this Project project)
+		{
+			var (unconditional, conditional) = project.PropertyAll("ProjectTypeGuids");
+			if (conditional.Count > 0)
+			{
+				// log unexpected case
+			}
+
+			var guidTypes = new HashSet<Guid>();
+			foreach (var element in unconditional)
+			{
+				// parse the CSV list
+				foreach (var guid in element.Value
+					.Split(new[] {';'}, StringSplitOptions.RemoveEmptyEntries)
+					.Select(x =>
+						Guid.TryParse(x.Trim(), out var res)
+							? res
+							: /* unexpected case */ Guid.Empty)
+					.Where(x => x != Guid.Empty))
+				{
+					if (guidTypes.Add(guid))
+						yield return (guid, element);
+				}
+			}
 		}
 
 		public static PropertyFindResult FindExistingElements(this Project project, params string[] names)
@@ -184,6 +218,32 @@ namespace Project2015To2017.Definition
 			}
 
 			project.ReplacePropertiesWith(newElement, elementName);
+		}
+
+		public static bool IsWindowsPresentationFoundationProject(this Project project)
+		{
+			if (project == null) throw new ArgumentNullException(nameof(project));
+
+			if (project.Property("UseWpf")?.Value == "true")
+				return true;
+
+			if (project.Property("ExtrasEnableWpfProjectSetup")?.Value == "true")
+				return true;
+
+			return project.IterateProjectTypeGuids().Any(x => x.guid == WpfGuid);
+		}
+
+		public static bool IsWindowsFormsProject(this Project project)
+		{
+			if (project == null) throw new ArgumentNullException(nameof(project));
+
+			if (project.Property("UseWindowsForms")?.Value == "true")
+				return true;
+
+			if (project.Property("ExtrasEnableWinFormsProjectSetup")?.Value == "true")
+				return true;
+
+			return project.Property("MyType", tryConditional: true)?.Value == "WindowsForms";
 		}
 
 		public static DirectoryInfo TryFindBestRootDirectory(this Project project)

--- a/Project2015To2017.Core/Extensions.cs
+++ b/Project2015To2017.Core/Extensions.cs
@@ -17,7 +17,7 @@ namespace Project2015To2017
 				return (fsi is DirectoryInfo d) ? (d.FullName.TrimEnd('\\') + "\\") : fsi.FullName;
 			}
 
-			var fromPath = GetPath(@from);
+			var fromPath = GetPath(from);
 			var toPath = GetPath(to);
 
 			var fromUri = new Uri(fromPath);
@@ -70,12 +70,14 @@ namespace Project2015To2017
 		public static IEnumerable<XElement> ElementsAnyNamespace<T>(this IEnumerable<T> source, string localName)
 			where T : XContainer
 		{
+			if (source == null) throw new ArgumentNullException(nameof(source));
 			return source.Elements().Where(e => e.Name.LocalName == localName);
 		}
 
 		public static IEnumerable<XElement> ElementsAnyNamespace<T>(this T source, string localName)
 			where T : XContainer
 		{
+			if (source == null) throw new ArgumentNullException(nameof(source));
 			return source.Elements().Where(e => e.Name.LocalName == localName);
 		}
 

--- a/Project2015To2017.Core/Transforms/PrimaryProjectPropertiesUpdateTransformation.cs
+++ b/Project2015To2017.Core/Transforms/PrimaryProjectPropertiesUpdateTransformation.cs
@@ -28,11 +28,6 @@ namespace Project2015To2017.Transforms
 			project.SetProperty("AppendTargetFrameworkToOutputPath",
 				project.AppendTargetFrameworkToOutputPath ? null : "false");
 
-			project.SetProperty("ExtrasEnableWpfProjectSetup",
-				project.IsWindowsPresentationFoundationProject ? "true" : null);
-			project.SetProperty("ExtrasEnableWinFormsProjectSetup",
-				project.IsWindowsFormsProject ? "true" : null);
-
 			string outputType;
 			switch (project.Type)
 			{

--- a/Project2015To2017.Core/UnsupportedProjectTypes.cs
+++ b/Project2015To2017.Core/UnsupportedProjectTypes.cs
@@ -12,26 +12,16 @@ namespace Project2015To2017
 		/// <summary>
 		/// Check for unsupported ProjectTypeGuids in project
 		/// </summary>
-		/// <param name="xmlDocument">source project document to check</param>
+		/// <param name="project">source project to check</param>
 		/// <returns></returns>
 		public static bool IsUnsupportedProjectType(Project project)
 		{
 			if (project == null) throw new ArgumentNullException(nameof(project));
-			var xmlDocument = project.ProjectDocument;
-
-			// try to get project type - may not exist
-			var typeElement = xmlDocument.Descendants(project.XmlNamespace + "ProjectTypeGuids").FirstOrDefault();
-			// no matching tag found, project should be okay to convert
-			if (typeElement == null) return false;
-
-			// parse the CSV list
-			var guidTypes = typeElement.Value.Split(';').Select(x => x.Trim());
+			
+			var guidTypes = project.IterateProjectTypeGuids();
 
 			// if any guid matches an unsupported type, return true
-			return (from guid in guidTypes
-					from unsupported in unsupportedGuids
-					where guid.Equals(unsupported, StringComparison.CurrentCultureIgnoreCase)
-					select unsupported).Any();
+			return guidTypes.Any(t => unsupportedGuids.Contains(t.guid));
 		}
 
 		/// <summary>
@@ -45,14 +35,14 @@ namespace Project2015To2017
 		/// Note that the list here is in upper case but project file guids are normally lower case
 		/// This list does not include Windows Forms apps, these have no type guid
 		/// </remarks>
-		private static readonly string[] unsupportedGuids =
-			{
-			"{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}",   // ASP.NET 5
-			"{603C0E0B-DB56-11DC-BE95-000D561079B0}",   // ASP.NET MVC 1
-			"{F85E285D-A4E0-4152-9332-AB1D724D3325}",   // ASP.NET MVC 2
-			"{E53F8FEA-EAE0-44A6-8774-FFD645390401}",   // ASP.NET MVC 3
-			"{E3E379DF-F4C6-4180-9B81-6769533ABE47}",   // ASP.NET MVC 4
-			"{349C5851-65DF-11DA-9384-00065B846F21}",   // ASP.NET MVC 5
-			};
+		private static readonly Guid[] unsupportedGuids =
+		{
+			Guid.ParseExact("8BB2217D-0F2D-49D1-97BC-3654ED321F3B", "D"), // ASP.NET 5
+			Guid.ParseExact("603C0E0B-DB56-11DC-BE95-000D561079B0", "D"), // ASP.NET MVC 1
+			Guid.ParseExact("F85E285D-A4E0-4152-9332-AB1D724D3325", "D"), // ASP.NET MVC 2
+			Guid.ParseExact("E53F8FEA-EAE0-44A6-8774-FFD645390401", "D"), // ASP.NET MVC 3
+			Guid.ParseExact("E3E379DF-F4C6-4180-9B81-6769533ABE47", "D"), // ASP.NET MVC 4
+			Guid.ParseExact("349C5851-65DF-11DA-9384-00065B846F21", "D"), // ASP.NET MVC 5
+		};
 	}
 }

--- a/Project2015To2017.Core/Writing/ProjectWriter.cs
+++ b/Project2015To2017.Core/Writing/ProjectWriter.cs
@@ -11,7 +11,6 @@ namespace Project2015To2017.Writing
 {
 	public sealed class ProjectWriter
 	{
-		private const string SdkExtrasVersion = "MSBuild.Sdk.Extras/1.6.47";
 		private readonly ILogger logger;
 		private readonly Action<FileSystemInfo> deleteFileOperation;
 		private readonly Action<FileSystemInfo> checkoutOperation;
@@ -174,12 +173,7 @@ namespace Project2015To2017.Writing
 
 		internal XElement CreateXml(Project project)
 		{
-			var outputFile = project.FilePath;
-
-			var netSdk = "Microsoft.NET.Sdk";
-			if (project.IsWindowsFormsProject || project.IsWindowsPresentationFoundationProject)
-				netSdk = SdkExtrasVersion;
-			var projectNode = new XElement("Project", new XAttribute("Sdk", netSdk));
+			var projectNode = new XElement("Project", new XAttribute("Sdk", project.ProjectSdk));
 
 			if (project.PropertyGroups != null)
 			{

--- a/Project2015To2017.Migrate2017.Library/Transforms/BrokenHookTargetsTransformation.cs
+++ b/Project2015To2017.Migrate2017.Library/Transforms/BrokenHookTargetsTransformation.cs
@@ -1,0 +1,52 @@
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using Project2015To2017.Definition;
+using Project2015To2017.Transforms;
+
+namespace Project2015To2017.Migrate2017.Transforms
+{
+	public sealed class BrokenHookTargetsTransformation : ILegacyOnlyProjectTransformation
+	{
+		private readonly ILogger logger;
+
+		public BrokenHookTargetsTransformation(ILogger logger = null)
+		{
+			this.logger = logger ?? NoopLogger.Instance;
+		}
+
+		public void Transform(Project definition)
+		{
+			var beforeBuildArray = definition.Targets.Where(x => x.Attribute("Name")?.Value == "BeforeBuild")
+				.ToImmutableArray();
+			if (!beforeBuildArray.IsDefaultOrEmpty)
+			{
+				if (beforeBuildArray.Length > 1)
+				{
+					this.logger.LogWarning("Unexpected multiple BeforeBuild targets.");
+				}
+
+				var beforeBuild = beforeBuildArray.LastOrDefault();
+
+				beforeBuild.SetAttributeValue("Name", "BeforeBuildMigrated");
+				beforeBuild.SetAttributeValue("BeforeTargets", "PreBuildEvent");
+			}
+
+			var afterBuildArray = definition.Targets.Where(x => x.Attribute("Name")?.Value == "AfterBuild")
+				.ToImmutableArray();
+			if (!afterBuildArray.IsDefaultOrEmpty)
+			{
+				if (afterBuildArray.Length > 1)
+				{
+					this.logger.LogWarning("Unexpected multiple AfterBuild targets.");
+				}
+
+				var afterBuild = afterBuildArray.LastOrDefault();
+
+				afterBuild.SetAttributeValue("Name", "AfterBuildMigrated");
+
+				definition.SetProperty("BuildDependsOn", "$(BuildDependsOn);AfterBuildMigrated");
+			}
+		}
+	}
+}

--- a/Project2015To2017.Migrate2017.Library/Transforms/FrameworkReferencesTransformation.cs
+++ b/Project2015To2017.Migrate2017.Library/Transforms/FrameworkReferencesTransformation.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Project2015To2017.Definition;
+using Project2015To2017.Transforms;
+
+namespace Project2015To2017.Migrate2017.Transforms
+{
+	public sealed class FrameworkReferencesTransformation : ILegacyOnlyProjectTransformation
+	{
+		private const string SdkExtrasVersion = "MSBuild.Sdk.Extras/1.6.65";
+		private static readonly Guid XamarinAndroid = Guid.ParseExact("EFBA0AD7-5A72-4C68-AF49-83D382785DCF", "D");
+		private static readonly Guid XamarinIos = Guid.ParseExact("6BC8ED88-2882-458C-8E55-DFD12B67127B", "D");
+		private static readonly Guid Uap = Guid.ParseExact("A5A43C5B-DE2A-4C0C-9213-0A381AF9435A", "D");
+
+		public void Transform(Project definition)
+		{
+			var isWindowsPresentationFoundationProject = definition.IsWindowsPresentationFoundationProject();
+			var isWindowsFormsProject = definition.IsWindowsFormsProject();
+			var isExtraPlatform = false;
+
+			var guidTypes = definition.IterateProjectTypeGuids().ToImmutableHashSet();
+
+			if (guidTypes.Any(x => x.guid == XamarinAndroid))
+			{
+				definition.TargetFrameworks.Add("xamarin.android");
+				isExtraPlatform = true;
+			}
+
+			if (guidTypes.Any(x => x.guid == XamarinIos))
+			{
+				definition.TargetFrameworks.Add("xamarin.ios");
+				isExtraPlatform = true;
+			}
+
+			if (guidTypes.Any(x => x.guid == Uap))
+			{
+				definition.TargetFrameworks.Add("uap");
+				isExtraPlatform = true;
+			}
+
+			if (isWindowsPresentationFoundationProject || isWindowsFormsProject || isExtraPlatform)
+			{
+				definition.ProjectSdk = SdkExtrasVersion;
+			}
+
+			if (isWindowsPresentationFoundationProject)
+			{
+				definition.SetProperty("ExtrasEnableWpfProjectSetup", "true");
+			}
+
+			if (isWindowsFormsProject)
+			{
+				definition.SetProperty("ExtrasEnableWinFormsProjectSetup", "true");
+			}
+		}
+	}
+}

--- a/Project2015To2017.Migrate2017.Library/Transforms/XamlPagesTransformation.cs
+++ b/Project2015To2017.Migrate2017.Library/Transforms/XamlPagesTransformation.cs
@@ -19,7 +19,7 @@ namespace Project2015To2017.Migrate2017.Transforms
 		/// <inheritdoc />
 		public void Transform(Project definition)
 		{
-			if (!definition.IsWindowsPresentationFoundationProject)
+			if (!definition.IsWindowsPresentationFoundationProject())
 			{
 				return;
 			}

--- a/Project2015To2017.Migrate2017.Library/Vs15TransformationSet.cs
+++ b/Project2015To2017.Migrate2017.Library/Vs15TransformationSet.cs
@@ -32,6 +32,7 @@ namespace Project2015To2017.Migrate2017
 				new PrimaryProjectPropertiesUpdateTransformation(),
 				new EmptyGroupRemoveTransformation(),
 				// VS15 migration
+				new FrameworkReferencesTransformation(),
 				new TestProjectPackageReferenceTransformation(logger),
 				new AssemblyFilterPackageReferencesTransformation(),
 				new AssemblyFilterHintedPackageReferencesTransformation(),
@@ -39,6 +40,7 @@ namespace Project2015To2017.Migrate2017
 				new ImportsTargetsFilterPackageReferencesTransformation(),
 				new FileTransformation(logger),
 				new XamlPagesTransformation(logger),
+				new BrokenHookTargetsTransformation(logger),
 			};
 		}
 	}

--- a/Project2015To2017.Tests/Project2015To2017.Tests.csproj
+++ b/Project2015To2017.Tests/Project2015To2017.Tests.csproj
@@ -5,8 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="OtherPackagesConfig\**" />
     <Compile Remove="TestFiles\FileInclusion\Resources.resx\**" />
     <Compile Remove="TestFiles\Solutions\ClassLibrary\obj\**" />
+    <EmbeddedResource Remove="OtherPackagesConfig\**" />
     <EmbeddedResource Remove="TestFiles\FileInclusion\Resources.resx\**" />
     <EmbeddedResource Remove="TestFiles\Solutions\ClassLibrary\obj\**" />
     <None Remove="TestFiles\FileInclusion\Resources.resx\**" />

--- a/Project2015To2017.Tests/PropertySimplificationTransformationTest.cs
+++ b/Project2015To2017.Tests/PropertySimplificationTransformationTest.cs
@@ -119,8 +119,8 @@ namespace Project2015To2017.Tests
 
 			var project = ParseAndTransform(xml, projectName: "Dopamine");
 
-			Assert.IsTrue(project.IsWindowsPresentationFoundationProject);
-			Assert.IsFalse(project.IsWindowsFormsProject);
+			Assert.IsTrue(project.IsWindowsPresentationFoundationProject());
+			Assert.IsFalse(project.IsWindowsFormsProject());
 
 			Assert.AreEqual(1, project.TargetFrameworks.Count);
 			Assert.AreEqual(1, project.TargetFrameworks.Count(x => x == "net461"));

--- a/Project2015To2017.Tests/UnsupportedProjectTypesTest.cs
+++ b/Project2015To2017.Tests/UnsupportedProjectTypesTest.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Xml.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Project2015To2017.Definition;
+using Project2015To2017.Reading;
 
 namespace Project2015To2017.Tests
 {
@@ -12,9 +13,6 @@ namespace Project2015To2017.Tests
 		/// <summary>
 		/// Run test cases
 		/// </summary>
-		/// <param name="guidTypes"></param>
-		/// <param name="testCase"></param>
-		/// <param name="expected"></param>
 		[DataRow("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}", "ASP.NET 5", true)]
 		[DataRow("{349C5851-65DF-11DA-9384-00065B846F21};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}", "ASP.NET MVC5", true)]
 		[DataRow("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}", "C# only", false)]
@@ -32,9 +30,6 @@ namespace Project2015To2017.Tests
 		/// <summary>
 		/// Run test cases
 		/// </summary>
-		/// <param name="guidTypes"></param>
-		/// <param name="testCase"></param>
-		/// <param name="expected"></param>
 		[DataRow("WindowsForms", "WinForms", false)]
 		[DataRow("", "Other", false)]
 		[TestMethod]
@@ -71,7 +66,10 @@ namespace Project2015To2017.Tests
 				var propertyGroup = xmlDocument.Descendants(Project.XmlLegacyNamespace + "PropertyGroup").First();
 				propertyGroup.Add(new XElement(Project.XmlLegacyNamespace + elementName, value));
 			}
-			return new Project { ProjectDocument = xmlDocument };
+
+			var testProject = new Project { ProjectDocument = xmlDocument };
+			ProjectPropertiesReader.ReadPropertyGroups(testProject);
+			return testProject;
 		}
 
 		/// <summary>

--- a/Project2015To2017.Tests/XamlTransformationTest.cs
+++ b/Project2015To2017.Tests/XamlTransformationTest.cs
@@ -75,8 +75,8 @@ namespace Project2015To2017.Tests
   </ItemGroup>
 </Project>");
 
-			Assert.IsTrue(project.IsWindowsPresentationFoundationProject);
-			Assert.IsFalse(project.IsWindowsFormsProject);
+			Assert.IsTrue(project.IsWindowsPresentationFoundationProject());
+			Assert.IsFalse(project.IsWindowsFormsProject());
 
 			Assert.AreEqual(1, project.TargetFrameworks.Count);
 			Assert.AreEqual(1, project.TargetFrameworks.Count(x => x == "net461"));

--- a/Project2015To2017/Facility.cs
+++ b/Project2015To2017/Facility.cs
@@ -160,7 +160,15 @@ namespace Project2015To2017
 				return;
 			}
 
+			var alreadyConverted = projects.Where(x => x.IsModernProject).ToImmutableArray();
+
 			DoAnalysis(projects, new AnalysisOptions(DiagnosticSet.All));
+
+			logger.LogInformation("List of modern CPS projects:");
+			foreach (var projectPath in alreadyConverted.Select(x => x.FilePath))
+			{
+				logger.LogInformation("Project {ProjectPath} is already CPS-based", projectPath);
+			}
 
 			var projectPaths = solutions.SelectMany(x => x.UnsupportedProjectPaths).ToImmutableArray();
 			if (projectPaths.Length <= 0) return;


### PR DESCRIPTION
* Add listing of already converted projects to evaluate CLI command
* Use Guid as keys in Dictionary where possible (always correctly ignores casing, improves performance)
* Replace IsWindowsFormsProject and IsWindowsPresentationFoundationProject fields with extension methods (preparation for .NET Core 3)
* Refactor project SDK assignment method (no more hacks in ProjectWriter)
* Add IterateProjectTypeGuids helper extension method
* Refactor out HandleSpecialProjectTypes into FrameworkReferencesTransformation (more robust this way)
* Add BrokenHookTargetsTransformation (fixes #172)
* Improve FileTransformation to fix recently arisen issues (tested on Dopamine, fixes #210)
* Fix ImportsTargetsFilterPackageReferencesTransformation to support multiple `<Error />` from different NuGet packages (like native libraries for sqlite for multiple platforms) in Visual Studio-generated NuGet property group
* Other minor fixes