### PR TITLE
Added direct support for removing transitive package references

### DIFF
--- a/Project2015To2017.Core/CleanUp/Dependency.cs
+++ b/Project2015To2017.Core/CleanUp/Dependency.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Project2015To2017.CleanUp
+{
+	internal class Dependency : IEquatable<Dependency>
+	{
+		public Dependency(string name, string version)
+		{
+			Name = name;
+			Version = version;
+		}
+
+		public string Name { get; }
+
+		public string Version { get; }
+
+		public string Parent { get; set; }
+
+		public List<Dependency> Children { get; set; } = new List<Dependency>();
+
+		public List<Dependency> ContainingPackages { get; set; }
+
+		public bool Equals(Dependency other)
+		{
+			if (ReferenceEquals(null, other)) return false;
+			if (ReferenceEquals(this, other)) return true;
+			return string.Equals(Name, other.Name) && string.Equals(Version, other.Version);
+		}
+
+		public override bool Equals(object obj)
+		{
+			if (ReferenceEquals(null, obj)) return false;
+			if (ReferenceEquals(this, obj)) return true;
+			if (obj.GetType() != this.GetType()) return false;
+			return Equals((Dependency)obj);
+		}
+
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				return ((Name != null ? Name.GetHashCode() : 0) * 397) ^ (Version != null ? Version.GetHashCode() : 0);
+			}
+		}
+
+		public override string ToString() => $"{Name} - {Version} => ContainingPackages: {string.Join(", ", ContainingPackages?.Select(p => p.Parent))}";
+	}
+}

--- a/Project2015To2017.Core/CleanUp/DependencyGraphService.cs
+++ b/Project2015To2017.Core/CleanUp/DependencyGraphService.cs
@@ -1,0 +1,31 @@
+using System;
+using System.IO;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NuGet.ProjectModel;
+
+namespace Project2015To2017.CleanUp
+{
+	/// <remarks>
+	/// Credit for the stuff happening in here goes to the https://github.com/jaredcnance/dotnet-status project
+	/// </remarks>
+	public class DependencyGraphService
+	{
+		public DependencyGraphSpec GenerateDependencyGraph(FileInfo projectPath)
+		{
+			var dotNetRunner = new DotNetRunner();
+			var dgOutput = Path.Combine(Path.GetTempPath(), Path.GetTempFileName());
+			var arguments = new[] { "msbuild", $"\"{projectPath.FullName}\"", "/t:GenerateRestoreGraphFile", $"/p:RestoreGraphOutputPath=\"{dgOutput}\"" };
+			var runStatus = dotNetRunner.Run(projectPath.DirectoryName, arguments);
+
+			if (runStatus.IsSuccess)
+			{
+				var dependencyGraphText = File.ReadAllText(dgOutput);
+				return new DependencyGraphSpec(JsonConvert.DeserializeObject<JObject>(dependencyGraphText));
+			}
+
+			throw new Exception($"Unable to process the the project `{projectPath}. Are you sure this is a valid .NET Core or .NET Standard project type?" +
+								$"\r\n\r\nHere is the full error message returned from the Microsoft Build Engine:\r\n\r\n" + runStatus.Output);
+		}
+	}
+}

--- a/Project2015To2017.Core/CleanUp/DotNetRunner.cs
+++ b/Project2015To2017.Core/CleanUp/DotNetRunner.cs
@@ -1,0 +1,56 @@
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Project2015To2017.CleanUp
+{
+	/// <remarks>
+	/// Credit for the stuff happening in here goes to the https://github.com/jaredcnance/dotnet-status project
+	/// </remarks>
+	public class DotNetRunner
+	{
+		public RunStatus Run(string workingDirectory, string[] arguments)
+		{
+			var psi = new ProcessStartInfo("dotnet", string.Join(" ", arguments))
+			{
+				WorkingDirectory = workingDirectory,
+				UseShellExecute = false,
+				CreateNoWindow = true,
+				RedirectStandardOutput = true,
+				RedirectStandardError = true
+			};
+
+			using (var p = new Process())
+			{
+				p.StartInfo = psi;
+				p.Start();
+
+				var output = new StringBuilder();
+				var errors = new StringBuilder();
+				var outputTask = ConsumeStreamReaderAsync(p.StandardOutput, output);
+				var errorTask = ConsumeStreamReaderAsync(p.StandardError, errors);
+
+				var processExited = p.WaitForExit(20000);
+
+				if (processExited == false)
+					return new RunStatus(output.ToString(), errors.ToString(), -1);
+
+				Task.WaitAll(outputTask, errorTask);
+
+				return new RunStatus(output.ToString(), errors.ToString(), p.ExitCode);
+			}
+		}
+
+		private static async Task ConsumeStreamReaderAsync(TextReader reader, StringBuilder lines)
+		{
+			await Task.Yield();
+
+			string line;
+			while ((line = await reader.ReadLineAsync()) != null)
+			{
+				lines.AppendLine(line);
+			}
+		}
+	}
+}

--- a/Project2015To2017.Core/CleanUp/LockFileService.cs
+++ b/Project2015To2017.Core/CleanUp/LockFileService.cs
@@ -1,0 +1,21 @@
+using System.IO;
+using NuGet.ProjectModel;
+
+namespace Project2015To2017.CleanUp
+{
+	public static class LockFileService
+	{
+		public static LockFile GetLockFile(string projectPath, string outputPath)
+		{
+			// Run the restore command
+			var dotNetRunner = new DotNetRunner();
+			var arguments = new[] { "restore", $"\"{projectPath}\"" };
+
+			dotNetRunner.Run(Path.GetDirectoryName(projectPath), arguments);
+
+			// Load the lock file
+			var lockFilePath = Path.Combine(outputPath, "project.assets.json");
+			return LockFileUtilities.GetLockFile(lockFilePath, NuGet.Common.NullLogger.Instance);
+		}
+	}
+}

--- a/Project2015To2017.Core/CleanUp/PackageReferenceCleaner.cs
+++ b/Project2015To2017.Core/CleanUp/PackageReferenceCleaner.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq;
+using Microsoft.Extensions.Logging;
+using NuGet.ProjectModel;
+using Project2015To2017.Definition;
+
+namespace Project2015To2017.CleanUp
+{
+	public class PackageReferenceCleaner
+	{
+		private readonly ILogger _logger;
+
+		public PackageReferenceCleaner(ILogger logger)
+		{
+			_logger = logger;
+		}
+
+		public bool CleanUpProjectReferences(Project project)
+		{
+			var graphService = new DependencyGraphService();
+			var graph = graphService.GenerateDependencyGraph(project.FilePath);
+			var changed = false;
+
+			foreach (var packageSpec in graph.Projects.Where(p => p.RestoreMetadata.ProjectStyle == ProjectStyle.PackageReference))
+			{
+				foreach (var removableProjectReference in GetRemovableProjectReferences(packageSpec))
+				{
+					var packageReferences = project.PackageReferences.Where(pr => pr.Id != removableProjectReference.Name).ToList();
+
+					_logger.LogInformation($"The following references are removed: {string.Join(Environment.NewLine, removableProjectReference)}");
+
+					project.PackageReferences = new ReadOnlyCollection<PackageReference>(packageReferences);
+					changed = true;
+				}
+			}
+
+			return changed;
+		}
+
+		private IEnumerable<Dependency> GetRemovableProjectReferences(PackageSpec packageSpec)
+		{
+			var lockFile = LockFileService.GetLockFile(packageSpec.FilePath, packageSpec.RestoreMetadata.OutputPath ?? Path.GetTempPath());
+			var collection = new List<Dependency>();
+
+			foreach (var targetFramework in packageSpec.TargetFrameworks)
+			{
+				var dependencies = GetDependencies(lockFile, targetFramework);
+				collection.AddRange(GetRemovableDependencies(dependencies));
+			}
+
+			return collection;
+		}
+
+		private IEnumerable<Dependency> GetRemovableDependencies(IEnumerable<Dependency> dependencies)
+		{
+			var childrenDependencies = dependencies.SelectMany(dep => dep.Children).ToList();
+
+			foreach (var dependency in dependencies)
+			{
+				var children = childrenDependencies.Where(c => c.Equals(dependency)).ToList();
+				if (children.Count > 0)
+				{
+					dependency.ContainingPackages = children;
+					yield return dependency;
+				}
+			}
+		}
+
+		private IEnumerable<Dependency> GetDependencies(LockFile lockFile, TargetFrameworkInformation targetFramework)
+		{
+			var dependencies = new List<Dependency>();
+			var lockFileTargetFramework = lockFile.Targets.FirstOrDefault(t => t.TargetFramework.Equals(targetFramework.FrameworkName));
+
+			if (lockFileTargetFramework != null)
+			{
+				foreach (var dependency in targetFramework.Dependencies)
+				{
+					var projectLibrary = lockFileTargetFramework.Libraries.FirstOrDefault(library => library.Name == dependency.Name);
+					var reportDependency = ReportDependency(projectLibrary, lockFileTargetFramework, 1);
+
+					if (reportDependency == null) continue;
+
+					dependencies.Add(reportDependency);
+				}
+			}
+
+			return dependencies;
+		}
+
+		private Dependency ReportDependency(LockFileTargetLibrary projectLibrary, LockFileTarget lockFileTargetFramework, int indentLevel, Dependency dependency = null)
+		{
+			if (projectLibrary == null)
+				return null;
+
+			if (indentLevel == 1)
+				dependency = new Dependency(projectLibrary.Name, projectLibrary.Version.OriginalVersion);
+
+			foreach (var childDependency in projectLibrary.Dependencies)
+			{
+				var childLibrary = lockFileTargetFramework.Libraries.FirstOrDefault(library => library.Name == childDependency.Id);
+				dependency.Children.Add(new Dependency(childDependency.Id, childDependency.VersionRange.MinVersion.OriginalVersion) { Parent = dependency.Name });
+				ReportDependency(childLibrary, lockFileTargetFramework, indentLevel + 1, dependency);
+			}
+
+			return dependency;
+		}
+	}
+}

--- a/Project2015To2017.Core/CleanUp/RunStatus.cs
+++ b/Project2015To2017.Core/CleanUp/RunStatus.cs
@@ -1,0 +1,20 @@
+namespace Project2015To2017.CleanUp
+{
+	public class RunStatus
+	{
+		public string Output { get; }
+
+		public string Errors { get; }
+
+		public int ExitCode { get; }
+
+		public bool IsSuccess => ExitCode == 0;
+
+		public RunStatus(string output, string errors, int exitCode)
+		{
+			Output = output;
+			Errors = errors;
+			ExitCode = exitCode;
+		}
+	}
+}

--- a/Project2015To2017.Core/Project2015To2017.Core.csproj
+++ b/Project2015To2017.Core/Project2015To2017.Core.csproj
@@ -12,8 +12,10 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
 		<PackageReference Include="NuGet.Configuration" Version="4.9.3" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+		<PackageReference Include="NuGet.ProjectModel" Version="4.9.3" />
 		<PackageReference Include="System.Memory" Version="4.5.2" />
 	</ItemGroup>
 	

--- a/Project2015To2017.Migrate2017.Tool/Program.cs
+++ b/Project2015To2017.Migrate2017.Tool/Program.cs
@@ -1,11 +1,11 @@
+using System;
+using System.IO;
+using System.Linq;
 using Microsoft.DotNet.Cli.CommandLine;
 using Project2015To2017.Caching;
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
-using System;
-using System.IO;
-using System.Linq;
 using static Microsoft.DotNet.Cli.CommandLine.Accept;
 using static Microsoft.DotNet.Cli.CommandLine.Create;
 
@@ -126,7 +126,7 @@ namespace Project2015To2017.Migrate2017.Tool
 					if (forceTransformations != null)
 						conversionOptions.ForceDefaultTransforms = forceTransformations;
 
-					logic.ExecuteMigrate(items, command.ValueOrDefault<bool>("no-backup"), conversionOptions);
+					logic.ExecuteMigrate(items, command.ValueOrDefault<bool>("no-backup"), command.ValueOrDefault<bool>("cleanup"), conversionOptions);
 					break;
 			}
 
@@ -189,6 +189,7 @@ namespace Project2015To2017.Migrate2017.Tool
 					"Specify multiple times for multiple enforced transformations.",
 					OneOrMoreArguments()
 						.With("Transformation names to enforce execution", "names")),
+				Option("-c|--cleanup", "Cleanup package references, if transitive references are found"),
 				HelpOption());
 
 		private static Command Analyze() =>

--- a/Project2015To2017.Tests/CleanUpTests.cs
+++ b/Project2015To2017.Tests/CleanUpTests.cs
@@ -1,0 +1,28 @@
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Project2015To2017.CleanUp;
+using Project2015To2017.Migrate2017.Transforms;
+using Project2015To2017.Reading;
+
+namespace Project2015To2017.Tests
+{
+	[TestClass]
+	public class CleanUpTests
+	{
+		[TestMethod]
+		public void CheckCleanUpExecution()
+		{
+			var project = new ProjectReader().Read(Path.Combine("Testfiles", "Transitive", "TransitiveDependeny.testcsproj"));
+			var transformation = new FileTransformation();
+
+			project.CodeFileExtension = "cs";
+			transformation.Transform(project);
+
+			var cleaner = new PackageReferenceCleaner(new DummyLogger());
+			cleaner.CleanUpProjectReferences(project);
+
+			Assert.AreEqual(1, project.PackageReferences.Count);
+			Assert.AreEqual("Autofac.Wcf", project.PackageReferences[0].Id);
+		}
+	}
+}

--- a/Project2015To2017.Tests/Project2015To2017.Tests.csproj
+++ b/Project2015To2017.Tests/Project2015To2017.Tests.csproj
@@ -164,6 +164,9 @@
     <None Include="TestFiles\OtherTestProjects\net46console.testcsproj">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="TestFiles\Transitive\TransitiveDependeny.testcsproj">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="TestFiles\OtherTestProjects\unittest.testcsproj">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Project2015To2017.Tests/TestFiles/Transitive/TransitiveDependeny.testcsproj
+++ b/Project2015To2017.Tests/TestFiles/Transitive/TransitiveDependeny.testcsproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <ProjectGuid>{19BF1086-43BE-480D-86DA-E40C70E85643}</ProjectGuid>
+    <TargetFramework>net471</TargetFramework>
+    <AssemblyTitle>TransitiveDependeny</AssemblyTitle>
+    <Product>TransitiveDependeny</Product>
+    <Copyright>Copyright ©  2019</Copyright>
+    <OutputPath>bin\$(Configuration)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Autofac" Version="3.3.1" />
+    <PackageReference Include="Autofac.Wcf" Version="4.1.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.ServiceModel.Activation" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Hey,

i've got another request. 

After migration it would be great to use the new transitive way for nuget package references. So it would be nice to remove unnecessary references.

I added another command line argument for migration to clean up the references.

What do you think about it? I've got already a console application to get the output for removable references [AnalyzeDotnetProjects](https://github.com/MO2k4/AnalyzeDotNetProject)