### PR TITLE
Keep linked app.config

### DIFF
--- a/Project2015To2017.Migrate2017.Library/Transforms/FileTransformation.cs
+++ b/Project2015To2017.Migrate2017.Library/Transforms/FileTransformation.cs
@@ -184,7 +184,8 @@ namespace Project2015To2017.Migrate2017.Transforms
 				return false;
 			}
 
-			if (tagName == "None" && include.EndsWith(".config", StringComparison.OrdinalIgnoreCase))
+			var isNotLinkedElement = x.Elements().FirstOrDefault(a => a.Name.LocalName == "Link") == null;
+			if (tagName == "None" && include.EndsWith(".config", StringComparison.OrdinalIgnoreCase) && isNotLinkedElement)
 			{
 				return false;
 			}


### PR DESCRIPTION
Hi, 

first off thank you for this great tool. I stumpled upon a minor problem for my migrated projects.

I am using linked app.configs in my test scenarios, so that i can reuse configuration, but after migrating them they are gone and i have to reconfigure them.

Why are *.config-Files skipped? I found this issue #155 but i do not understand why this is a problem.