### PR TITLE
Don't crash if PackageReference had no Version information

### DIFF
--- a/Project2015To2017.Core/Writing/ProjectWriter.cs
+++ b/Project2015To2017.Core/Writing/ProjectWriter.cs
@@ -254,6 +254,7 @@ namespace Project2015To2017.Writing
 					{
 						reference.Add(new XAttribute("Version", packageReference.Version));
 					}
+					
 					if (packageReference.IsDevelopmentDependency)
 					{
 						reference.Add(new XElement("PrivateAssets", "all"));

--- a/Project2015To2017.Core/Writing/ProjectWriter.cs
+++ b/Project2015To2017.Core/Writing/ProjectWriter.cs
@@ -249,8 +249,11 @@ namespace Project2015To2017.Writing
 				var nugetReferences = new XElement("ItemGroup");
 				foreach (var packageReference in project.PackageReferences)
 				{
-					var reference = new XElement("PackageReference", new XAttribute("Include", packageReference.Id),
-						new XAttribute("Version", packageReference.Version));
+					var reference = new XElement("PackageReference", new XAttribute("Include", packageReference.Id));
+					if (packageReference.Version != null)
+					{
+						reference.Add(new XAttribute("Version", packageReference.Version));
+					}
 					if (packageReference.IsDevelopmentDependency)
 					{
 						reference.Add(new XElement("PrivateAssets", "all"));


### PR DESCRIPTION
Hi,

Some of PackageReference references in our project don't have a Version specified so the conversion crashes with the following exception:

> System.ArgumentNullException: Value cannot be null.
> Parameter name: value
>    at new System.Xml.Linq.XAttribute(XName name, object value)
>    at XElement Project2015To2017.Writing.ProjectWriter.CreateXml(Project project) in CsprojToVs2017\Project2015To2017.Core\Writing\ProjectWriter.cs:line 252
>    at bool Project2015To2017.Writing.ProjectWriter.WriteProjectFile(Project project) in CsprojToVs2017\Project2015To2017.Core\Writing\ProjectWriter.cs:line 75
>    at bool Project2015To2017.Writing.ProjectWriter.TryWriteOrThrow(Project project, bool makeBackups) CsprojToVs2017\Project2015To2017.Core\Writing\ProjectWriter.cs:line 57
>    at bool Project2015To2017.Writing.ProjectWriter.TryWrite(Project project, bool makeBackups) in CsprojToVs2017\Project2015To2017.Core\Writing\ProjectWriter.cs:line 40

This PR allows converter not to crash, but to produce similar PackageReference with no version attribute instead. 
