### PR TITLE
Apply standard formatting across solution

### DIFF
--- a/Project2015To2017.Console/Project2015To2017.Console.csproj
+++ b/Project2015To2017.Console/Project2015To2017.Console.csproj
@@ -1,18 +1,18 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>netcoreapp2.1</TargetFramework>
-		<PackAsTool>True</PackAsTool>
+  <PropertyGroup>
+	<TargetFramework>netcoreapp2.1</TargetFramework>
+	<PackAsTool>True</PackAsTool>
 
-		<PackageId>Project2015To2017.Cli</PackageId>
-		<Product>Project2015To2017.Cli</Product>
-		<OutputType>Exe</OutputType>
-		<ToolCommandName>csproj-to-2017</ToolCommandName>
-	</PropertyGroup>
+	<PackageId>Project2015To2017.Cli</PackageId>
+	<Product>Project2015To2017.Cli</Product>
+	<OutputType>Exe</OutputType>
+	<ToolCommandName>csproj-to-2017</ToolCommandName>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="CommandLineParser" Version="2.4.3" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
-	</ItemGroup>
+  <ItemGroup>
+	<PackageReference Include="CommandLineParser" Version="2.4.3" />
+	<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
+  </ItemGroup>
 
 </Project>

--- a/Project2015To2017.Core/Analysis/AnalysisExtensions.cs
+++ b/Project2015To2017.Core/Analysis/AnalysisExtensions.cs
@@ -29,7 +29,7 @@ namespace Project2015To2017.Analysis
 				{
 					Location = new DiagnosticLocation(self.Location)
 					{
-						SourceLine = (uint) elementOnLine.LineNumber
+						SourceLine = (uint)elementOnLine.LineNumber
 					}
 				};
 			}

--- a/Project2015To2017.Core/ChainTransformationSet.cs
+++ b/Project2015To2017.Core/ChainTransformationSet.cs
@@ -15,7 +15,7 @@ namespace Project2015To2017
 		}
 
 		public ChainTransformationSet(params ITransformationSet[] sets)
-			: this((IReadOnlyCollection<ITransformationSet>) sets)
+			: this((IReadOnlyCollection<ITransformationSet>)sets)
 		{
 		}
 

--- a/Project2015To2017.Core/ConversionOptions.cs
+++ b/Project2015To2017.Core/ConversionOptions.cs
@@ -4,17 +4,17 @@ using Project2015To2017.Transforms;
 
 namespace Project2015To2017
 {
-    public sealed class ConversionOptions
-    {
+	public sealed class ConversionOptions
+	{
 		/// <summary>
 		/// Project cache, if any. When null no caching is used.
 		/// </summary>
 		public Caching.IProjectCache ProjectCache { get; set; }
-	    /// <summary>
-	    /// Whether to keep the AssemblyInfo.cs file, or to
-	    /// move the attributes into the project file
-	    /// </summary>
-	    public bool KeepAssemblyInfo { get; set; }
+		/// <summary>
+		/// Whether to keep the AssemblyInfo.cs file, or to
+		/// move the attributes into the project file
+		/// </summary>
+		public bool KeepAssemblyInfo { get; set; }
 		/// <summary>
 		/// Change the target framework to a specific framework, or to
 		/// multi target frameworks
@@ -24,19 +24,19 @@ namespace Project2015To2017
 		/// Append the target framework to the output path
 		/// </summary>
 		public bool AppendTargetFrameworkToOutputPath { get; set; } = true;
-	    /// <summary>
-	    /// A collection of transforms executed before the execution of default ones
-	    /// </summary>
-	    public IReadOnlyList<ITransformation> PreDefaultTransforms { get; set; } = ImmutableArray<ITransformation>.Empty;
-	    /// <summary>
-	    /// A collection of transforms executed after the execution of default ones
-	    /// </summary>
-	    public IReadOnlyList<ITransformation> PostDefaultTransforms { get; set; } = ImmutableArray<ITransformation>.Empty;
-	    /// <summary>
-	    /// A collection of transform class names executed despite being intended for different project system,
-	    /// like forcing <see cref="ILegacyOnlyProjectTransformation"/> run on already converted project.
-	    /// </summary>
-	    public IReadOnlyList<string> ForceDefaultTransforms { get; set; } = ImmutableArray<string>.Empty;
+		/// <summary>
+		/// A collection of transforms executed before the execution of default ones
+		/// </summary>
+		public IReadOnlyList<ITransformation> PreDefaultTransforms { get; set; } = ImmutableArray<ITransformation>.Empty;
+		/// <summary>
+		/// A collection of transforms executed after the execution of default ones
+		/// </summary>
+		public IReadOnlyList<ITransformation> PostDefaultTransforms { get; set; } = ImmutableArray<ITransformation>.Empty;
+		/// <summary>
+		/// A collection of transform class names executed despite being intended for different project system,
+		/// like forcing <see cref="ILegacyOnlyProjectTransformation"/> run on already converted project.
+		/// </summary>
+		public IReadOnlyList<string> ForceDefaultTransforms { get; set; } = ImmutableArray<string>.Empty;
 		/// <summary>
 		/// Action that will be executed when project reader cannot unambiguously determine target frameworks
 		/// for the currently processing project.

--- a/Project2015To2017.Core/Definition/ApplicationType.cs
+++ b/Project2015To2017.Core/Definition/ApplicationType.cs
@@ -1,12 +1,12 @@
 namespace Project2015To2017.Definition
 {
-    public enum ApplicationType
-    {
-        Unknown = 0,
-        ClassLibrary = 1,
-        ConsoleApplication = 2,
-        WindowsApplication = 3,
-        TestProject = 4,
+	public enum ApplicationType
+	{
+		Unknown = 0,
+		ClassLibrary = 1,
+		ConsoleApplication = 2,
+		WindowsApplication = 3,
+		TestProject = 4,
 		AppContainerExe = 5
 	}
 }

--- a/Project2015To2017.Core/Definition/AssemblyAttributes.cs
+++ b/Project2015To2017.Core/Definition/AssemblyAttributes.cs
@@ -21,32 +21,38 @@ namespace Project2015To2017.Definition
 			set => SetAttribute(typeof(AssemblyTitleAttribute), value);
 		}
 
-		public string Company {
+		public string Company
+		{
 			get => GetAttribute(typeof(AssemblyCompanyAttribute));
 			set => SetAttribute(typeof(AssemblyCompanyAttribute), value);
 		}
 
-		public string Product {
+		public string Product
+		{
 			get => GetAttribute(typeof(AssemblyProductAttribute));
 			set => SetAttribute(typeof(AssemblyProductAttribute), value);
 		}
 
-		public string Copyright {
+		public string Copyright
+		{
 			get => GetAttribute(typeof(AssemblyCopyrightAttribute));
 			set => SetAttribute(typeof(AssemblyCopyrightAttribute), value);
 		}
 
-		public string InformationalVersion {
+		public string InformationalVersion
+		{
 			get => GetAttribute(typeof(AssemblyInformationalVersionAttribute));
 			set => SetAttribute(typeof(AssemblyInformationalVersionAttribute), value);
 		}
 
-		public string Version {
+		public string Version
+		{
 			get => GetAttribute(typeof(AssemblyVersionAttribute));
 			set => SetAttribute(typeof(AssemblyVersionAttribute), value);
 		}
 
-		public string Description {
+		public string Description
+		{
 			get => GetAttribute(typeof(AssemblyDescriptionAttribute));
 			set => SetAttribute(typeof(AssemblyDescriptionAttribute), value);
 		}
@@ -69,12 +75,14 @@ namespace Project2015To2017.Definition
 			set => SetAttribute(typeof(NeutralResourcesLanguageAttribute), value);
 		}
 
-		public string Configuration {
+		public string Configuration
+		{
 			get => GetAttribute(typeof(AssemblyConfigurationAttribute));
 			set => SetAttribute(typeof(AssemblyConfigurationAttribute), value);
 		}
 
-		public string FileVersion {
+		public string FileVersion
+		{
 			get => GetAttribute(typeof(AssemblyFileVersionAttribute));
 			set => SetAttribute(typeof(AssemblyFileVersionAttribute), value);
 		}
@@ -164,7 +172,7 @@ namespace Project2015To2017.Definition
 
 		private static AttributeListSyntax CreateAttribute(Type attributeType, string value)
 		{
-			var root = (CompilationUnitSyntax) SyntaxFactory
+			var root = (CompilationUnitSyntax)SyntaxFactory
 				.ParseSyntaxTree($"[assembly: {attributeType.Name}(\"{value}\")]")
 				.GetRoot();
 

--- a/Project2015To2017.Core/Definition/PackageConfiguration.cs
+++ b/Project2015To2017.Core/Definition/PackageConfiguration.cs
@@ -4,20 +4,20 @@ using System.Xml.Linq;
 
 namespace Project2015To2017.Definition
 {
-    public sealed class PackageConfiguration
-    {
-	    public string Id { get; set; }
-        public string Version { get; set; }
-        public string Authors { get; set; }
-        public string Description { get; set; }
-        public string Copyright { get; set; }
-        public string LicenseUrl { get; set; }
-        public string ProjectUrl { get; set; }
-        public string IconUrl { get; set; }
-        public string Tags { get; set; }
-        public string ReleaseNotes { get; set; }
-        public bool RequiresLicenseAcceptance { get; set; }
-	    public IList<XElement> Dependencies { get; set; }
-	    public FileInfo NuspecFile { get; set; }
-    }
+	public sealed class PackageConfiguration
+	{
+		public string Id { get; set; }
+		public string Version { get; set; }
+		public string Authors { get; set; }
+		public string Description { get; set; }
+		public string Copyright { get; set; }
+		public string LicenseUrl { get; set; }
+		public string ProjectUrl { get; set; }
+		public string IconUrl { get; set; }
+		public string Tags { get; set; }
+		public string ReleaseNotes { get; set; }
+		public bool RequiresLicenseAcceptance { get; set; }
+		public IList<XElement> Dependencies { get; set; }
+		public FileInfo NuspecFile { get; set; }
+	}
 }

--- a/Project2015To2017.Core/Definition/ProjectExtensions.cs
+++ b/Project2015To2017.Core/Definition/ProjectExtensions.cs
@@ -55,7 +55,7 @@ namespace Project2015To2017.Definition
 
 			var (unconditional, conditional) = project.PropertyAll(name);
 			return unconditional.LastOrDefault()
-			       ?? (tryConditional ? conditional.Select(x => x.element).LastOrDefault() : null);
+				   ?? (tryConditional ? conditional.Select(x => x.element).LastOrDefault() : null);
 		}
 
 		public static IEnumerable<(Guid guid, XElement source)> IterateProjectTypeGuids(this Project project)
@@ -71,7 +71,7 @@ namespace Project2015To2017.Definition
 			{
 				// parse the CSV list
 				foreach (var guid in element.Value
-					.Split(new[] {';'}, StringSplitOptions.RemoveEmptyEntries)
+					.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
 					.Select(x =>
 						Guid.TryParse(x.Trim(), out var res)
 							? res
@@ -132,14 +132,14 @@ namespace Project2015To2017.Definition
 		public static IEnumerable<XElement> AllUnconditional(this PropertyFindResult self)
 		{
 			return self.LastUnconditionalElement != null
-				? self.OtherUnconditionalElements.Concat(new[] {self.LastUnconditionalElement})
+				? self.OtherUnconditionalElements.Concat(new[] { self.LastUnconditionalElement })
 				: Array.Empty<XElement>();
 		}
 
 		public static IEnumerable<XElement> AllConditional(this PropertyFindResult self)
 		{
 			return self.LastConditionalElement != null
-				? self.OtherConditionalElements.Concat(new[] {self.LastConditionalElement})
+				? self.OtherConditionalElements.Concat(new[] { self.LastConditionalElement })
 				: Array.Empty<XElement>();
 		}
 

--- a/Project2015To2017.Core/Extensions.cs
+++ b/Project2015To2017.Core/Extensions.cs
@@ -93,11 +93,11 @@ namespace Project2015To2017
 		{
 			return new XElement(e.Name.LocalName,
 				(from n in e.Nodes()
-					select ((n is XElement element) ? RemoveAllNamespaces(element) : n)),
+				 select ((n is XElement element) ? RemoveAllNamespaces(element) : n)),
 				(e.HasAttributes)
 					? (from a in e.Attributes()
-						where (!a.IsNamespaceDeclaration)
-						select new XAttribute(a.Name.LocalName, a.Value))
+					   where (!a.IsNamespaceDeclaration)
+					   select new XAttribute(a.Name.LocalName, a.Value))
 					: null);
 		}
 

--- a/Project2015To2017.Core/ExtensionsExternal.cs
+++ b/Project2015To2017.Core/ExtensionsExternal.cs
@@ -23,9 +23,9 @@ namespace Project2015To2017
 			// Don't bother with arrays or properties or network paths, or those that
 			// have no slashes.
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-			    || string.IsNullOrEmpty(value)
-			    || value.StartsWith("$(", comparisonType) || value.StartsWith("@(", comparisonType)
-			    || value.StartsWith("\\\\", comparisonType))
+				|| string.IsNullOrEmpty(value)
+				|| value.StartsWith("$(", comparisonType) || value.StartsWith("@(", comparisonType)
+				|| value.StartsWith("\\\\", comparisonType))
 			{
 				return value;
 			}
@@ -35,7 +35,7 @@ namespace Project2015To2017
 
 			// Find the part of the name we want to check, that is remove quotes, if present
 			var shouldAdjust = newValue.IndexOf('/') != -1 &&
-			                   LooksLikeUnixFilePath(RemoveQuotes(newValue), baseDirectory);
+							   LooksLikeUnixFilePath(RemoveQuotes(newValue), baseDirectory);
 			return shouldAdjust ? newValue : value;
 		}
 
@@ -73,8 +73,8 @@ namespace Project2015To2017
 			const char doubleQuote = '\"';
 
 			var hasQuotes = path.Length > 2
-			                && (path[0] == singleQuote && path[endId] == singleQuote
-			                    || path[0] == doubleQuote && path[endId] == doubleQuote);
+							&& (path[0] == singleQuote && path[endId] == singleQuote
+								|| path[0] == doubleQuote && path[endId] == doubleQuote);
 
 			return hasQuotes ? path.Substring(1, endId - 1) : path;
 		}
@@ -104,8 +104,8 @@ namespace Project2015To2017
 			var shouldCheckFileOrDirectory = !shouldCheckDirectory && value.Length > 0 && value[0] == '/';
 
 			return shouldCheckDirectory &&
-			       Directory.Exists(Path.Combine(baseDirectory, value.Substring(0, directoryLength)))
-			       || shouldCheckFileOrDirectory && (File.Exists(value) || Directory.Exists(value));
+				   Directory.Exists(Path.Combine(baseDirectory, value.Substring(0, directoryLength)))
+				   || shouldCheckFileOrDirectory && (File.Exists(value) || Directory.Exists(value));
 		}
 	}
 }

--- a/Project2015To2017.Core/ExtensionsGraph.cs
+++ b/Project2015To2017.Core/ExtensionsGraph.cs
@@ -13,7 +13,7 @@ namespace Project2015To2017
 			var all = set.Transformations(logger, conversionOptions);
 			var (normal, others) = all.Split(FilterTargetNormalTransformations);
 			var (early, late) = others.Split(x =>
-				((ITransformationWithTargetMoment) x).ExecutionMoment == TargetTransformationExecutionMoment.Early);
+				((ITransformationWithTargetMoment)x).ExecutionMoment == TargetTransformationExecutionMoment.Early);
 			var res = new List<ITransformation>(all.Count);
 			TopologicalSort(early, res, logger);
 			TopologicalSort(normal, res, logger);

--- a/Project2015To2017.Core/PathCompat.NETFramework.cs
+++ b/Project2015To2017.Core/PathCompat.NETFramework.cs
@@ -117,18 +117,18 @@ namespace Project2015To2017
 		/// Returns true if the two paths have the same root
 		/// </summary>
 		private static bool AreRootsEqual(string first, string second, StringComparison comparisonType)
-        {
-            int firstRootLength = GetRootLength(first.AsSpan());
-            int secondRootLength = GetRootLength(second.AsSpan());
+		{
+			int firstRootLength = GetRootLength(first.AsSpan());
+			int secondRootLength = GetRootLength(second.AsSpan());
 
-            return firstRootLength == secondRootLength
-                && string.Compare(
-                    strA: first,
-                    indexA: 0,
-                    strB: second,
-                    indexB: 0,
-                    length: firstRootLength,
-                    comparisonType: comparisonType) == 0;
+			return firstRootLength == secondRootLength
+				&& string.Compare(
+					strA: first,
+					indexA: 0,
+					strB: second,
+					indexB: 0,
+					length: firstRootLength,
+					comparisonType: comparisonType) == 0;
 		}
 
 		// \\?\, \\.\, \??\
@@ -149,10 +149,10 @@ namespace Project2015To2017
 			// While paths like "//?/C:/" will work, they're treated the same as "\\.\" paths.
 			// Skipping of normalization will *only* occur if back slashes ('\') are used.
 			return path.Length >= DevicePrefixLength
-			       && path[0] == '\\'
-			       && (path[1] == '\\' || path[1] == '?')
-			       && path[2] == '?'
-			       && path[3] == '\\';
+				   && path[0] == '\\'
+				   && (path[1] == '\\' || path[1] == '?')
+				   && path[2] == '?'
+				   && path[3] == '\\';
 		}
 
 		/// <summary>
@@ -163,14 +163,14 @@ namespace Project2015To2017
 			// If the path begins with any two separators is will be recognized and normalized and prepped with
 			// "\??\" for internal usage correctly. "\??\" is recognized and handled, "/??/" is not.
 			return IsExtended(path)
-			       ||
-			       (
-				       path.Length >= DevicePrefixLength
-				       && IsDirectorySeparator(path[0])
-				       && IsDirectorySeparator(path[1])
-				       && (path[2] == '.' || path[2] == '?')
-				       && IsDirectorySeparator(path[3])
-			       );
+				   ||
+				   (
+					   path.Length >= DevicePrefixLength
+					   && IsDirectorySeparator(path[0])
+					   && IsDirectorySeparator(path[1])
+					   && (path[2] == '.' || path[2] == '?')
+					   && IsDirectorySeparator(path[3])
+				   );
 		}
 
 		/// <summary>
@@ -179,11 +179,11 @@ namespace Project2015To2017
 		private static bool IsDeviceUNC(ReadOnlySpan<char> path)
 		{
 			return path.Length >= UncExtendedPrefixLength
-			       && IsDevice(path)
-			       && IsDirectorySeparator(path[7])
-			       && path[4] == 'U'
-			       && path[5] == 'N'
-			       && path[6] == 'C';
+				   && IsDevice(path)
+				   && IsDirectorySeparator(path[7])
+				   && path[4] == 'U'
+				   && path[5] == 'N'
+				   && path[6] == 'C';
 		}
 
 		/// <summary>
@@ -245,8 +245,8 @@ namespace Project2015To2017
 					i++;
 			}
 			else if (pathLength >= 2
-			         && path[1] == VolumeSeparatorChar
-			         && IsValidDriveChar(path[0]))
+					 && path[1] == VolumeSeparatorChar
+					 && IsValidDriveChar(path[0]))
 			{
 				// Valid drive specified path ("C:", "D:", etc.)
 				i = 2;
@@ -265,16 +265,16 @@ namespace Project2015To2017
 		/// just spaces ((char)32).
 		/// </summary>
 		private static bool IsEffectivelyEmpty(ReadOnlySpan<char> path)
-        {
-            if (path.IsEmpty)
-                return true;
+		{
+			if (path.IsEmpty)
+				return true;
 
-            foreach (char c in path)
-            {
-                if (c != ' ')
-                    return false;
-            }
-            return true;
+			foreach (char c in path)
+			{
+				if (c != ' ')
+					return false;
+			}
+			return true;
 		}
 
 		/// <summary>
@@ -299,7 +299,7 @@ namespace Project2015To2017
 
 			// Or we're a full string and equal length or match to a separator
 			if (commonChars == first.Length
-			    && (commonChars == second.Length || IsDirectorySeparator(second[commonChars])))
+				&& (commonChars == second.Length || IsDirectorySeparator(second[commonChars])))
 				return commonChars;
 
 			if (commonChars == second.Length && IsDirectorySeparator(first[commonChars]))
@@ -330,7 +330,7 @@ namespace Project2015To2017
 				char* rightEnd = r + second.Length;
 
 				while (l != leftEnd && r != rightEnd
-				                    && (*l == *r || (ignoreCase && char.ToUpperInvariant((*l)) == char.ToUpperInvariant((*r)))))
+									&& (*l == *r || (ignoreCase && char.ToUpperInvariant((*l)) == char.ToUpperInvariant((*r)))))
 				{
 					commonChars++;
 					l++;

--- a/Project2015To2017.Core/Project2015To2017.Core.csproj
+++ b/Project2015To2017.Core/Project2015To2017.Core.csproj
@@ -1,28 +1,28 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net461;netcoreapp2.1</TargetFrameworks>
-		<RootNamespace>Project2015To2017</RootNamespace>
-	</PropertyGroup>
-	
-	<PropertyGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
-		<!-- PathCompat.NETFramework.cs -->
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-	</PropertyGroup>
+  <PropertyGroup>
+	<TargetFrameworks>netstandard2.0;net461;netcoreapp2.1</TargetFrameworks>
+	<RootNamespace>Project2015To2017</RootNamespace>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
-		<PackageReference Include="NuGet.Configuration" Version="4.9.3" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
-		<PackageReference Include="System.Memory" Version="4.5.2" />
-	</ItemGroup>
-	
-	<ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
-		<Compile Remove="PathCompat.NETFramework.cs" />
-	</ItemGroup>
-	
-	<ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
-		<Compile Remove="PathCompat.NETCore.cs" />
-	</ItemGroup>
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+	<!-- PathCompat.NETFramework.cs -->
+	<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+	<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.10.0" />
+	<PackageReference Include="NuGet.Configuration" Version="4.9.3" />
+	<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
+	<PackageReference Include="System.Memory" Version="4.5.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+	<Compile Remove="PathCompat.NETFramework.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+	<Compile Remove="PathCompat.NETCore.cs" />
+  </ItemGroup>
 
 </Project>

--- a/Project2015To2017.Core/ProjectConverter.cs
+++ b/Project2015To2017.Core/ProjectConverter.cs
@@ -36,7 +36,7 @@ namespace Project2015To2017
 			this.transformationSet = transformationSet ?? BasicReadTransformationSet.Instance;
 			projectReader = new ProjectReader(logger, this.conversionOptions);
 		}
-		
+
 		public IEnumerable<Project> ProcessSolutionFile(Solution solution)
 		{
 			logger.LogTrace("Solution parsing started.");
@@ -94,15 +94,15 @@ namespace Project2015To2017
 			foreach (var transform in transformationSet.IterateTransformations(logger, conversionOptions))
 			{
 				if (project.IsModernProject
-				    && transform is ILegacyOnlyProjectTransformation
-				    && !conversionOptions.ForceDefaultTransforms.Contains(transform.GetType().Name))
+					&& transform is ILegacyOnlyProjectTransformation
+					&& !conversionOptions.ForceDefaultTransforms.Contains(transform.GetType().Name))
 				{
 					continue;
 				}
 
 				if (!project.IsModernProject
-				    && transform is IModernOnlyProjectTransformation
-				    && !conversionOptions.ForceDefaultTransforms.Contains(transform.GetType().Name))
+					&& transform is IModernOnlyProjectTransformation
+					&& !conversionOptions.ForceDefaultTransforms.Contains(transform.GetType().Name))
 				{
 					continue;
 				}

--- a/Project2015To2017.Core/Reading/AssemblyInfoReader.cs
+++ b/Project2015To2017.Core/Reading/AssemblyInfoReader.cs
@@ -87,7 +87,7 @@ namespace Project2015To2017.Reading
 
 			var tree = CSharpSyntaxTree.ParseText(text);
 
-			var root = (CompilationUnitSyntax) tree.GetRoot();
+			var root = (CompilationUnitSyntax)tree.GetRoot();
 
 			var assemblyAttributes = new AssemblyAttributes
 			{

--- a/Project2015To2017.Core/Reading/ConditionEvaluator.Cache.cs
+++ b/Project2015To2017.Core/Reading/ConditionEvaluator.Cache.cs
@@ -6,21 +6,21 @@ namespace Project2015To2017.Reading
 	///
 	/// </summary>
 	internal static partial class ConditionEvaluator
-    {
-        private static readonly Dictionary<string, ConditionEvaluationStateImpl> Cache = new Dictionary<string, ConditionEvaluationStateImpl>();
+	{
+		private static readonly Dictionary<string, ConditionEvaluationStateImpl> Cache = new Dictionary<string, ConditionEvaluationStateImpl>();
 
-        private static bool TryGetCachedOrCreateState(string condition, out ConditionEvaluationStateImpl state)
-        {
-            if (Cache.TryGetValue(condition, out state))
-            {
-                return true;
-            }
+		private static bool TryGetCachedOrCreateState(string condition, out ConditionEvaluationStateImpl state)
+		{
+			if (Cache.TryGetValue(condition, out state))
+			{
+				return true;
+			}
 
-            state = new ConditionEvaluationStateImpl(condition);
+			state = new ConditionEvaluationStateImpl(condition);
 
-            Cache.Add(condition, state);
+			Cache.Add(condition, state);
 
-            return false;
-        }
-    }
+			return false;
+		}
+	}
 }

--- a/Project2015To2017.Core/Reading/Conditionals/AndExpressionNode.cs
+++ b/Project2015To2017.Core/Reading/Conditionals/AndExpressionNode.cs
@@ -5,38 +5,38 @@ using System.Diagnostics;
 
 namespace Project2015To2017.Reading.Conditionals
 {
-    /// <summary>
-    /// Performs logical AND on children
-    /// Does not update conditioned properties table
-    /// </summary>
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    internal sealed class AndExpressionNode : OperatorExpressionNode
-    {
-        /// <summary>
-        /// Evaluate as boolean
-        /// </summary>
-        internal override bool BoolEvaluate(IConditionEvaluationState state)
-        {
-            if (!this.LeftChild.BoolEvaluate(state))
-            {
-                // Short circuit
-                return false;
-            }
-            else
-            {
-                return this.RightChild.BoolEvaluate(state);
-            }
-        }
+	/// <summary>
+	/// Performs logical AND on children
+	/// Does not update conditioned properties table
+	/// </summary>
+	[DebuggerDisplay("{DebuggerDisplay,nq}")]
+	internal sealed class AndExpressionNode : OperatorExpressionNode
+	{
+		/// <summary>
+		/// Evaluate as boolean
+		/// </summary>
+		internal override bool BoolEvaluate(IConditionEvaluationState state)
+		{
+			if (!this.LeftChild.BoolEvaluate(state))
+			{
+				// Short circuit
+				return false;
+			}
+			else
+			{
+				return this.RightChild.BoolEvaluate(state);
+			}
+		}
 
-        internal override string DebuggerDisplay => $"(and {this.LeftChild.DebuggerDisplay} {this.RightChild.DebuggerDisplay})";
+		internal override string DebuggerDisplay => $"(and {this.LeftChild.DebuggerDisplay} {this.RightChild.DebuggerDisplay})";
 
-        #region REMOVE_COMPAT_WARNING
-        private bool _possibleAndCollision = true;
-        internal override bool PossibleAndCollision
-        {
-            set { this._possibleAndCollision = value; }
-            get { return this._possibleAndCollision; }
-        }
-        #endregion
-    }
+		#region REMOVE_COMPAT_WARNING
+		private bool _possibleAndCollision = true;
+		internal override bool PossibleAndCollision
+		{
+			set { this._possibleAndCollision = value; }
+			get { return this._possibleAndCollision; }
+		}
+		#endregion
+	}
 }

--- a/Project2015To2017.Core/Reading/Conditionals/CharacterUtilities.cs
+++ b/Project2015To2017.Core/Reading/Conditionals/CharacterUtilities.cs
@@ -3,32 +3,32 @@
 
 namespace Project2015To2017.Reading.Conditionals
 {
-    internal static class CharacterUtilities
-    {
-        static internal bool IsNumberStart(char candidate)
-        {
-            return (candidate == '+' || candidate == '-' || candidate == '.' || char.IsDigit(candidate));
-        }
+	internal static class CharacterUtilities
+	{
+		static internal bool IsNumberStart(char candidate)
+		{
+			return (candidate == '+' || candidate == '-' || candidate == '.' || char.IsDigit(candidate));
+		}
 
-        static internal bool IsSimpleStringStart(char candidate)
-        {
-            return (candidate == '_' || char.IsLetter(candidate));
-        }
+		static internal bool IsSimpleStringStart(char candidate)
+		{
+			return (candidate == '_' || char.IsLetter(candidate));
+		}
 
-        static internal bool IsSimpleStringChar(char candidate)
-        {
-            return (IsSimpleStringStart(candidate) || char.IsDigit(candidate));
-        }
+		static internal bool IsSimpleStringChar(char candidate)
+		{
+			return (IsSimpleStringStart(candidate) || char.IsDigit(candidate));
+		}
 
-        static internal bool IsHexAlphabetic(char candidate)
-        {
-            return (candidate == 'a' || candidate == 'b' || candidate == 'c' || candidate == 'd' || candidate == 'e' || candidate == 'f' ||
-                candidate == 'A' || candidate == 'B' || candidate == 'C' || candidate == 'D' || candidate == 'E' || candidate == 'F');
-        }
+		static internal bool IsHexAlphabetic(char candidate)
+		{
+			return (candidate == 'a' || candidate == 'b' || candidate == 'c' || candidate == 'd' || candidate == 'e' || candidate == 'f' ||
+				candidate == 'A' || candidate == 'B' || candidate == 'C' || candidate == 'D' || candidate == 'E' || candidate == 'F');
+		}
 
-        static internal bool IsHexDigit(char candidate)
-        {
-            return (char.IsDigit(candidate) || IsHexAlphabetic(candidate));
-        }
-    }
+		static internal bool IsHexDigit(char candidate)
+		{
+			return (char.IsDigit(candidate) || IsHexAlphabetic(candidate));
+		}
+	}
 }

--- a/Project2015To2017.Core/Reading/Conditionals/ConversionUtilities.cs
+++ b/Project2015To2017.Core/Reading/Conditionals/ConversionUtilities.cs
@@ -8,155 +8,155 @@ using error = Project2015To2017.Reading.Conditionals.ErrorUtilities;
 
 namespace Project2015To2017.Reading.Conditionals
 {
-    /// <summary>
-    /// This class contains only static methods, which are useful throughout many
-    /// of the MSBuild classes and don't really belong in any specific class.   
-    /// </summary>
-    internal static class ConversionUtilities
-    {
-        /// <summary>
-        /// Converts a string to a bool.  We consider "true/false", "on/off", and 
-        /// "yes/no" to be valid boolean representations in the XML.
-        /// </summary>
-        /// <param name="parameterValue">The string to convert.</param>
-        /// <returns>Boolean true or false, corresponding to the string.</returns>
-        internal static bool ConvertStringToBool(string parameterValue)
-        {
-            if (ValidBooleanTrue(parameterValue))
-            {
-                return true;
-            }
-            else if (ValidBooleanFalse(parameterValue))
-            {
-                return false;
-            }
-            else
-            {
-                // Unsupported boolean representation.
-                error.VerifyThrowArgument(false, "Shared.CannotConvertStringToBool", parameterValue);
-                return false;
-            }
-        }
+	/// <summary>
+	/// This class contains only static methods, which are useful throughout many
+	/// of the MSBuild classes and don't really belong in any specific class.   
+	/// </summary>
+	internal static class ConversionUtilities
+	{
+		/// <summary>
+		/// Converts a string to a bool.  We consider "true/false", "on/off", and 
+		/// "yes/no" to be valid boolean representations in the XML.
+		/// </summary>
+		/// <param name="parameterValue">The string to convert.</param>
+		/// <returns>Boolean true or false, corresponding to the string.</returns>
+		internal static bool ConvertStringToBool(string parameterValue)
+		{
+			if (ValidBooleanTrue(parameterValue))
+			{
+				return true;
+			}
+			else if (ValidBooleanFalse(parameterValue))
+			{
+				return false;
+			}
+			else
+			{
+				// Unsupported boolean representation.
+				error.VerifyThrowArgument(false, "Shared.CannotConvertStringToBool", parameterValue);
+				return false;
+			}
+		}
 
-        /// <summary>
-        /// Returns a hex representation of a byte array.
-        /// </summary>
-        /// <param name="bytes">The bytes to convert</param>
-        /// <returns>A string byte types formated as X2.</returns>
-        internal static string ConvertByteArrayToHex(byte[] bytes)
-        {
-            var sb = new StringBuilder();
-            foreach (var b in bytes)
-            {
-                sb.AppendFormat("{0:X2}", b);
-            }
+		/// <summary>
+		/// Returns a hex representation of a byte array.
+		/// </summary>
+		/// <param name="bytes">The bytes to convert</param>
+		/// <returns>A string byte types formated as X2.</returns>
+		internal static string ConvertByteArrayToHex(byte[] bytes)
+		{
+			var sb = new StringBuilder();
+			foreach (var b in bytes)
+			{
+				sb.AppendFormat("{0:X2}", b);
+			}
 
-            return sb.ToString();
-        }
+			return sb.ToString();
+		}
 
-        /// <summary>
-        /// Returns true if the string can be successfully converted to a bool,
-        /// such as "on" or "yes"
-        /// </summary>
-        internal static bool CanConvertStringToBool(string parameterValue)
-        {
-            return (ValidBooleanTrue(parameterValue) || ValidBooleanFalse(parameterValue));
-        }
+		/// <summary>
+		/// Returns true if the string can be successfully converted to a bool,
+		/// such as "on" or "yes"
+		/// </summary>
+		internal static bool CanConvertStringToBool(string parameterValue)
+		{
+			return (ValidBooleanTrue(parameterValue) || ValidBooleanFalse(parameterValue));
+		}
 
-        /// <summary>
-        /// Returns true if the string represents a valid MSBuild boolean true value,
-        /// such as "on", "!false", "yes"
-        /// </summary>
-        private static bool ValidBooleanTrue(string parameterValue)
-        {
-            return ((String.Compare(parameterValue, "true", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "on", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "yes", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "!false", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "!off", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "!no", StringComparison.OrdinalIgnoreCase) == 0));
-        }
+		/// <summary>
+		/// Returns true if the string represents a valid MSBuild boolean true value,
+		/// such as "on", "!false", "yes"
+		/// </summary>
+		private static bool ValidBooleanTrue(string parameterValue)
+		{
+			return ((String.Compare(parameterValue, "true", StringComparison.OrdinalIgnoreCase) == 0) ||
+					(String.Compare(parameterValue, "on", StringComparison.OrdinalIgnoreCase) == 0) ||
+					(String.Compare(parameterValue, "yes", StringComparison.OrdinalIgnoreCase) == 0) ||
+					(String.Compare(parameterValue, "!false", StringComparison.OrdinalIgnoreCase) == 0) ||
+					(String.Compare(parameterValue, "!off", StringComparison.OrdinalIgnoreCase) == 0) ||
+					(String.Compare(parameterValue, "!no", StringComparison.OrdinalIgnoreCase) == 0));
+		}
 
-        /// <summary>
-        /// Returns true if the string represents a valid MSBuild boolean false value,
-        /// such as "!on" "off" "no" "!true"
-        /// </summary>
-        private static bool ValidBooleanFalse(string parameterValue)
-        {
-            return ((String.Compare(parameterValue, "false", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "off", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "no", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "!true", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "!on", StringComparison.OrdinalIgnoreCase) == 0) ||
-                    (String.Compare(parameterValue, "!yes", StringComparison.OrdinalIgnoreCase) == 0));
-        }
+		/// <summary>
+		/// Returns true if the string represents a valid MSBuild boolean false value,
+		/// such as "!on" "off" "no" "!true"
+		/// </summary>
+		private static bool ValidBooleanFalse(string parameterValue)
+		{
+			return ((String.Compare(parameterValue, "false", StringComparison.OrdinalIgnoreCase) == 0) ||
+					(String.Compare(parameterValue, "off", StringComparison.OrdinalIgnoreCase) == 0) ||
+					(String.Compare(parameterValue, "no", StringComparison.OrdinalIgnoreCase) == 0) ||
+					(String.Compare(parameterValue, "!true", StringComparison.OrdinalIgnoreCase) == 0) ||
+					(String.Compare(parameterValue, "!on", StringComparison.OrdinalIgnoreCase) == 0) ||
+					(String.Compare(parameterValue, "!yes", StringComparison.OrdinalIgnoreCase) == 0));
+		}
 
-        /// <summary>
-        /// Converts a string like "123.456" into a double. Leading sign is allowed.
-        /// </summary>
-        internal static double ConvertDecimalToDouble(string number)
-        {
-            return Double.Parse(number, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture.NumberFormat);
-        }
+		/// <summary>
+		/// Converts a string like "123.456" into a double. Leading sign is allowed.
+		/// </summary>
+		internal static double ConvertDecimalToDouble(string number)
+		{
+			return Double.Parse(number, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture.NumberFormat);
+		}
 
-        /// <summary>
-        /// Converts a hex string like "0xABC" into a double.
-        /// </summary>
-        internal static double ConvertHexToDouble(string number)
-        {
-            return (double)Int32.Parse(number.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture.NumberFormat);
-        }
+		/// <summary>
+		/// Converts a hex string like "0xABC" into a double.
+		/// </summary>
+		internal static double ConvertHexToDouble(string number)
+		{
+			return (double)Int32.Parse(number.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture.NumberFormat);
+		}
 
-        /// <summary>
-        /// Converts a string like "123.456" or "0xABC" into a double.
-        /// Tries decimal conversion first.
-        /// </summary>
-        internal static double ConvertDecimalOrHexToDouble(string number)
-        {
-            if (ConversionUtilities.ValidDecimalNumber(number))
-            {
-                return ConversionUtilities.ConvertDecimalToDouble(number);
-            }
-            else if (ConversionUtilities.ValidHexNumber(number))
-            {
-                return ConversionUtilities.ConvertHexToDouble(number);
-            }
-            else
-            {
-                ErrorUtilities.VerifyThrow(false, "Cannot numeric evaluate");
-                return 0.0D;
-            }
-        }
+		/// <summary>
+		/// Converts a string like "123.456" or "0xABC" into a double.
+		/// Tries decimal conversion first.
+		/// </summary>
+		internal static double ConvertDecimalOrHexToDouble(string number)
+		{
+			if (ConversionUtilities.ValidDecimalNumber(number))
+			{
+				return ConversionUtilities.ConvertDecimalToDouble(number);
+			}
+			else if (ConversionUtilities.ValidHexNumber(number))
+			{
+				return ConversionUtilities.ConvertHexToDouble(number);
+			}
+			else
+			{
+				ErrorUtilities.VerifyThrow(false, "Cannot numeric evaluate");
+				return 0.0D;
+			}
+		}
 
-        /// <summary>
-        /// Returns true if the string is a valid hex number, like "0xABC"
-        /// </summary>
-        private static bool ValidHexNumber(string number)
-        {
-            bool canConvert = false;
-            if (number.Length >= 3 && number[0] == '0' && (number[1] == 'x' || number[1] == 'X'))
-            {
-                int value;
-                canConvert = Int32.TryParse(number.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture.NumberFormat, out value);
-            }
-            return canConvert;
-        }
+		/// <summary>
+		/// Returns true if the string is a valid hex number, like "0xABC"
+		/// </summary>
+		private static bool ValidHexNumber(string number)
+		{
+			bool canConvert = false;
+			if (number.Length >= 3 && number[0] == '0' && (number[1] == 'x' || number[1] == 'X'))
+			{
+				int value;
+				canConvert = Int32.TryParse(number.Substring(2), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture.NumberFormat, out value);
+			}
+			return canConvert;
+		}
 
-        /// <summary>
-        /// Returns true if the string is a valid decimal number, like "-123.456"
-        /// </summary>
-        private static bool ValidDecimalNumber(string number)
-        {
-            double value;
-            return Double.TryParse(number, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture.NumberFormat, out value);
-        }
+		/// <summary>
+		/// Returns true if the string is a valid decimal number, like "-123.456"
+		/// </summary>
+		private static bool ValidDecimalNumber(string number)
+		{
+			double value;
+			return Double.TryParse(number, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture.NumberFormat, out value);
+		}
 
-        /// <summary>
-        /// Returns true if the string is a valid decimal or hex number
-        /// </summary>
-        internal static bool ValidDecimalOrHexNumber(string number)
-        {
-            return ValidDecimalNumber(number) || ValidHexNumber(number);
-        }
-    }
+		/// <summary>
+		/// Returns true if the string is a valid decimal or hex number
+		/// </summary>
+		internal static bool ValidDecimalOrHexNumber(string number)
+		{
+			return ValidDecimalNumber(number) || ValidHexNumber(number);
+		}
+	}
 }

--- a/Project2015To2017.Core/Reading/Conditionals/EqualExpressionNode.cs
+++ b/Project2015To2017.Core/Reading/Conditionals/EqualExpressionNode.cs
@@ -6,36 +6,36 @@ using System.Diagnostics;
 
 namespace Project2015To2017.Reading.Conditionals
 {
-    /// <summary>
-    /// Compares for equality
-    /// </summary>
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    internal sealed class EqualExpressionNode : MultipleComparisonNode
-    {
-        /// <summary>
-        /// Compare numbers
-        /// </summary>
-        protected override bool Compare(double left, double right)
-        {
-            return left == right;
-        }
+	/// <summary>
+	/// Compares for equality
+	/// </summary>
+	[DebuggerDisplay("{DebuggerDisplay,nq}")]
+	internal sealed class EqualExpressionNode : MultipleComparisonNode
+	{
+		/// <summary>
+		/// Compare numbers
+		/// </summary>
+		protected override bool Compare(double left, double right)
+		{
+			return left == right;
+		}
 
-        /// <summary>
-        /// Compare booleans
-        /// </summary>
-        protected override bool Compare(bool left, bool right)
-        {
-            return left == right;
-        }
+		/// <summary>
+		/// Compare booleans
+		/// </summary>
+		protected override bool Compare(bool left, bool right)
+		{
+			return left == right;
+		}
 
-        /// <summary>
-        /// Compare strings
-        /// </summary>
-        protected override bool Compare(string left, string right)
-        {
-            return String.Equals(left, right, StringComparison.OrdinalIgnoreCase);
-        }
+		/// <summary>
+		/// Compare strings
+		/// </summary>
+		protected override bool Compare(string left, string right)
+		{
+			return String.Equals(left, right, StringComparison.OrdinalIgnoreCase);
+		}
 
-        internal override string DebuggerDisplay => $"(== {this.LeftChild.DebuggerDisplay} {this.RightChild.DebuggerDisplay})";
-    }
+		internal override string DebuggerDisplay => $"(== {this.LeftChild.DebuggerDisplay} {this.RightChild.DebuggerDisplay})";
+	}
 }

--- a/Project2015To2017.Core/Reading/Conditionals/ErrorUtilities.cs
+++ b/Project2015To2017.Core/Reading/Conditionals/ErrorUtilities.cs
@@ -12,707 +12,707 @@ namespace Microsoft.Build.AppxPackage.Shared
 namespace Project2015To2017.Reading.Conditionals
 #endif
 {
-    /// <summary>
-    /// This class contains methods that are useful for error checking and validation.
-    /// </summary>
-    internal static class ErrorUtilities
-    {
-        /// <summary>
-        /// Emergency escape hatch. If a customer hits a bug in the shipped product causing an internal exception,
-        /// and fortuitously it happens that ignoring the VerifyThrow allows execution to continue in a reasonable way,
-        /// then we can give them this undocumented environment variable as an immediate workaround.
-        /// </summary>
-        private static readonly bool s_throwExceptions = String.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDDONOTTHROWINTERNAL"));
+	/// <summary>
+	/// This class contains methods that are useful for error checking and validation.
+	/// </summary>
+	internal static class ErrorUtilities
+	{
+		/// <summary>
+		/// Emergency escape hatch. If a customer hits a bug in the shipped product causing an internal exception,
+		/// and fortuitously it happens that ignoring the VerifyThrow allows execution to continue in a reasonable way,
+		/// then we can give them this undocumented environment variable as an immediate workaround.
+		/// </summary>
+		private static readonly bool s_throwExceptions = String.IsNullOrEmpty(Environment.GetEnvironmentVariable("MSBUILDDONOTTHROWINTERNAL"));
 
-        #region DebugTracing
-        public static void DebugTraceMessage(string category, string formatstring, params object[] parameters)
-        {
-        }
-        #endregion
+		#region DebugTracing
+		public static void DebugTraceMessage(string category, string formatstring, params object[] parameters)
+		{
+		}
+		#endregion
 
 #if !BUILDINGAPPXTASKS
-        #region VerifyThrow -- for internal errors
+		#region VerifyThrow -- for internal errors
 
-        /// <summary>
-        /// Throws InternalErrorException. 
-        /// This is only for situations that would mean that there is a bug in MSBuild itself.
-        /// </summary>
-        internal static void ThrowInternalError(string message, params object[] args)
-        {
-            if (s_throwExceptions)
-            {
-                throw new InternalErrorException(String.Format(CultureInfo.CurrentCulture, message, args));
-            }
-        }
+		/// <summary>
+		/// Throws InternalErrorException. 
+		/// This is only for situations that would mean that there is a bug in MSBuild itself.
+		/// </summary>
+		internal static void ThrowInternalError(string message, params object[] args)
+		{
+			if (s_throwExceptions)
+			{
+				throw new InternalErrorException(String.Format(CultureInfo.CurrentCulture, message, args));
+			}
+		}
 
-        /// <summary>
-        /// Throws InternalErrorException. 
-        /// This is only for situations that would mean that there is a bug in MSBuild itself.
-        /// </summary>
-        internal static void ThrowInternalError(string message, Exception innerException, params object[] args)
-        {
-            if (s_throwExceptions)
-            {
-                throw new InternalErrorException(String.Format(CultureInfo.CurrentCulture, message, args), innerException);
-            }
-        }
+		/// <summary>
+		/// Throws InternalErrorException. 
+		/// This is only for situations that would mean that there is a bug in MSBuild itself.
+		/// </summary>
+		internal static void ThrowInternalError(string message, Exception innerException, params object[] args)
+		{
+			if (s_throwExceptions)
+			{
+				throw new InternalErrorException(String.Format(CultureInfo.CurrentCulture, message, args), innerException);
+			}
+		}
 
-        /// <summary>
-        /// Throws InternalErrorException. 
-        /// Indicates the code path followed should not have been possible.
-        /// This is only for situations that would mean that there is a bug in MSBuild itself.
-        /// </summary>
-        internal static void ThrowInternalErrorUnreachable()
-        {
-            if (s_throwExceptions)
-            {
-                throw new InternalErrorException("Unreachable?");
-            }
-        }
+		/// <summary>
+		/// Throws InternalErrorException. 
+		/// Indicates the code path followed should not have been possible.
+		/// This is only for situations that would mean that there is a bug in MSBuild itself.
+		/// </summary>
+		internal static void ThrowInternalErrorUnreachable()
+		{
+			if (s_throwExceptions)
+			{
+				throw new InternalErrorException("Unreachable?");
+			}
+		}
 
-        /// <summary>
-        /// Throws InternalErrorException. 
-        /// Indicates the code path followed should not have been possible.
-        /// This is only for situations that would mean that there is a bug in MSBuild itself.
-        /// </summary>
-        internal static void ThrowIfTypeDoesNotImplementToString(object param)
-        {
+		/// <summary>
+		/// Throws InternalErrorException. 
+		/// Indicates the code path followed should not have been possible.
+		/// This is only for situations that would mean that there is a bug in MSBuild itself.
+		/// </summary>
+		internal static void ThrowIfTypeDoesNotImplementToString(object param)
+		{
 #if DEBUG
-            // Check it has a real implementation of ToString()
-            if (String.Equals(param.GetType().ToString(), param.ToString(), StringComparison.Ordinal))
-            {
-                ErrorUtilities.ThrowInternalError("This type does not implement ToString() properly {0}", param.GetType().FullName);
-            }
+			// Check it has a real implementation of ToString()
+			if (String.Equals(param.GetType().ToString(), param.ToString(), StringComparison.Ordinal))
+			{
+				ErrorUtilities.ThrowInternalError("This type does not implement ToString() properly {0}", param.GetType().FullName);
+			}
 #endif
-        }
+		}
 
-        /// <summary>
-        /// Helper to throw an InternalErrorException when the specified parameter is null.
-        /// This should be used ONLY if this would indicate a bug in MSBuild rather than
-        /// anything caused by user action.
-        /// </summary>
-        /// <param name="parameter">The value of the argument.</param>
-        /// <param name="parameterName">Parameter that should not be null</param>
-        internal static void VerifyThrowInternalNull(object parameter, string parameterName)
-        {
-            if (parameter == null)
-            {
-                ThrowInternalError("{0} unexpectedly null", parameterName);
-            }
-        }
+		/// <summary>
+		/// Helper to throw an InternalErrorException when the specified parameter is null.
+		/// This should be used ONLY if this would indicate a bug in MSBuild rather than
+		/// anything caused by user action.
+		/// </summary>
+		/// <param name="parameter">The value of the argument.</param>
+		/// <param name="parameterName">Parameter that should not be null</param>
+		internal static void VerifyThrowInternalNull(object parameter, string parameterName)
+		{
+			if (parameter == null)
+			{
+				ThrowInternalError("{0} unexpectedly null", parameterName);
+			}
+		}
 
-        /// <summary>
-        /// Helper to throw an InternalErrorException when a lock on the specified object is not already held.
-        /// This should be used ONLY if this would indicate a bug in MSBuild rather than
-        /// anything caused by user action.
-        /// </summary>
-        /// <param name="locker">The object that should already have been used as a lock.</param>
-        internal static void VerifyThrowInternalLockHeld(object locker)
-        {
+		/// <summary>
+		/// Helper to throw an InternalErrorException when a lock on the specified object is not already held.
+		/// This should be used ONLY if this would indicate a bug in MSBuild rather than
+		/// anything caused by user action.
+		/// </summary>
+		/// <param name="locker">The object that should already have been used as a lock.</param>
+		internal static void VerifyThrowInternalLockHeld(object locker)
+		{
 #if !CLR2COMPATIBILITY
-            if (!Monitor.IsEntered(locker))
-            {
-                ThrowInternalError("Lock should already have been taken");
-            }
+			if (!Monitor.IsEntered(locker))
+			{
+				ThrowInternalError("Lock should already have been taken");
+			}
 #endif
-        }
+		}
 
-        /// <summary>
-        /// Helper to throw an InternalErrorException when the specified parameter is null or zero length.
-        /// This should be used ONLY if this would indicate a bug in MSBuild rather than
-        /// anything caused by user action.
-        /// </summary>
-        /// <param name="parameterValue">The value of the argument.</param>
-        /// <param name="parameterName">Parameter that should not be null or zero length</param>
-        internal static void VerifyThrowInternalLength(string parameterValue, string parameterName)
-        {
-            VerifyThrowInternalNull(parameterValue, parameterName);
+		/// <summary>
+		/// Helper to throw an InternalErrorException when the specified parameter is null or zero length.
+		/// This should be used ONLY if this would indicate a bug in MSBuild rather than
+		/// anything caused by user action.
+		/// </summary>
+		/// <param name="parameterValue">The value of the argument.</param>
+		/// <param name="parameterName">Parameter that should not be null or zero length</param>
+		internal static void VerifyThrowInternalLength(string parameterValue, string parameterName)
+		{
+			VerifyThrowInternalNull(parameterValue, parameterName);
 
-            if (parameterValue.Length == 0)
-            {
-                ThrowInternalError("{0} unexpectedly empty", parameterName);
-            }
-        }
+			if (parameterValue.Length == 0)
+			{
+				ThrowInternalError("{0} unexpectedly empty", parameterName);
+			}
+		}
 
-        /// <summary>
-        /// Helper to throw an InternalErrorException when the specified parameter is not a rooted path.
-        /// This should be used ONLY if this would indicate a bug in MSBuild rather than
-        /// anything caused by user action.
-        /// </summary>
-        /// <param name="value">Parameter that should be a rooted path</param>
-        internal static void VerifyThrowInternalRooted(string value)
-        {
-            if (!Path.IsPathRooted(value))
-            {
-                ThrowInternalError("{0} unexpectedly not a rooted path", value);
-            }
-        }
+		/// <summary>
+		/// Helper to throw an InternalErrorException when the specified parameter is not a rooted path.
+		/// This should be used ONLY if this would indicate a bug in MSBuild rather than
+		/// anything caused by user action.
+		/// </summary>
+		/// <param name="value">Parameter that should be a rooted path</param>
+		internal static void VerifyThrowInternalRooted(string value)
+		{
+			if (!Path.IsPathRooted(value))
+			{
+				ThrowInternalError("{0} unexpectedly not a rooted path", value);
+			}
+		}
 
-        /// <summary>
-        /// This method should be used in places where one would normally put
-        /// an "assert". It should be used to validate that our assumptions are
-        /// true, where false would indicate that there must be a bug in our
-        /// code somewhere. This should not be used to throw errors based on bad
-        /// user input or anything that the user did wrong.
-        /// </summary>
-        /// <param name="condition"></param>
-        /// <param name="unformattedMessage"></param>
-        internal static void VerifyThrow
-        (
-            bool condition,
-            string unformattedMessage
-        )
-        {
-            if (!condition)
-            {
-                // PERF NOTE: explicitly passing null for the arguments array
-                // prevents memory allocation
-                ThrowInternalError(unformattedMessage, null, null);
-            }
-        }
+		/// <summary>
+		/// This method should be used in places where one would normally put
+		/// an "assert". It should be used to validate that our assumptions are
+		/// true, where false would indicate that there must be a bug in our
+		/// code somewhere. This should not be used to throw errors based on bad
+		/// user input or anything that the user did wrong.
+		/// </summary>
+		/// <param name="condition"></param>
+		/// <param name="unformattedMessage"></param>
+		internal static void VerifyThrow
+		(
+			bool condition,
+			string unformattedMessage
+		)
+		{
+			if (!condition)
+			{
+				// PERF NOTE: explicitly passing null for the arguments array
+				// prevents memory allocation
+				ThrowInternalError(unformattedMessage, null, null);
+			}
+		}
 
-        /// <summary>
-        /// Overload for one string format argument.
-        /// </summary>
-        /// <param name="condition"></param>
-        /// <param name="unformattedMessage"></param>
-        /// <param name="arg0"></param>
-        internal static void VerifyThrow
-        (
-            bool condition,
-            string unformattedMessage,
-            object arg0
-        )
-        {
-            // PERF NOTE: check the condition here instead of pushing it into
-            // the ThrowInternalError() method, because that method always
-            // allocates memory for its variable array of arguments
-            if (!condition)
-            {
-                ThrowInternalError(unformattedMessage, arg0);
-            }
-        }
+		/// <summary>
+		/// Overload for one string format argument.
+		/// </summary>
+		/// <param name="condition"></param>
+		/// <param name="unformattedMessage"></param>
+		/// <param name="arg0"></param>
+		internal static void VerifyThrow
+		(
+			bool condition,
+			string unformattedMessage,
+			object arg0
+		)
+		{
+			// PERF NOTE: check the condition here instead of pushing it into
+			// the ThrowInternalError() method, because that method always
+			// allocates memory for its variable array of arguments
+			if (!condition)
+			{
+				ThrowInternalError(unformattedMessage, arg0);
+			}
+		}
 
-        /// <summary>
-        /// Overload for two string format arguments.
-        /// </summary>
-        /// <param name="condition"></param>
-        /// <param name="unformattedMessage"></param>
-        /// <param name="arg0"></param>
-        /// <param name="arg1"></param>
-        internal static void VerifyThrow
-        (
-            bool condition,
-            string unformattedMessage,
-            object arg0,
-            object arg1
-        )
-        {
-            // PERF NOTE: check the condition here instead of pushing it into
-            // the ThrowInternalError() method, because that method always
-            // allocates memory for its variable array of arguments
-            if (!condition)
-            {
-                ThrowInternalError(unformattedMessage, arg0, arg1);
-            }
-        }
+		/// <summary>
+		/// Overload for two string format arguments.
+		/// </summary>
+		/// <param name="condition"></param>
+		/// <param name="unformattedMessage"></param>
+		/// <param name="arg0"></param>
+		/// <param name="arg1"></param>
+		internal static void VerifyThrow
+		(
+			bool condition,
+			string unformattedMessage,
+			object arg0,
+			object arg1
+		)
+		{
+			// PERF NOTE: check the condition here instead of pushing it into
+			// the ThrowInternalError() method, because that method always
+			// allocates memory for its variable array of arguments
+			if (!condition)
+			{
+				ThrowInternalError(unformattedMessage, arg0, arg1);
+			}
+		}
 
-        /// <summary>
-        /// Overload for three string format arguments.
-        /// </summary>
-        /// <param name="condition"></param>
-        /// <param name="unformattedMessage"></param>
-        /// <param name="arg0"></param>
-        /// <param name="arg1"></param>
-        /// <param name="arg2"></param>
-        internal static void VerifyThrow
-        (
-            bool condition,
-            string unformattedMessage,
-            object arg0,
-            object arg1,
-            object arg2
-        )
-        {
-            // PERF NOTE: check the condition here instead of pushing it into
-            // the ThrowInternalError() method, because that method always
-            // allocates memory for its variable array of arguments
-            if (!condition)
-            {
-                ThrowInternalError(unformattedMessage, arg0, arg1, arg2);
-            }
-        }
+		/// <summary>
+		/// Overload for three string format arguments.
+		/// </summary>
+		/// <param name="condition"></param>
+		/// <param name="unformattedMessage"></param>
+		/// <param name="arg0"></param>
+		/// <param name="arg1"></param>
+		/// <param name="arg2"></param>
+		internal static void VerifyThrow
+		(
+			bool condition,
+			string unformattedMessage,
+			object arg0,
+			object arg1,
+			object arg2
+		)
+		{
+			// PERF NOTE: check the condition here instead of pushing it into
+			// the ThrowInternalError() method, because that method always
+			// allocates memory for its variable array of arguments
+			if (!condition)
+			{
+				ThrowInternalError(unformattedMessage, arg0, arg1, arg2);
+			}
+		}
 
-        /// <summary>
-        /// Overload for four string format arguments.
-        /// </summary>
-        /// <param name="condition"></param>
-        /// <param name="unformattedMessage"></param>
-        /// <param name="arg0"></param>
-        /// <param name="arg1"></param>
-        /// <param name="arg2"></param>
-        /// <param name="arg3"></param>
-        internal static void VerifyThrow
-        (
-            bool condition,
-            string unformattedMessage,
-            object arg0,
-            object arg1,
-            object arg2,
-            object arg3
-        )
-        {
-            // PERF NOTE: check the condition here instead of pushing it into
-            // the ThrowInternalError() method, because that method always
-            // allocates memory for its variable array of arguments
-            if (!condition)
-            {
-                ThrowInternalError(unformattedMessage, arg0, arg1, arg2, arg3);
-            }
-        }
+		/// <summary>
+		/// Overload for four string format arguments.
+		/// </summary>
+		/// <param name="condition"></param>
+		/// <param name="unformattedMessage"></param>
+		/// <param name="arg0"></param>
+		/// <param name="arg1"></param>
+		/// <param name="arg2"></param>
+		/// <param name="arg3"></param>
+		internal static void VerifyThrow
+		(
+			bool condition,
+			string unformattedMessage,
+			object arg0,
+			object arg1,
+			object arg2,
+			object arg3
+		)
+		{
+			// PERF NOTE: check the condition here instead of pushing it into
+			// the ThrowInternalError() method, because that method always
+			// allocates memory for its variable array of arguments
+			if (!condition)
+			{
+				ThrowInternalError(unformattedMessage, arg0, arg1, arg2, arg3);
+			}
+		}
 
-        #endregion
+		#endregion
 
-        #region VerifyThrowInvalidOperation
+		#region VerifyThrowInvalidOperation
 
-        /// <summary>
-        /// Throws an InvalidOperationException with the specified resource string
-        /// </summary>
-        /// <param name="resourceName">Resource to use in the exception</param>
-        /// <param name="args">Formatting args.</param>
-        internal static void ThrowInvalidOperation(string resourceName, params object[] args)
-        {
-            if (s_throwExceptions)
-            {
-                throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture, resourceName, args));
-            }
-        }
+		/// <summary>
+		/// Throws an InvalidOperationException with the specified resource string
+		/// </summary>
+		/// <param name="resourceName">Resource to use in the exception</param>
+		/// <param name="args">Formatting args.</param>
+		internal static void ThrowInvalidOperation(string resourceName, params object[] args)
+		{
+			if (s_throwExceptions)
+			{
+				throw new InvalidOperationException(String.Format(CultureInfo.CurrentCulture, resourceName, args));
+			}
+		}
 
-        /// <summary>
-        /// Throws an InvalidOperationException if the given condition is false.
-        /// </summary>
-        /// <param name="condition"></param>
-        /// <param name="resourceName"></param>
-        internal static void VerifyThrowInvalidOperation
-        (
-            bool condition,
-            string resourceName
-        )
-        {
-            if (!condition)
-            {
-                // PERF NOTE: explicitly passing null for the arguments array
-                // prevents memory allocation
-                ThrowInvalidOperation(resourceName, null);
-            }
-        }
+		/// <summary>
+		/// Throws an InvalidOperationException if the given condition is false.
+		/// </summary>
+		/// <param name="condition"></param>
+		/// <param name="resourceName"></param>
+		internal static void VerifyThrowInvalidOperation
+		(
+			bool condition,
+			string resourceName
+		)
+		{
+			if (!condition)
+			{
+				// PERF NOTE: explicitly passing null for the arguments array
+				// prevents memory allocation
+				ThrowInvalidOperation(resourceName, null);
+			}
+		}
 
-        /// <summary>
-        /// Overload for one string format argument.
-        /// </summary>
-        /// <param name="condition"></param>
-        /// <param name="resourceName"></param>
-        /// <param name="arg0"></param>
-        internal static void VerifyThrowInvalidOperation
-        (
-            bool condition,
-            string resourceName,
-            object arg0
-        )
-        {
-            // PERF NOTE: check the condition here instead of pushing it into
-            // the ThrowInvalidOperation() method, because that method always
-            // allocates memory for its variable array of arguments
-            if (!condition)
-            {
-                ThrowInvalidOperation(resourceName, arg0);
-            }
-        }
+		/// <summary>
+		/// Overload for one string format argument.
+		/// </summary>
+		/// <param name="condition"></param>
+		/// <param name="resourceName"></param>
+		/// <param name="arg0"></param>
+		internal static void VerifyThrowInvalidOperation
+		(
+			bool condition,
+			string resourceName,
+			object arg0
+		)
+		{
+			// PERF NOTE: check the condition here instead of pushing it into
+			// the ThrowInvalidOperation() method, because that method always
+			// allocates memory for its variable array of arguments
+			if (!condition)
+			{
+				ThrowInvalidOperation(resourceName, arg0);
+			}
+		}
 
-        /// <summary>
-        /// Overload for two string format arguments.
-        /// </summary>
-        /// <param name="condition"></param>
-        /// <param name="resourceName"></param>
-        /// <param name="arg0"></param>
-        /// <param name="arg1"></param>
-        internal static void VerifyThrowInvalidOperation
-        (
-            bool condition,
-            string resourceName,
-            object arg0,
-            object arg1
-        )
-        {
-            // PERF NOTE: check the condition here instead of pushing it into
-            // the ThrowInvalidOperation() method, because that method always
-            // allocates memory for its variable array of arguments
-            if (!condition)
-            {
-                ThrowInvalidOperation(resourceName, arg0, arg1);
-            }
-        }
+		/// <summary>
+		/// Overload for two string format arguments.
+		/// </summary>
+		/// <param name="condition"></param>
+		/// <param name="resourceName"></param>
+		/// <param name="arg0"></param>
+		/// <param name="arg1"></param>
+		internal static void VerifyThrowInvalidOperation
+		(
+			bool condition,
+			string resourceName,
+			object arg0,
+			object arg1
+		)
+		{
+			// PERF NOTE: check the condition here instead of pushing it into
+			// the ThrowInvalidOperation() method, because that method always
+			// allocates memory for its variable array of arguments
+			if (!condition)
+			{
+				ThrowInvalidOperation(resourceName, arg0, arg1);
+			}
+		}
 
-        /// <summary>
-        /// Overload for three string format arguments.
-        /// </summary>
-        /// <param name="condition"></param>
-        /// <param name="resourceName"></param>
-        /// <param name="arg0"></param>
-        /// <param name="arg1"></param>
-        /// <param name="arg2"></param>
-        internal static void VerifyThrowInvalidOperation
-        (
-            bool condition,
-            string resourceName,
-            object arg0,
-            object arg1,
-            object arg2
-        )
-        {
-            // PERF NOTE: check the condition here instead of pushing it into
-            // the ThrowInvalidOperation() method, because that method always
-            // allocates memory for its variable array of arguments
-            if (!condition)
-            {
-                ThrowInvalidOperation(resourceName, arg0, arg1, arg2);
-            }
-        }
+		/// <summary>
+		/// Overload for three string format arguments.
+		/// </summary>
+		/// <param name="condition"></param>
+		/// <param name="resourceName"></param>
+		/// <param name="arg0"></param>
+		/// <param name="arg1"></param>
+		/// <param name="arg2"></param>
+		internal static void VerifyThrowInvalidOperation
+		(
+			bool condition,
+			string resourceName,
+			object arg0,
+			object arg1,
+			object arg2
+		)
+		{
+			// PERF NOTE: check the condition here instead of pushing it into
+			// the ThrowInvalidOperation() method, because that method always
+			// allocates memory for its variable array of arguments
+			if (!condition)
+			{
+				ThrowInvalidOperation(resourceName, arg0, arg1, arg2);
+			}
+		}
 
-        /// <summary>
-        /// Overload for four string format arguments.
-        /// </summary>
-        /// <param name="condition"></param>
-        /// <param name="resourceName"></param>
-        /// <param name="arg0"></param>
-        /// <param name="arg1"></param>
-        /// <param name="arg2"></param>
-        /// <param name="arg3"></param>
-        internal static void VerifyThrowInvalidOperation
-        (
-            bool condition,
-            string resourceName,
-            object arg0,
-            object arg1,
-            object arg2,
-            object arg3
-        )
-        {
-            // PERF NOTE: check the condition here instead of pushing it into
-            // the ThrowInvalidOperation() method, because that method always
-            // allocates memory for its variable array of arguments
-            if (!condition)
-            {
-                ThrowInvalidOperation(resourceName, arg0, arg1, arg2, arg3);
-            }
-        }
+		/// <summary>
+		/// Overload for four string format arguments.
+		/// </summary>
+		/// <param name="condition"></param>
+		/// <param name="resourceName"></param>
+		/// <param name="arg0"></param>
+		/// <param name="arg1"></param>
+		/// <param name="arg2"></param>
+		/// <param name="arg3"></param>
+		internal static void VerifyThrowInvalidOperation
+		(
+			bool condition,
+			string resourceName,
+			object arg0,
+			object arg1,
+			object arg2,
+			object arg3
+		)
+		{
+			// PERF NOTE: check the condition here instead of pushing it into
+			// the ThrowInvalidOperation() method, because that method always
+			// allocates memory for its variable array of arguments
+			if (!condition)
+			{
+				ThrowInvalidOperation(resourceName, arg0, arg1, arg2, arg3);
+			}
+		}
 
-        #endregion
+		#endregion
 
-        #region VerifyThrowArgument
+		#region VerifyThrowArgument
 
-        /// <summary>
-        /// Throws an ArgumentException that can include an inner exception.
-        /// 
-        /// PERF WARNING: calling a method that takes a variable number of arguments
-        /// is expensive, because memory is allocated for the array of arguments -- do
-        /// not call this method repeatedly in performance-critical scenarios
-        /// </summary>
-        internal static void ThrowArgument
-        (
-            string resourceName,
-            params object[] args
-        )
-        {
-            ThrowArgument(null, resourceName, args);
-        }
+		/// <summary>
+		/// Throws an ArgumentException that can include an inner exception.
+		/// 
+		/// PERF WARNING: calling a method that takes a variable number of arguments
+		/// is expensive, because memory is allocated for the array of arguments -- do
+		/// not call this method repeatedly in performance-critical scenarios
+		/// </summary>
+		internal static void ThrowArgument
+		(
+			string resourceName,
+			params object[] args
+		)
+		{
+			ThrowArgument(null, resourceName, args);
+		}
 
-        /// <summary>
-        /// Throws an ArgumentException that can include an inner exception.
-        /// 
-        /// PERF WARNING: calling a method that takes a variable number of arguments
-        /// is expensive, because memory is allocated for the array of arguments -- do
-        /// not call this method repeatedly in performance-critical scenarios
-        /// </summary>
-        /// <remarks>
-        /// This method is thread-safe.
-        /// </remarks>
-        /// <param name="innerException">Can be null.</param>
-        /// <param name="resourceName"></param>
-        /// <param name="args"></param>
-        private static void ThrowArgument
-        (
-            Exception innerException,
-            string resourceName,
-            params object[] args
-        )
-        {
-            if (s_throwExceptions)
-            {
-                throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, resourceName, args), innerException);
-            }
-        }
+		/// <summary>
+		/// Throws an ArgumentException that can include an inner exception.
+		/// 
+		/// PERF WARNING: calling a method that takes a variable number of arguments
+		/// is expensive, because memory is allocated for the array of arguments -- do
+		/// not call this method repeatedly in performance-critical scenarios
+		/// </summary>
+		/// <remarks>
+		/// This method is thread-safe.
+		/// </remarks>
+		/// <param name="innerException">Can be null.</param>
+		/// <param name="resourceName"></param>
+		/// <param name="args"></param>
+		private static void ThrowArgument
+		(
+			Exception innerException,
+			string resourceName,
+			params object[] args
+		)
+		{
+			if (s_throwExceptions)
+			{
+				throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, resourceName, args), innerException);
+			}
+		}
 
-        /// <summary>
-        /// Throws an ArgumentException if the given condition is false.
-        /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
-        /// <param name="condition"></param>
-        /// <param name="resourceName"></param>
-        internal static void VerifyThrowArgument
-        (
-            bool condition,
-            string resourceName
-        )
-        {
-            VerifyThrowArgument(condition, null, resourceName);
-        }
+		/// <summary>
+		/// Throws an ArgumentException if the given condition is false.
+		/// </summary>
+		/// <remarks>This method is thread-safe.</remarks>
+		/// <param name="condition"></param>
+		/// <param name="resourceName"></param>
+		internal static void VerifyThrowArgument
+		(
+			bool condition,
+			string resourceName
+		)
+		{
+			VerifyThrowArgument(condition, null, resourceName);
+		}
 
-        /// <summary>
-        /// Overload for one string format argument.
-        /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
-        /// <param name="condition"></param>
-        /// <param name="resourceName"></param>
-        /// <param name="arg0"></param>
-        internal static void VerifyThrowArgument
-        (
-            bool condition,
-            string resourceName,
-            object arg0
-        )
-        {
-            VerifyThrowArgument(condition, null, resourceName, arg0);
-        }
+		/// <summary>
+		/// Overload for one string format argument.
+		/// </summary>
+		/// <remarks>This method is thread-safe.</remarks>
+		/// <param name="condition"></param>
+		/// <param name="resourceName"></param>
+		/// <param name="arg0"></param>
+		internal static void VerifyThrowArgument
+		(
+			bool condition,
+			string resourceName,
+			object arg0
+		)
+		{
+			VerifyThrowArgument(condition, null, resourceName, arg0);
+		}
 
-        /// <summary>
-        /// Overload for two string format arguments.
-        /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
-        /// <param name="condition"></param>
-        /// <param name="resourceName"></param>
-        /// <param name="arg0"></param>
-        /// <param name="arg1"></param>
-        internal static void VerifyThrowArgument
-        (
-            bool condition,
-            string resourceName,
-            object arg0,
-            object arg1
-        )
-        {
-            VerifyThrowArgument(condition, null, resourceName, arg0, arg1);
-        }
+		/// <summary>
+		/// Overload for two string format arguments.
+		/// </summary>
+		/// <remarks>This method is thread-safe.</remarks>
+		/// <param name="condition"></param>
+		/// <param name="resourceName"></param>
+		/// <param name="arg0"></param>
+		/// <param name="arg1"></param>
+		internal static void VerifyThrowArgument
+		(
+			bool condition,
+			string resourceName,
+			object arg0,
+			object arg1
+		)
+		{
+			VerifyThrowArgument(condition, null, resourceName, arg0, arg1);
+		}
 
-        /// <summary>
-        /// Overload for three string format arguments.
-        /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
-        internal static void VerifyThrowArgument
-        (
-            bool condition,
-            string resourceName,
-            object arg0,
-            object arg1,
-            object arg2
-        )
-        {
-            VerifyThrowArgument(condition, null, resourceName, arg0, arg1, arg2);
-        }
+		/// <summary>
+		/// Overload for three string format arguments.
+		/// </summary>
+		/// <remarks>This method is thread-safe.</remarks>
+		internal static void VerifyThrowArgument
+		(
+			bool condition,
+			string resourceName,
+			object arg0,
+			object arg1,
+			object arg2
+		)
+		{
+			VerifyThrowArgument(condition, null, resourceName, arg0, arg1, arg2);
+		}
 
-        /// <summary>
-        /// Overload for four string format arguments.
-        /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
-        internal static void VerifyThrowArgument
-        (
-            bool condition,
-            string resourceName,
-            object arg0,
-            object arg1,
-            object arg2,
-            object arg3
-        )
-        {
-            VerifyThrowArgument(condition, null, resourceName, arg0, arg1, arg2, arg3);
-        }
+		/// <summary>
+		/// Overload for four string format arguments.
+		/// </summary>
+		/// <remarks>This method is thread-safe.</remarks>
+		internal static void VerifyThrowArgument
+		(
+			bool condition,
+			string resourceName,
+			object arg0,
+			object arg1,
+			object arg2,
+			object arg3
+		)
+		{
+			VerifyThrowArgument(condition, null, resourceName, arg0, arg1, arg2, arg3);
+		}
 
-        /// <summary>
-        /// Throws an ArgumentException that includes an inner exception, if
-        /// the given condition is false.
-        /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
-        /// <param name="condition"></param>
-        /// <param name="innerException">Can be null.</param>
-        /// <param name="resourceName"></param>
-        internal static void VerifyThrowArgument
-        (
-            bool condition,
-            Exception innerException,
-            string resourceName
-        )
-        {
-            if (!condition)
-            {
-                // PERF NOTE: explicitly passing null for the arguments array
-                // prevents memory allocation
-                ThrowArgument(innerException, resourceName, null);
-            }
-        }
+		/// <summary>
+		/// Throws an ArgumentException that includes an inner exception, if
+		/// the given condition is false.
+		/// </summary>
+		/// <remarks>This method is thread-safe.</remarks>
+		/// <param name="condition"></param>
+		/// <param name="innerException">Can be null.</param>
+		/// <param name="resourceName"></param>
+		internal static void VerifyThrowArgument
+		(
+			bool condition,
+			Exception innerException,
+			string resourceName
+		)
+		{
+			if (!condition)
+			{
+				// PERF NOTE: explicitly passing null for the arguments array
+				// prevents memory allocation
+				ThrowArgument(innerException, resourceName, null);
+			}
+		}
 
-        /// <summary>
-        /// Overload for one string format argument.
-        /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
-        /// <param name="condition"></param>
-        /// <param name="innerException"></param>
-        /// <param name="resourceName"></param>
-        /// <param name="arg0"></param>
-        internal static void VerifyThrowArgument
-        (
-            bool condition,
-            Exception innerException,
-            string resourceName,
-            object arg0
-        )
-        {
-            // PERF NOTE: check the condition here instead of pushing it into
-            // the ThrowArgument() method, because that method always allocates
-            // memory for its variable array of arguments
-            if (!condition)
-            {
-                ThrowArgument(innerException, resourceName, arg0);
-            }
-        }
+		/// <summary>
+		/// Overload for one string format argument.
+		/// </summary>
+		/// <remarks>This method is thread-safe.</remarks>
+		/// <param name="condition"></param>
+		/// <param name="innerException"></param>
+		/// <param name="resourceName"></param>
+		/// <param name="arg0"></param>
+		internal static void VerifyThrowArgument
+		(
+			bool condition,
+			Exception innerException,
+			string resourceName,
+			object arg0
+		)
+		{
+			// PERF NOTE: check the condition here instead of pushing it into
+			// the ThrowArgument() method, because that method always allocates
+			// memory for its variable array of arguments
+			if (!condition)
+			{
+				ThrowArgument(innerException, resourceName, arg0);
+			}
+		}
 
-        /// <summary>
-        /// Overload for two string format arguments.
-        /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
-        /// <param name="condition"></param>
-        /// <param name="innerException"></param>
-        /// <param name="resourceName"></param>
-        /// <param name="arg0"></param>
-        /// <param name="arg1"></param>
-        internal static void VerifyThrowArgument
-        (
-            bool condition,
-            Exception innerException,
-            string resourceName,
-            object arg0,
-            object arg1
-        )
-        {
-            // PERF NOTE: check the condition here instead of pushing it into
-            // the ThrowArgument() method, because that method always allocates
-            // memory for its variable array of arguments
-            if (!condition)
-            {
-                ThrowArgument(innerException, resourceName, arg0, arg1);
-            }
-        }
+		/// <summary>
+		/// Overload for two string format arguments.
+		/// </summary>
+		/// <remarks>This method is thread-safe.</remarks>
+		/// <param name="condition"></param>
+		/// <param name="innerException"></param>
+		/// <param name="resourceName"></param>
+		/// <param name="arg0"></param>
+		/// <param name="arg1"></param>
+		internal static void VerifyThrowArgument
+		(
+			bool condition,
+			Exception innerException,
+			string resourceName,
+			object arg0,
+			object arg1
+		)
+		{
+			// PERF NOTE: check the condition here instead of pushing it into
+			// the ThrowArgument() method, because that method always allocates
+			// memory for its variable array of arguments
+			if (!condition)
+			{
+				ThrowArgument(innerException, resourceName, arg0, arg1);
+			}
+		}
 
-        /// <summary>
-        /// Overload for three string format arguments.
-        /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
-        internal static void VerifyThrowArgument
-        (
-            bool condition,
-            Exception innerException,
-            string resourceName,
-            object arg0,
-            object arg1,
-            object arg2
-        )
-        {
-            // PERF NOTE: check the condition here instead of pushing it into
-            // the ThrowArgument() method, because that method always allocates
-            // memory for its variable array of arguments
-            if (!condition)
-            {
-                ThrowArgument(innerException, resourceName, arg0, arg1, arg2);
-            }
-        }
+		/// <summary>
+		/// Overload for three string format arguments.
+		/// </summary>
+		/// <remarks>This method is thread-safe.</remarks>
+		internal static void VerifyThrowArgument
+		(
+			bool condition,
+			Exception innerException,
+			string resourceName,
+			object arg0,
+			object arg1,
+			object arg2
+		)
+		{
+			// PERF NOTE: check the condition here instead of pushing it into
+			// the ThrowArgument() method, because that method always allocates
+			// memory for its variable array of arguments
+			if (!condition)
+			{
+				ThrowArgument(innerException, resourceName, arg0, arg1, arg2);
+			}
+		}
 
-        /// <summary>
-        /// Overload for four string format arguments.
-        /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
-        internal static void VerifyThrowArgument
-        (
-            bool condition,
-            Exception innerException,
-            string resourceName,
-            object arg0,
-            object arg1,
-            object arg2,
-            object arg3
-        )
-        {
-            // PERF NOTE: check the condition here instead of pushing it into
-            // the ThrowArgument() method, because that method always allocates
-            // memory for its variable array of arguments
-            if (!condition)
-            {
-                ThrowArgument(innerException, resourceName, arg0, arg1, arg2, arg3);
-            }
-        }
+		/// <summary>
+		/// Overload for four string format arguments.
+		/// </summary>
+		/// <remarks>This method is thread-safe.</remarks>
+		internal static void VerifyThrowArgument
+		(
+			bool condition,
+			Exception innerException,
+			string resourceName,
+			object arg0,
+			object arg1,
+			object arg2,
+			object arg3
+		)
+		{
+			// PERF NOTE: check the condition here instead of pushing it into
+			// the ThrowArgument() method, because that method always allocates
+			// memory for its variable array of arguments
+			if (!condition)
+			{
+				ThrowArgument(innerException, resourceName, arg0, arg1, arg2, arg3);
+			}
+		}
 
-        #endregion
+		#endregion
 
-        #region VerifyThrowArgumentXXX
+		#region VerifyThrowArgumentXXX
 
-        /// <summary>
-        /// Throws an argument out of range exception.
-        /// </summary>
-        internal static void ThrowArgumentOutOfRange(string parameterName)
-        {
-            if (s_throwExceptions)
-            {
-                throw new ArgumentOutOfRangeException(parameterName);
-            }
-        }
+		/// <summary>
+		/// Throws an argument out of range exception.
+		/// </summary>
+		internal static void ThrowArgumentOutOfRange(string parameterName)
+		{
+			if (s_throwExceptions)
+			{
+				throw new ArgumentOutOfRangeException(parameterName);
+			}
+		}
 
-        /// <summary>
-        /// Throws an ArgumentOutOfRangeException using the given parameter name
-        /// if the condition is false.
-        /// </summary>
-        internal static void VerifyThrowArgumentOutOfRange(bool condition, string parameterName)
-        {
-            if (!condition)
-            {
-                ThrowArgumentOutOfRange(parameterName);
-            }
-        }
+		/// <summary>
+		/// Throws an ArgumentOutOfRangeException using the given parameter name
+		/// if the condition is false.
+		/// </summary>
+		internal static void VerifyThrowArgumentOutOfRange(bool condition, string parameterName)
+		{
+			if (!condition)
+			{
+				ThrowArgumentOutOfRange(parameterName);
+			}
+		}
 
-        /// <summary>
-        /// Throws an ArgumentNullException if the given parameter is null.
-        /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
-        /// <param name="parameter"></param>
-        /// <param name="parameterName"></param>
-        internal static void VerifyThrowArgumentNull(object parameter, string parameterName)
-        {
-            VerifyThrowArgumentNull(parameter, parameterName, "Shared.ParameterCannotBeNull");
-        }
+		/// <summary>
+		/// Throws an ArgumentNullException if the given parameter is null.
+		/// </summary>
+		/// <remarks>This method is thread-safe.</remarks>
+		/// <param name="parameter"></param>
+		/// <param name="parameterName"></param>
+		internal static void VerifyThrowArgumentNull(object parameter, string parameterName)
+		{
+			VerifyThrowArgumentNull(parameter, parameterName, "Shared.ParameterCannotBeNull");
+		}
 
-        /// <summary>
-        /// Throws an ArgumentNullException if the given parameter is null.
-        /// </summary>
-        /// <remarks>This method is thread-safe.</remarks>
-        internal static void VerifyThrowArgumentNull(object parameter, string parameterName, string resourceName)
-        {
-            if (parameter == null && s_throwExceptions)
-            {
-                // Most ArgumentNullException overloads append its own rather clunky multi-line message. 
-                // So use the one overload that doesn't.
-                throw new ArgumentNullException(
-	                String.Format(CultureInfo.CurrentCulture, resourceName, parameterName),
-                    (Exception)null);
-            }
-        }
-        #endregion
+		/// <summary>
+		/// Throws an ArgumentNullException if the given parameter is null.
+		/// </summary>
+		/// <remarks>This method is thread-safe.</remarks>
+		internal static void VerifyThrowArgumentNull(object parameter, string parameterName, string resourceName)
+		{
+			if (parameter == null && s_throwExceptions)
+			{
+				// Most ArgumentNullException overloads append its own rather clunky multi-line message. 
+				// So use the one overload that doesn't.
+				throw new ArgumentNullException(
+					String.Format(CultureInfo.CurrentCulture, resourceName, parameterName),
+					(Exception)null);
+			}
+		}
+		#endregion
 #endif
-    }
+	}
 }

--- a/Project2015To2017.Core/Reading/Conditionals/FunctionCallExpressionNode.cs
+++ b/Project2015To2017.Core/Reading/Conditionals/FunctionCallExpressionNode.cs
@@ -6,39 +6,39 @@ using System.Collections.Generic;
 
 namespace Project2015To2017.Reading.Conditionals
 {
-    /// <summary>
-    /// Evaluates a function expression, such as "Exists('foo')"
-    /// </summary>
-    internal sealed class FunctionCallExpressionNode : OperatorExpressionNode
-    {
-        private readonly List<GenericExpressionNode> _arguments;
-        public readonly string _functionName;
+	/// <summary>
+	/// Evaluates a function expression, such as "Exists('foo')"
+	/// </summary>
+	internal sealed class FunctionCallExpressionNode : OperatorExpressionNode
+	{
+		private readonly List<GenericExpressionNode> _arguments;
+		public readonly string _functionName;
 
-        internal FunctionCallExpressionNode(string functionName, List<GenericExpressionNode> arguments)
-        {
+		internal FunctionCallExpressionNode(string functionName, List<GenericExpressionNode> arguments)
+		{
 			this._functionName = functionName;
 			this._arguments = arguments;
-        }
+		}
 
-        /// <summary>
-        /// Evaluate node as boolean
-        /// </summary>
-        internal override bool BoolEvaluate(IConditionEvaluationState state)
-        {
-	        if (String.Compare(this._functionName, "exists", StringComparison.OrdinalIgnoreCase) == 0)
-            {
-                return true;
-            }
+		/// <summary>
+		/// Evaluate node as boolean
+		/// </summary>
+		internal override bool BoolEvaluate(IConditionEvaluationState state)
+		{
+			if (String.Compare(this._functionName, "exists", StringComparison.OrdinalIgnoreCase) == 0)
+			{
+				return true;
+			}
 
-	        if (String.Compare(this._functionName, "HasTrailingSlash", StringComparison.OrdinalIgnoreCase) == 0)
-	        {
-		        // often used to append slash to path so return false to enable this codepath
-		        return false;
-	        }
+			if (String.Compare(this._functionName, "HasTrailingSlash", StringComparison.OrdinalIgnoreCase) == 0)
+			{
+				// often used to append slash to path so return false to enable this codepath
+				return false;
+			}
 
-	        // We haven't implemented any other "functions"
+			// We haven't implemented any other "functions"
 
-	        return false;
-        }
-    }
+			return false;
+		}
+	}
 }

--- a/Project2015To2017.Core/Reading/Conditionals/GenericExpressionNode.cs
+++ b/Project2015To2017.Core/Reading/Conditionals/GenericExpressionNode.cs
@@ -9,76 +9,76 @@ namespace Project2015To2017.Reading.Conditionals
 	/// Base class for all expression nodes.
 	/// </summary>
 	public abstract class GenericExpressionNode
-    {
-        internal abstract bool CanBoolEvaluate(IConditionEvaluationState state);
-        internal abstract bool CanNumericEvaluate(IConditionEvaluationState state);
-        internal abstract bool CanVersionEvaluate(IConditionEvaluationState state);
-        internal abstract bool BoolEvaluate(IConditionEvaluationState state);
-        internal abstract double NumericEvaluate(IConditionEvaluationState state);
-        internal abstract Version VersionEvaluate(IConditionEvaluationState state);
+	{
+		internal abstract bool CanBoolEvaluate(IConditionEvaluationState state);
+		internal abstract bool CanNumericEvaluate(IConditionEvaluationState state);
+		internal abstract bool CanVersionEvaluate(IConditionEvaluationState state);
+		internal abstract bool BoolEvaluate(IConditionEvaluationState state);
+		internal abstract double NumericEvaluate(IConditionEvaluationState state);
+		internal abstract Version VersionEvaluate(IConditionEvaluationState state);
 
-        /// <summary>
-        /// Returns true if this node evaluates to an empty string,
-        /// otherwise false.
-        /// (It may be cheaper to determine whether an expression will evaluate
-        /// to empty than to fully evaluate it.)
-        /// Implementations should cache the result so that calls after the first are free.
-        /// </summary>
-        internal virtual bool EvaluatesToEmpty(IConditionEvaluationState state)
-        {
-            return false;
-        }
+		/// <summary>
+		/// Returns true if this node evaluates to an empty string,
+		/// otherwise false.
+		/// (It may be cheaper to determine whether an expression will evaluate
+		/// to empty than to fully evaluate it.)
+		/// Implementations should cache the result so that calls after the first are free.
+		/// </summary>
+		internal virtual bool EvaluatesToEmpty(IConditionEvaluationState state)
+		{
+			return false;
+		}
 
-        /// <summary>
-        /// Value after any item and property expressions are expanded
-        /// </summary>
-        /// <returns></returns>
-        internal abstract string GetExpandedValue(IConditionEvaluationState state);
+		/// <summary>
+		/// Value after any item and property expressions are expanded
+		/// </summary>
+		/// <returns></returns>
+		internal abstract string GetExpandedValue(IConditionEvaluationState state);
 
-        /// <summary>
-        /// Value before any item and property expressions are expanded
-        /// </summary>
-        /// <returns></returns>
-        internal abstract string GetUnexpandedValue(IConditionEvaluationState state);
+		/// <summary>
+		/// Value before any item and property expressions are expanded
+		/// </summary>
+		/// <returns></returns>
+		internal abstract string GetUnexpandedValue(IConditionEvaluationState state);
 
-        /// <summary>
-        /// If any expression nodes cache any state for the duration of evaluation, 
-        /// now's the time to clean it up
-        /// </summary>
-        internal abstract void ResetState();
+		/// <summary>
+		/// If any expression nodes cache any state for the duration of evaluation, 
+		/// now's the time to clean it up
+		/// </summary>
+		internal abstract void ResetState();
 
-        /// <summary>
-        /// The main evaluate entry point for expression trees
-        /// </summary>
-        /// <param name="state"></param>
-        /// <returns></returns>
-        internal bool Evaluate(IConditionEvaluationState state)
-        {
-            return BoolEvaluate(state);
-        }
+		/// <summary>
+		/// The main evaluate entry point for expression trees
+		/// </summary>
+		/// <param name="state"></param>
+		/// <returns></returns>
+		internal bool Evaluate(IConditionEvaluationState state)
+		{
+			return BoolEvaluate(state);
+		}
 
-        /// <summary>
-        /// Get display string for this node for use in the debugger.
-        /// </summary>
-        internal virtual string DebuggerDisplay { get; }
+		/// <summary>
+		/// Get display string for this node for use in the debugger.
+		/// </summary>
+		internal virtual string DebuggerDisplay { get; }
 
 
-        #region REMOVE_COMPAT_WARNING
-        internal virtual bool PossibleAndCollision
-        {
-            set { /* do nothing */ }
-            get { return false; }
-        }
+		#region REMOVE_COMPAT_WARNING
+		internal virtual bool PossibleAndCollision
+		{
+			set { /* do nothing */ }
+			get { return false; }
+		}
 
-        internal virtual bool PossibleOrCollision
-        {
-            set { /* do nothing */ }
-            get { return false; }
-        }
+		internal virtual bool PossibleOrCollision
+		{
+			set { /* do nothing */ }
+			get { return false; }
+		}
 
-        internal abstract bool DetectOr();
-        internal abstract bool DetectAnd();
-        #endregion
+		internal abstract bool DetectOr();
+		internal abstract bool DetectAnd();
+		#endregion
 
-    }
+	}
 }

--- a/Project2015To2017.Core/Reading/Conditionals/GreaterThanExpressionNode.cs
+++ b/Project2015To2017.Core/Reading/Conditionals/GreaterThanExpressionNode.cs
@@ -6,59 +6,59 @@ using System.Diagnostics;
 
 namespace Project2015To2017.Reading.Conditionals
 {
-    /// <summary>
-    /// Compares for left > right
-    /// </summary>
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    internal sealed class GreaterThanExpressionNode : NumericComparisonExpressionNode
-    {
-        /// <summary>
-        /// Compare numerically
-        /// </summary>
-        protected override bool Compare(double left, double right)
-        {
-            return left > right;
-        }
+	/// <summary>
+	/// Compares for left > right
+	/// </summary>
+	[DebuggerDisplay("{DebuggerDisplay,nq}")]
+	internal sealed class GreaterThanExpressionNode : NumericComparisonExpressionNode
+	{
+		/// <summary>
+		/// Compare numerically
+		/// </summary>
+		protected override bool Compare(double left, double right)
+		{
+			return left > right;
+		}
 
-        /// <summary>
-        /// Compare Versions. This is only intended to compare version formats like "A.B.C.D" which can otherwise not be compared numerically
-        /// </summary>
-        /// <returns></returns>
-        protected override bool Compare(Version left, Version right)
-        {
-            return left > right;
-        }
+		/// <summary>
+		/// Compare Versions. This is only intended to compare version formats like "A.B.C.D" which can otherwise not be compared numerically
+		/// </summary>
+		/// <returns></returns>
+		protected override bool Compare(Version left, Version right)
+		{
+			return left > right;
+		}
 
-        /// <summary>
-        /// Compare mixed numbers and Versions
-        /// </summary>
-        protected override bool Compare(Version left, double right)
-        {
-            if (left.Major != right)
-            {
-                return left.Major > right;
-            }
+		/// <summary>
+		/// Compare mixed numbers and Versions
+		/// </summary>
+		protected override bool Compare(Version left, double right)
+		{
+			if (left.Major != right)
+			{
+				return left.Major > right;
+			}
 
-            // If they have same "major" number, then that means we are comparing something like "6.X.Y.Z" to "6". Version treats the objects with more dots as
-            // "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
-            return true;
-        }
+			// If they have same "major" number, then that means we are comparing something like "6.X.Y.Z" to "6". Version treats the objects with more dots as
+			// "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
+			return true;
+		}
 
-        /// <summary>
-        /// Compare mixed numbers and Versions
-        /// </summary>
-        protected override bool Compare(double left, Version right)
-        {
-            if (right.Major != left)
-            {
-                return left > right.Major;
-            }
+		/// <summary>
+		/// Compare mixed numbers and Versions
+		/// </summary>
+		protected override bool Compare(double left, Version right)
+		{
+			if (right.Major != left)
+			{
+				return left > right.Major;
+			}
 
-            // If they have same "major" number, then that means we are comparing something like "6.X.Y.Z" to "6". Version treats the objects with more dots as
-            // "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
-            return false;
-        }
+			// If they have same "major" number, then that means we are comparing something like "6.X.Y.Z" to "6". Version treats the objects with more dots as
+			// "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
+			return false;
+		}
 
-        internal override string DebuggerDisplay => $"(> {this.LeftChild.DebuggerDisplay} {this.RightChild.DebuggerDisplay})";
-    }
+		internal override string DebuggerDisplay => $"(> {this.LeftChild.DebuggerDisplay} {this.RightChild.DebuggerDisplay})";
+	}
 }

--- a/Project2015To2017.Core/Reading/Conditionals/GreaterThanOrEqualExpressionNode.cs
+++ b/Project2015To2017.Core/Reading/Conditionals/GreaterThanOrEqualExpressionNode.cs
@@ -6,59 +6,59 @@ using System.Diagnostics;
 
 namespace Project2015To2017.Reading.Conditionals
 {
-    /// <summary>
-    /// Compares for left >= right
-    /// </summary>
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    internal sealed class GreaterThanOrEqualExpressionNode : NumericComparisonExpressionNode
-    {
-        /// <summary>
-        /// Compare numerically
-        /// </summary>
-        protected override bool Compare(double left, double right)
-        {
-            return left >= right;
-        }
+	/// <summary>
+	/// Compares for left >= right
+	/// </summary>
+	[DebuggerDisplay("{DebuggerDisplay,nq}")]
+	internal sealed class GreaterThanOrEqualExpressionNode : NumericComparisonExpressionNode
+	{
+		/// <summary>
+		/// Compare numerically
+		/// </summary>
+		protected override bool Compare(double left, double right)
+		{
+			return left >= right;
+		}
 
-        /// <summary>
-        /// Compare Versions. This is only intended to compare version formats like "A.B.C.D" which can otherwise not be compared numerically
-        /// </summary>
-        /// <returns></returns>
-        protected override bool Compare(Version left, Version right)
-        {
-            return left >= right;
-        }
+		/// <summary>
+		/// Compare Versions. This is only intended to compare version formats like "A.B.C.D" which can otherwise not be compared numerically
+		/// </summary>
+		/// <returns></returns>
+		protected override bool Compare(Version left, Version right)
+		{
+			return left >= right;
+		}
 
-        /// <summary>
-        /// Compare mixed numbers and Versions
-        /// </summary>
-        protected override bool Compare(Version left, double right)
-        {
-            if (left.Major != right)
-            {
-                return left.Major >= right;
-            }
+		/// <summary>
+		/// Compare mixed numbers and Versions
+		/// </summary>
+		protected override bool Compare(Version left, double right)
+		{
+			if (left.Major != right)
+			{
+				return left.Major >= right;
+			}
 
-            // If they have same "major" number, then that means we are comparing something like "6.X.Y.Z" to "6". Version treats the objects with more dots as
-            // "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
-            return true;
-        }
+			// If they have same "major" number, then that means we are comparing something like "6.X.Y.Z" to "6". Version treats the objects with more dots as
+			// "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
+			return true;
+		}
 
-        /// <summary>
-        /// Compare mixed numbers and Versions
-        /// </summary>
-        protected override bool Compare(double left, Version right)
-        {
-            if (right.Major != left)
-            {
-                return left >= right.Major;
-            }
+		/// <summary>
+		/// Compare mixed numbers and Versions
+		/// </summary>
+		protected override bool Compare(double left, Version right)
+		{
+			if (right.Major != left)
+			{
+				return left >= right.Major;
+			}
 
-            // If they have same "major" number, then that means we are comparing something like "6.X.Y.Z" to "6". Version treats the objects with more dots as
-            // "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
-            return false;
-        }
+			// If they have same "major" number, then that means we are comparing something like "6.X.Y.Z" to "6". Version treats the objects with more dots as
+			// "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
+			return false;
+		}
 
-        internal override string DebuggerDisplay => $"(>= {this.LeftChild.DebuggerDisplay} {this.RightChild.DebuggerDisplay})";
-    }
+		internal override string DebuggerDisplay => $"(>= {this.LeftChild.DebuggerDisplay} {this.RightChild.DebuggerDisplay})";
+	}
 }

--- a/Project2015To2017.Core/Reading/Conditionals/InternalErrorException.cs
+++ b/Project2015To2017.Core/Reading/Conditionals/InternalErrorException.cs
@@ -6,117 +6,117 @@ using System.Diagnostics;
 
 namespace Project2015To2017.Reading.Conditionals
 {
-    /// <summary>
-    /// This exception is to be thrown whenever an assumption we have made in the code turns out to be false. Thus, if this
-    /// exception ever gets thrown, it is because of a bug in our own code, not because of something the user or project author
-    /// did wrong.
-    /// 
-    /// !~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~
-    /// WARNING: When this file is shared into multiple assemblies each assembly will view this as a different type.
-    ///          Don't throw this exception from one assembly and catch it in another.
-    /// !~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~
-    ///     
-    /// </summary>
-    internal sealed class InternalErrorException : Exception
-    {
-        /// <summary>
-        /// Default constructor.
-        /// SHOULD ONLY BE CALLED BY DESERIALIZER. 
-        /// SUPPLY A MESSAGE INSTEAD.
-        /// </summary>
-        internal InternalErrorException() : base()
-        {
-            // do nothing
-        }
+	/// <summary>
+	/// This exception is to be thrown whenever an assumption we have made in the code turns out to be false. Thus, if this
+	/// exception ever gets thrown, it is because of a bug in our own code, not because of something the user or project author
+	/// did wrong.
+	/// 
+	/// !~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~
+	/// WARNING: When this file is shared into multiple assemblies each assembly will view this as a different type.
+	///          Don't throw this exception from one assembly and catch it in another.
+	/// !~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~!~
+	///     
+	/// </summary>
+	internal sealed class InternalErrorException : Exception
+	{
+		/// <summary>
+		/// Default constructor.
+		/// SHOULD ONLY BE CALLED BY DESERIALIZER. 
+		/// SUPPLY A MESSAGE INSTEAD.
+		/// </summary>
+		internal InternalErrorException() : base()
+		{
+			// do nothing
+		}
 
-        /// <summary>
-        /// Creates an instance of this exception using the given message.
-        /// </summary>
-        internal InternalErrorException
-        (
-            String message
-        ) :
-            base("MSB0001: Internal MSBuild Error: " + message)
-        {
-            ConsiderDebuggerLaunch(message, null);
-        }
+		/// <summary>
+		/// Creates an instance of this exception using the given message.
+		/// </summary>
+		internal InternalErrorException
+		(
+			String message
+		) :
+			base("MSB0001: Internal MSBuild Error: " + message)
+		{
+			ConsiderDebuggerLaunch(message, null);
+		}
 
-        /// <summary>
-        /// Creates an instance of this exception using the given message and inner exception.
-        /// Adds the inner exception's details to the exception message because most bug reporters don't bother
-        /// to provide the inner exception details which is typically what we care about.
-        /// </summary>
-        internal InternalErrorException
-        (
-            String message,
-            Exception innerException
-        ) :
-            base("MSB0001: Internal MSBuild Error: " + message + (innerException == null ? String.Empty : ("\n=============\n" + innerException.ToString() + "\n\n")), innerException)
-        {
-            ConsiderDebuggerLaunch(message, innerException);
-        }
+		/// <summary>
+		/// Creates an instance of this exception using the given message and inner exception.
+		/// Adds the inner exception's details to the exception message because most bug reporters don't bother
+		/// to provide the inner exception details which is typically what we care about.
+		/// </summary>
+		internal InternalErrorException
+		(
+			String message,
+			Exception innerException
+		) :
+			base("MSB0001: Internal MSBuild Error: " + message + (innerException == null ? String.Empty : ("\n=============\n" + innerException.ToString() + "\n\n")), innerException)
+		{
+			ConsiderDebuggerLaunch(message, innerException);
+		}
 
-        #region ConsiderDebuggerLaunch
-        /// <summary>
-        /// A fatal internal error due to a bug has occurred. Give the dev a chance to debug it, if possible.
-        /// 
-        /// Will in all cases launch the debugger, if the environment variable "MSBUILDLAUNCHDEBUGGER" is set.
-        /// 
-        /// In DEBUG build, will always launch the debugger, unless we are in razzle (_NTROOT is set) or in NUnit,
-        /// or MSBUILDDONOTLAUNCHDEBUGGER is set (that could be useful in suite runs).
-        /// We don't launch in retail or LKG so builds don't jam; they get a callstack, and continue or send a mail, etc.
-        /// We don't launch in NUnit as tests often intentionally cause InternalErrorExceptions.
-        /// 
-        /// Because we only call this method from this class, just before throwing an InternalErrorException, there is 
-        /// no danger that this suppression will cause a bug to only manifest itself outside NUnit
-        /// (which would be most unfortunate!). Do not make this non-private.
-        /// 
-        /// Unfortunately NUnit can't handle unhandled exceptions like InternalErrorException on anything other than
-        /// the main test thread. However, there's still a callstack displayed before it quits.
-        /// 
-        /// If it is going to launch the debugger, it first does a Debug.Fail to give information about what needs to
-        /// be debugged -- the exception hasn't been thrown yet. This automatically displays the current callstack.
-        /// </summary>
-        private static void ConsiderDebuggerLaunch(string message, Exception innerException)
-        {
-            string innerMessage = (innerException == null) ? String.Empty : innerException.ToString();
+		#region ConsiderDebuggerLaunch
+		/// <summary>
+		/// A fatal internal error due to a bug has occurred. Give the dev a chance to debug it, if possible.
+		/// 
+		/// Will in all cases launch the debugger, if the environment variable "MSBUILDLAUNCHDEBUGGER" is set.
+		/// 
+		/// In DEBUG build, will always launch the debugger, unless we are in razzle (_NTROOT is set) or in NUnit,
+		/// or MSBUILDDONOTLAUNCHDEBUGGER is set (that could be useful in suite runs).
+		/// We don't launch in retail or LKG so builds don't jam; they get a callstack, and continue or send a mail, etc.
+		/// We don't launch in NUnit as tests often intentionally cause InternalErrorExceptions.
+		/// 
+		/// Because we only call this method from this class, just before throwing an InternalErrorException, there is 
+		/// no danger that this suppression will cause a bug to only manifest itself outside NUnit
+		/// (which would be most unfortunate!). Do not make this non-private.
+		/// 
+		/// Unfortunately NUnit can't handle unhandled exceptions like InternalErrorException on anything other than
+		/// the main test thread. However, there's still a callstack displayed before it quits.
+		/// 
+		/// If it is going to launch the debugger, it first does a Debug.Fail to give information about what needs to
+		/// be debugged -- the exception hasn't been thrown yet. This automatically displays the current callstack.
+		/// </summary>
+		private static void ConsiderDebuggerLaunch(string message, Exception innerException)
+		{
+			string innerMessage = (innerException == null) ? String.Empty : innerException.ToString();
 
-            if (Environment.GetEnvironmentVariable("MSBUILDLAUNCHDEBUGGER") != null)
-            {
-                LaunchDebugger(message, innerMessage);
-                return;
-            }
+			if (Environment.GetEnvironmentVariable("MSBUILDLAUNCHDEBUGGER") != null)
+			{
+				LaunchDebugger(message, innerMessage);
+				return;
+			}
 
 #if DEBUG
-            if (!RunningTests() && Environment.GetEnvironmentVariable("MSBUILDDONOTLAUNCHDEBUGGER") == null
-                && Environment.GetEnvironmentVariable("_NTROOT") == null)
-            {
-                LaunchDebugger(message, innerMessage);
-                return;
-            }
+			if (!RunningTests() && Environment.GetEnvironmentVariable("MSBUILDDONOTLAUNCHDEBUGGER") == null
+				&& Environment.GetEnvironmentVariable("_NTROOT") == null)
+			{
+				LaunchDebugger(message, innerMessage);
+				return;
+			}
 #endif
-        }
+		}
 
-        private static void LaunchDebugger(string message, string innerMessage)
-        {
+		private static void LaunchDebugger(string message, string innerMessage)
+		{
 #if FEATURE_DEBUG_LAUNCH
             Debug.Fail(message, innerMessage);
             Debugger.Launch();
 #else
-            Console.WriteLine("MSBuild Failure: " + message);    
-            if (!string.IsNullOrEmpty(innerMessage))
-            {
-                Console.WriteLine(innerMessage);
-            }
-            Console.WriteLine("Waiting for debugger to attach to process: " + Process.GetCurrentProcess().Id);
-            while (!Debugger.IsAttached)
-            {
-                System.Threading.Thread.Sleep(100);
-            }
+			Console.WriteLine("MSBuild Failure: " + message);
+			if (!string.IsNullOrEmpty(innerMessage))
+			{
+				Console.WriteLine(innerMessage);
+			}
+			Console.WriteLine("Waiting for debugger to attach to process: " + Process.GetCurrentProcess().Id);
+			while (!Debugger.IsAttached)
+			{
+				System.Threading.Thread.Sleep(100);
+			}
 #endif
-        }
-        #endregion
+		}
+		#endregion
 
-        private static bool RunningTests() => false;
-    }
+		private static bool RunningTests() => false;
+	}
 }

--- a/Project2015To2017.Core/Reading/Conditionals/LessThanExpressionNode.cs
+++ b/Project2015To2017.Core/Reading/Conditionals/LessThanExpressionNode.cs
@@ -6,59 +6,59 @@ using System.Diagnostics;
 
 namespace Project2015To2017.Reading.Conditionals
 {
-    /// <summary>
-    /// Compares for left &lt; right
-    /// </summary>
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    internal sealed class LessThanExpressionNode : NumericComparisonExpressionNode
-    {
-        /// <summary>
-        /// Compare numerically
-        /// </summary>
-        protected override bool Compare(double left, double right)
-        {
-            return left < right;
-        }
+	/// <summary>
+	/// Compares for left &lt; right
+	/// </summary>
+	[DebuggerDisplay("{DebuggerDisplay,nq}")]
+	internal sealed class LessThanExpressionNode : NumericComparisonExpressionNode
+	{
+		/// <summary>
+		/// Compare numerically
+		/// </summary>
+		protected override bool Compare(double left, double right)
+		{
+			return left < right;
+		}
 
-        /// <summary>
-        /// Compare Versions. This is only intended to compare version formats like "A.B.C.D" which can otherwise not be compared numerically
-        /// </summary>
-        /// <returns></returns>
-        protected override bool Compare(Version left, Version right)
-        {
-            return left < right;
-        }
+		/// <summary>
+		/// Compare Versions. This is only intended to compare version formats like "A.B.C.D" which can otherwise not be compared numerically
+		/// </summary>
+		/// <returns></returns>
+		protected override bool Compare(Version left, Version right)
+		{
+			return left < right;
+		}
 
-        /// <summary>
-        /// Compare mixed numbers and Versions
-        /// </summary>
-        protected override bool Compare(Version left, double right)
-        {
-            if (left.Major != right)
-            {
-                return left.Major < right;
-            }
+		/// <summary>
+		/// Compare mixed numbers and Versions
+		/// </summary>
+		protected override bool Compare(Version left, double right)
+		{
+			if (left.Major != right)
+			{
+				return left.Major < right;
+			}
 
-            // If they have same "major" number, then that means we are comparing something like "6.X.Y.Z" to "6". Version treats the objects with more dots as
-            // "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
-            return false;
-        }
+			// If they have same "major" number, then that means we are comparing something like "6.X.Y.Z" to "6". Version treats the objects with more dots as
+			// "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
+			return false;
+		}
 
-        /// <summary>
-        /// Compare mixed numbers and Versions
-        /// </summary>
-        protected override bool Compare(double left, Version right)
-        {
-            if (right.Major != left)
-            {
-                return left < right.Major;
-            }
+		/// <summary>
+		/// Compare mixed numbers and Versions
+		/// </summary>
+		protected override bool Compare(double left, Version right)
+		{
+			if (right.Major != left)
+			{
+				return left < right.Major;
+			}
 
-            // If they have same "major" number, then that means we are comparing something like "6.X.Y.Z" to "6". Version treats the objects with more dots as
-            // "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
-            return true;
-        }
+			// If they have same "major" number, then that means we are comparing something like "6.X.Y.Z" to "6". Version treats the objects with more dots as
+			// "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
+			return true;
+		}
 
-        internal override string DebuggerDisplay => $"(< {this.LeftChild.DebuggerDisplay} {this.RightChild.DebuggerDisplay})";
-    }
+		internal override string DebuggerDisplay => $"(< {this.LeftChild.DebuggerDisplay} {this.RightChild.DebuggerDisplay})";
+	}
 }

--- a/Project2015To2017.Core/Reading/Conditionals/LessThanOrEqualExpressionNode.cs
+++ b/Project2015To2017.Core/Reading/Conditionals/LessThanOrEqualExpressionNode.cs
@@ -6,59 +6,59 @@ using System.Diagnostics;
 
 namespace Project2015To2017.Reading.Conditionals
 {
-    /// <summary>
-    /// Compares for left &lt;= right
-    /// </summary>
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    internal sealed class LessThanOrEqualExpressionNode : NumericComparisonExpressionNode
-    {
-        /// <summary>
-        /// Compare numerically
-        /// </summary>
-        protected override bool Compare(double left, double right)
-        {
-            return left <= right;
-        }
+	/// <summary>
+	/// Compares for left &lt;= right
+	/// </summary>
+	[DebuggerDisplay("{DebuggerDisplay,nq}")]
+	internal sealed class LessThanOrEqualExpressionNode : NumericComparisonExpressionNode
+	{
+		/// <summary>
+		/// Compare numerically
+		/// </summary>
+		protected override bool Compare(double left, double right)
+		{
+			return left <= right;
+		}
 
-        /// <summary>
-        /// Compare Versions. This is only intended to compare version formats like "A.B.C.D" which can otherwise not be compared numerically
-        /// </summary>
-        /// <returns></returns>
-        protected override bool Compare(Version left, Version right)
-        {
-            return left <= right;
-        }
+		/// <summary>
+		/// Compare Versions. This is only intended to compare version formats like "A.B.C.D" which can otherwise not be compared numerically
+		/// </summary>
+		/// <returns></returns>
+		protected override bool Compare(Version left, Version right)
+		{
+			return left <= right;
+		}
 
-        /// <summary>
-        /// Compare mixed numbers and Versions
-        /// </summary>
-        protected override bool Compare(Version left, double right)
-        {
-            if (left.Major != right)
-            {
-                return left.Major <= right;
-            }
+		/// <summary>
+		/// Compare mixed numbers and Versions
+		/// </summary>
+		protected override bool Compare(Version left, double right)
+		{
+			if (left.Major != right)
+			{
+				return left.Major <= right;
+			}
 
-            // If they have same "major" number, then that means we are comparing something like "6.X.Y.Z" to "6". Version treats the objects with more dots as
-            // "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
-            return false;
-        }
+			// If they have same "major" number, then that means we are comparing something like "6.X.Y.Z" to "6". Version treats the objects with more dots as
+			// "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
+			return false;
+		}
 
-        /// <summary>
-        /// Compare mixed numbers and Versions
-        /// </summary>
-        protected override bool Compare(double left, Version right)
-        {
-            if (right.Major != left)
-            {
-                return left <= right.Major;
-            }
+		/// <summary>
+		/// Compare mixed numbers and Versions
+		/// </summary>
+		protected override bool Compare(double left, Version right)
+		{
+			if (right.Major != left)
+			{
+				return left <= right.Major;
+			}
 
-            // If they have same "major" number, then that means we are comparing something like "6.X.Y.Z" to "6". Version treats the objects with more dots as
-            // "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
-            return true;
-        }
+			// If they have same "major" number, then that means we are comparing something like "6.X.Y.Z" to "6". Version treats the objects with more dots as
+			// "larger" regardless of what those dots are (e.g. 6.0.0.0 > 6 is a true statement)
+			return true;
+		}
 
-        internal override string DebuggerDisplay => $"(<= {this.LeftChild.DebuggerDisplay} {this.RightChild.DebuggerDisplay})";
-    }
+		internal override string DebuggerDisplay => $"(<= {this.LeftChild.DebuggerDisplay} {this.RightChild.DebuggerDisplay})";
+	}
 }

--- a/Project2015To2017.Core/Reading/Conditionals/MultipleComparisonExpressionNode.cs
+++ b/Project2015To2017.Core/Reading/Conditionals/MultipleComparisonExpressionNode.cs
@@ -3,106 +3,106 @@
 
 namespace Project2015To2017.Reading.Conditionals
 {
-    /// <summary>
-    /// Evaluates as boolean and evaluates children as boolean, numeric, or string.
-    /// Order in which comparisons are attempted is numeric, boolean, then string.
-    /// Updates conditioned properties table.
-    /// </summary>
-    internal abstract class MultipleComparisonNode : OperatorExpressionNode
-    {
-        private bool _conditionedPropertiesUpdated = false;
+	/// <summary>
+	/// Evaluates as boolean and evaluates children as boolean, numeric, or string.
+	/// Order in which comparisons are attempted is numeric, boolean, then string.
+	/// Updates conditioned properties table.
+	/// </summary>
+	internal abstract class MultipleComparisonNode : OperatorExpressionNode
+	{
+		private bool _conditionedPropertiesUpdated = false;
 
-        /// <summary>
-        /// Compare numbers
-        /// </summary>
-        protected abstract bool Compare(double left, double right);
+		/// <summary>
+		/// Compare numbers
+		/// </summary>
+		protected abstract bool Compare(double left, double right);
 
-        /// <summary>
-        /// Compare booleans
-        /// </summary>
-        protected abstract bool Compare(bool left, bool right);
+		/// <summary>
+		/// Compare booleans
+		/// </summary>
+		protected abstract bool Compare(bool left, bool right);
 
-        /// <summary>
-        /// Compare strings
-        /// </summary>
-        protected abstract bool Compare(string left, string right);
+		/// <summary>
+		/// Compare strings
+		/// </summary>
+		protected abstract bool Compare(string left, string right);
 
-        /// <summary>
-        /// Evaluates as boolean and evaluates children as boolean, numeric, or string.
-        /// Order in which comparisons are attempted is numeric, boolean, then string.
-        /// Updates conditioned properties table.
-        /// </summary>
-        internal override bool BoolEvaluate(IConditionEvaluationState state)
-        {
-            // It's sometimes possible to bail out of expansion early if we just need to know whether 
-            // the result is empty string.
-            // If at least one of the left or the right hand side will evaluate to empty, 
-            // and we know which do, then we already have enough information to evaluate this expression.
-            // That means we don't have to fully expand a condition like " '@(X)' == '' " 
-            // which is a performance advantage if @(X) is a huge item list.
-            if (this.LeftChild.EvaluatesToEmpty(state) || this.RightChild.EvaluatesToEmpty(state))
-            {
-                UpdateConditionedProperties(state);
+		/// <summary>
+		/// Evaluates as boolean and evaluates children as boolean, numeric, or string.
+		/// Order in which comparisons are attempted is numeric, boolean, then string.
+		/// Updates conditioned properties table.
+		/// </summary>
+		internal override bool BoolEvaluate(IConditionEvaluationState state)
+		{
+			// It's sometimes possible to bail out of expansion early if we just need to know whether 
+			// the result is empty string.
+			// If at least one of the left or the right hand side will evaluate to empty, 
+			// and we know which do, then we already have enough information to evaluate this expression.
+			// That means we don't have to fully expand a condition like " '@(X)' == '' " 
+			// which is a performance advantage if @(X) is a huge item list.
+			if (this.LeftChild.EvaluatesToEmpty(state) || this.RightChild.EvaluatesToEmpty(state))
+			{
+				UpdateConditionedProperties(state);
 
-                return Compare(this.LeftChild.EvaluatesToEmpty(state), this.RightChild.EvaluatesToEmpty(state));
-            }
+				return Compare(this.LeftChild.EvaluatesToEmpty(state), this.RightChild.EvaluatesToEmpty(state));
+			}
 
-            if (this.LeftChild.CanNumericEvaluate(state) && this.RightChild.CanNumericEvaluate(state))
-            {
-                return Compare(this.LeftChild.NumericEvaluate(state), this.RightChild.NumericEvaluate(state));
-            }
-            else if (this.LeftChild.CanBoolEvaluate(state) && this.RightChild.CanBoolEvaluate(state))
-            {
-                return Compare(this.LeftChild.BoolEvaluate(state), this.RightChild.BoolEvaluate(state));
-            }
-            else // string comparison
-            {
-                string leftExpandedValue = this.LeftChild.GetExpandedValue(state);
-                string rightExpandedValue = this.RightChild.GetExpandedValue(state);
-				
-                UpdateConditionedProperties(state);
+			if (this.LeftChild.CanNumericEvaluate(state) && this.RightChild.CanNumericEvaluate(state))
+			{
+				return Compare(this.LeftChild.NumericEvaluate(state), this.RightChild.NumericEvaluate(state));
+			}
+			else if (this.LeftChild.CanBoolEvaluate(state) && this.RightChild.CanBoolEvaluate(state))
+			{
+				return Compare(this.LeftChild.BoolEvaluate(state), this.RightChild.BoolEvaluate(state));
+			}
+			else // string comparison
+			{
+				string leftExpandedValue = this.LeftChild.GetExpandedValue(state);
+				string rightExpandedValue = this.RightChild.GetExpandedValue(state);
 
-                return Compare(leftExpandedValue, rightExpandedValue);
-            }
-        }
+				UpdateConditionedProperties(state);
 
-        /// <summary>
-        /// Reset temporary state
-        /// </summary>
-        internal override void ResetState()
-        {
-            base.ResetState();
+				return Compare(leftExpandedValue, rightExpandedValue);
+			}
+		}
+
+		/// <summary>
+		/// Reset temporary state
+		/// </summary>
+		internal override void ResetState()
+		{
+			base.ResetState();
 			this._conditionedPropertiesUpdated = false;
-        }
+		}
 
-        /// <summary>
-        /// Updates the conditioned properties table if it hasn't already been done.
-        /// </summary>
-        private void UpdateConditionedProperties(IConditionEvaluationState state)
-        {
-            if (!this._conditionedPropertiesUpdated && state.ConditionedPropertiesInProject != null)
-            {
-                string leftUnexpandedValue = this.LeftChild.GetUnexpandedValue(state);
-                string rightUnexpandedValue = this.RightChild.GetUnexpandedValue(state);
+		/// <summary>
+		/// Updates the conditioned properties table if it hasn't already been done.
+		/// </summary>
+		private void UpdateConditionedProperties(IConditionEvaluationState state)
+		{
+			if (!this._conditionedPropertiesUpdated && state.ConditionedPropertiesInProject != null)
+			{
+				string leftUnexpandedValue = this.LeftChild.GetUnexpandedValue(state);
+				string rightUnexpandedValue = this.RightChild.GetUnexpandedValue(state);
 
-                if (leftUnexpandedValue != null)
-                {
-                    ConditionEvaluator.UpdateConditionedPropertiesTable
-                        (state.ConditionedPropertiesInProject,
-                         leftUnexpandedValue,
+				if (leftUnexpandedValue != null)
+				{
+					ConditionEvaluator.UpdateConditionedPropertiesTable
+						(state.ConditionedPropertiesInProject,
+						 leftUnexpandedValue,
 						 this.RightChild.GetExpandedValue(state));
-                }
+				}
 
-                if (rightUnexpandedValue != null)
-                {
-                    ConditionEvaluator.UpdateConditionedPropertiesTable
-                        (state.ConditionedPropertiesInProject,
-                         rightUnexpandedValue,
+				if (rightUnexpandedValue != null)
+				{
+					ConditionEvaluator.UpdateConditionedPropertiesTable
+						(state.ConditionedPropertiesInProject,
+						 rightUnexpandedValue,
 						 this.LeftChild.GetExpandedValue(state));
-                }
+				}
 
 				this._conditionedPropertiesUpdated = true;
-            }
-        }
-    }
+			}
+		}
+	}
 }

--- a/Project2015To2017.Core/Reading/Conditionals/NotEqualExpressionNode.cs
+++ b/Project2015To2017.Core/Reading/Conditionals/NotEqualExpressionNode.cs
@@ -6,36 +6,36 @@ using System.Diagnostics;
 
 namespace Project2015To2017.Reading.Conditionals
 {
-    /// <summary>
-    /// Compares for inequality
-    /// </summary>
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    internal sealed class NotEqualExpressionNode : MultipleComparisonNode
-    {
-        /// <summary>
-        /// Compare numbers
-        /// </summary>
-        protected override bool Compare(double left, double right)
-        {
-            return left != right;
-        }
+	/// <summary>
+	/// Compares for inequality
+	/// </summary>
+	[DebuggerDisplay("{DebuggerDisplay,nq}")]
+	internal sealed class NotEqualExpressionNode : MultipleComparisonNode
+	{
+		/// <summary>
+		/// Compare numbers
+		/// </summary>
+		protected override bool Compare(double left, double right)
+		{
+			return left != right;
+		}
 
-        /// <summary>
-        /// Compare booleans
-        /// </summary>
-        protected override bool Compare(bool left, bool right)
-        {
-            return left != right;
-        }
+		/// <summary>
+		/// Compare booleans
+		/// </summary>
+		protected override bool Compare(bool left, bool right)
+		{
+			return left != right;
+		}
 
-        /// <summary>
-        /// Compare strings
-        /// </summary>
-        protected override bool Compare(string left, string right)
-        {
-            return !String.Equals(left, right, StringComparison.OrdinalIgnoreCase);
-        }
+		/// <summary>
+		/// Compare strings
+		/// </summary>
+		protected override bool Compare(string left, string right)
+		{
+			return !String.Equals(left, right, StringComparison.OrdinalIgnoreCase);
+		}
 
-        internal override string DebuggerDisplay => $"(!= {this.LeftChild.DebuggerDisplay} {this.RightChild.DebuggerDisplay})";
-    }
+		internal override string DebuggerDisplay => $"(!= {this.LeftChild.DebuggerDisplay} {this.RightChild.DebuggerDisplay})";
+	}
 }

--- a/Project2015To2017.Core/Reading/Conditionals/NotExpressionNode.cs
+++ b/Project2015To2017.Core/Reading/Conditionals/NotExpressionNode.cs
@@ -5,42 +5,42 @@ using System.Diagnostics;
 
 namespace Project2015To2017.Reading.Conditionals
 {
-    /// <summary>
-    /// Performs logical NOT on left child
-    /// Does not update conditioned properties table
-    /// </summary>
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    internal sealed class NotExpressionNode : OperatorExpressionNode
-    {
-        /// <summary>
-        /// Evaluate as boolean
-        /// </summary>
-        internal override bool BoolEvaluate(IConditionEvaluationState state)
-        {
-            return !this.LeftChild.BoolEvaluate(state);
-        }
+	/// <summary>
+	/// Performs logical NOT on left child
+	/// Does not update conditioned properties table
+	/// </summary>
+	[DebuggerDisplay("{DebuggerDisplay,nq}")]
+	internal sealed class NotExpressionNode : OperatorExpressionNode
+	{
+		/// <summary>
+		/// Evaluate as boolean
+		/// </summary>
+		internal override bool BoolEvaluate(IConditionEvaluationState state)
+		{
+			return !this.LeftChild.BoolEvaluate(state);
+		}
 
-        internal override bool CanBoolEvaluate(IConditionEvaluationState state)
-        {
-            return this.LeftChild.CanBoolEvaluate(state);
-        }
+		internal override bool CanBoolEvaluate(IConditionEvaluationState state)
+		{
+			return this.LeftChild.CanBoolEvaluate(state);
+		}
 
-        /// <summary>
-        /// Returns unexpanded value with '!' prepended. Useful for error messages.
-        /// </summary>
-        internal override string GetUnexpandedValue(IConditionEvaluationState state)
-        {
-            return "!" + this.LeftChild.GetUnexpandedValue(state);
-        }
+		/// <summary>
+		/// Returns unexpanded value with '!' prepended. Useful for error messages.
+		/// </summary>
+		internal override string GetUnexpandedValue(IConditionEvaluationState state)
+		{
+			return "!" + this.LeftChild.GetUnexpandedValue(state);
+		}
 
-        /// <summary>
-        /// Returns expanded value with '!' prepended. Useful for error messages.
-        /// </summary>
-        internal override string GetExpandedValue(IConditionEvaluationState state)
-        {
-            return "!" + this.LeftChild.GetExpandedValue(state);
-        }
+		/// <summary>
+		/// Returns expanded value with '!' prepended. Useful for error messages.
+		/// </summary>
+		internal override string GetExpandedValue(IConditionEvaluationState state)
+		{
+			return "!" + this.LeftChild.GetExpandedValue(state);
+		}
 
-        internal override string DebuggerDisplay => $"(not {this.LeftChild.DebuggerDisplay})";
-    }
+		internal override string DebuggerDisplay => $"(not {this.LeftChild.DebuggerDisplay})";
+	}
 }

--- a/Project2015To2017.Core/Reading/Conditionals/NumericComparisonExpressionNode.cs
+++ b/Project2015To2017.Core/Reading/Conditionals/NumericComparisonExpressionNode.cs
@@ -5,67 +5,67 @@ using System;
 
 namespace Project2015To2017.Reading.Conditionals
 {
-    /// <summary>
-    /// Evaluates a numeric comparison, such as less-than, or greater-or-equal-than
-    /// Does not update conditioned properties table.
-    /// </summary>
-    internal abstract class NumericComparisonExpressionNode : OperatorExpressionNode
-    {
-        /// <summary>
-        /// Compare numbers
-        /// </summary>
-        protected abstract bool Compare(double left, double right);
+	/// <summary>
+	/// Evaluates a numeric comparison, such as less-than, or greater-or-equal-than
+	/// Does not update conditioned properties table.
+	/// </summary>
+	internal abstract class NumericComparisonExpressionNode : OperatorExpressionNode
+	{
+		/// <summary>
+		/// Compare numbers
+		/// </summary>
+		protected abstract bool Compare(double left, double right);
 
-        /// <summary>
-        /// Compare Versions. This is only intended to compare version formats like "A.B.C.D" which can otherwise not be compared numerically
-        /// </summary>
-        protected abstract bool Compare(Version left, Version right);
+		/// <summary>
+		/// Compare Versions. This is only intended to compare version formats like "A.B.C.D" which can otherwise not be compared numerically
+		/// </summary>
+		protected abstract bool Compare(Version left, Version right);
 
-        /// <summary>
-        /// Compare mixed numbers and Versions
-        /// </summary>
-        protected abstract bool Compare(Version left, double right);
+		/// <summary>
+		/// Compare mixed numbers and Versions
+		/// </summary>
+		protected abstract bool Compare(Version left, double right);
 
-        /// <summary>
-        /// Compare mixed numbers and Versions
-        /// </summary>
-        protected abstract bool Compare(double left, Version right);
+		/// <summary>
+		/// Compare mixed numbers and Versions
+		/// </summary>
+		protected abstract bool Compare(double left, Version right);
 
-        /// <summary>
-        /// Evaluate as boolean
-        /// </summary>
-        internal override bool BoolEvaluate(IConditionEvaluationState state)
-        {
-            bool isLeftNum = this.LeftChild.CanNumericEvaluate(state);
-            bool isLeftVersion = this.LeftChild.CanVersionEvaluate(state);
-            bool isRightNum = this.RightChild.CanNumericEvaluate(state);
-            bool isRightVersion = this.RightChild.CanVersionEvaluate(state);
-            bool isNumeric = isLeftNum && isRightNum;
-            bool isVersion = isLeftVersion && isRightVersion;
+		/// <summary>
+		/// Evaluate as boolean
+		/// </summary>
+		internal override bool BoolEvaluate(IConditionEvaluationState state)
+		{
+			bool isLeftNum = this.LeftChild.CanNumericEvaluate(state);
+			bool isLeftVersion = this.LeftChild.CanVersionEvaluate(state);
+			bool isRightNum = this.RightChild.CanNumericEvaluate(state);
+			bool isRightVersion = this.RightChild.CanVersionEvaluate(state);
+			bool isNumeric = isLeftNum && isRightNum;
+			bool isVersion = isLeftVersion && isRightVersion;
 
-            // If the values identify as numeric, make that comparison instead of the Version comparison since numeric has a stricter definition
-            if (isNumeric)
-            {
-                return Compare(this.LeftChild.NumericEvaluate(state), this.RightChild.NumericEvaluate(state));
-            }
-            else if (isVersion)
-            {
-                return Compare(this.LeftChild.VersionEvaluate(state), this.RightChild.VersionEvaluate(state));
-            }
+			// If the values identify as numeric, make that comparison instead of the Version comparison since numeric has a stricter definition
+			if (isNumeric)
+			{
+				return Compare(this.LeftChild.NumericEvaluate(state), this.RightChild.NumericEvaluate(state));
+			}
+			else if (isVersion)
+			{
+				return Compare(this.LeftChild.VersionEvaluate(state), this.RightChild.VersionEvaluate(state));
+			}
 
-            // If the numbers are of a mixed type, call that specific Compare method
-            if (isLeftNum && isRightVersion)
-            {
-                return Compare(this.LeftChild.NumericEvaluate(state), this.RightChild.VersionEvaluate(state));
-            }
-            else if (isLeftVersion && isRightNum)
-            {
-                return Compare(this.LeftChild.VersionEvaluate(state), this.RightChild.NumericEvaluate(state));
-            }
+			// If the numbers are of a mixed type, call that specific Compare method
+			if (isLeftNum && isRightVersion)
+			{
+				return Compare(this.LeftChild.NumericEvaluate(state), this.RightChild.VersionEvaluate(state));
+			}
+			else if (isLeftVersion && isRightNum)
+			{
+				return Compare(this.LeftChild.VersionEvaluate(state), this.RightChild.NumericEvaluate(state));
+			}
 
-            // Throw error here as this code should be unreachable
-            ErrorUtilities.ThrowInternalErrorUnreachable();
-            return false;
-        }
-    }
+			// Throw error here as this code should be unreachable
+			ErrorUtilities.ThrowInternalErrorUnreachable();
+			return false;
+		}
+	}
 }

--- a/Project2015To2017.Core/Reading/Conditionals/NumericExpressionNode.cs
+++ b/Project2015To2017.Core/Reading/Conditionals/NumericExpressionNode.cs
@@ -6,101 +6,101 @@ using System.Diagnostics;
 
 namespace Project2015To2017.Reading.Conditionals
 {
-    /// <summary>
-    /// Represents a number - evaluates as numeric.
-    /// </summary>
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    internal sealed class NumericExpressionNode : OperandExpressionNode
-    {
-        private string _value;
+	/// <summary>
+	/// Represents a number - evaluates as numeric.
+	/// </summary>
+	[DebuggerDisplay("{DebuggerDisplay,nq}")]
+	internal sealed class NumericExpressionNode : OperandExpressionNode
+	{
+		private string _value;
 
-        private NumericExpressionNode() { }
+		private NumericExpressionNode() { }
 
-        internal NumericExpressionNode(string value)
-        {
+		internal NumericExpressionNode(string value)
+		{
 			this._value = value;
-        }
+		}
 
-        /// <summary>
-        /// Evaluate as boolean
-        /// </summary>
-        internal override bool BoolEvaluate(IConditionEvaluationState state)
-        {
-            // Should be unreachable: all calls check CanBoolEvaluate() first
-            ErrorUtilities.VerifyThrow(false, "Can't evaluate a numeric expression as boolean.");
-            return false;
-        }
+		/// <summary>
+		/// Evaluate as boolean
+		/// </summary>
+		internal override bool BoolEvaluate(IConditionEvaluationState state)
+		{
+			// Should be unreachable: all calls check CanBoolEvaluate() first
+			ErrorUtilities.VerifyThrow(false, "Can't evaluate a numeric expression as boolean.");
+			return false;
+		}
 
-        /// <summary>
-        /// Evaluate as numeric
-        /// </summary>
-        internal override double NumericEvaluate(IConditionEvaluationState state)
-        {
-            return ConversionUtilities.ConvertDecimalOrHexToDouble(this._value);
-        }
+		/// <summary>
+		/// Evaluate as numeric
+		/// </summary>
+		internal override double NumericEvaluate(IConditionEvaluationState state)
+		{
+			return ConversionUtilities.ConvertDecimalOrHexToDouble(this._value);
+		}
 
-        /// <summary>
-        /// Evaluate as a Version
-        /// </summary>
-        internal override Version VersionEvaluate(IConditionEvaluationState state)
-        {
-            return Version.Parse(this._value);
-        }
+		/// <summary>
+		/// Evaluate as a Version
+		/// </summary>
+		internal override Version VersionEvaluate(IConditionEvaluationState state)
+		{
+			return Version.Parse(this._value);
+		}
 
-        /// <summary>
-        /// Whether it can be evaluated as a boolean: never allowed for numerics
-        /// </summary>
-        internal override bool CanBoolEvaluate(IConditionEvaluationState state)
-        {
-            // Numeric expressions are never allowed to be treated as booleans.
-            return false;
-        }
+		/// <summary>
+		/// Whether it can be evaluated as a boolean: never allowed for numerics
+		/// </summary>
+		internal override bool CanBoolEvaluate(IConditionEvaluationState state)
+		{
+			// Numeric expressions are never allowed to be treated as booleans.
+			return false;
+		}
 
-        /// <summary>
-        /// Whether it can be evaluated as numeric
-        /// </summary>
-        internal override bool CanNumericEvaluate(IConditionEvaluationState state)
-        {
-            // It is not always possible to numerically evaluate even a numerical expression -
-            // for example, it may overflow a double. So check here.
-            return ConversionUtilities.ValidDecimalOrHexNumber(this._value);
-        }
+		/// <summary>
+		/// Whether it can be evaluated as numeric
+		/// </summary>
+		internal override bool CanNumericEvaluate(IConditionEvaluationState state)
+		{
+			// It is not always possible to numerically evaluate even a numerical expression -
+			// for example, it may overflow a double. So check here.
+			return ConversionUtilities.ValidDecimalOrHexNumber(this._value);
+		}
 
-        /// <summary>
-        /// Whether it can be evaluated as a Version
-        /// </summary>
-        internal override bool CanVersionEvaluate(IConditionEvaluationState state)
-        {
-            // Check if the value can be formatted as a Version number
-            // This is needed for nodes that identify as Numeric but can't be parsed as numbers (e.g. 8.1.1.0 vs 8.1)
-            Version unused;
-            return Version.TryParse(this._value, out unused);
-        }
+		/// <summary>
+		/// Whether it can be evaluated as a Version
+		/// </summary>
+		internal override bool CanVersionEvaluate(IConditionEvaluationState state)
+		{
+			// Check if the value can be formatted as a Version number
+			// This is needed for nodes that identify as Numeric but can't be parsed as numbers (e.g. 8.1.1.0 vs 8.1)
+			Version unused;
+			return Version.TryParse(this._value, out unused);
+		}
 
-        /// <summary>
-        /// Get the unexpanded value
-        /// </summary>
-        internal override string GetUnexpandedValue(IConditionEvaluationState state)
-        {
-            return this._value;
-        }
+		/// <summary>
+		/// Get the unexpanded value
+		/// </summary>
+		internal override string GetUnexpandedValue(IConditionEvaluationState state)
+		{
+			return this._value;
+		}
 
-        /// <summary>
-        /// Get the expanded value
-        /// </summary>
-        internal override string GetExpandedValue(IConditionEvaluationState state)
-        {
-            return this._value;
-        }
+		/// <summary>
+		/// Get the expanded value
+		/// </summary>
+		internal override string GetExpandedValue(IConditionEvaluationState state)
+		{
+			return this._value;
+		}
 
-        /// <summary>
-        /// If any expression nodes cache any state for the duration of evaluation, 
-        /// now's the time to clean it up
-        /// </summary>
-        internal override void ResetState()
-        {
-        }
+		/// <summary>
+		/// If any expression nodes cache any state for the duration of evaluation, 
+		/// now's the time to clean it up
+		/// </summary>
+		internal override void ResetState()
+		{
+		}
 
-        internal override string DebuggerDisplay => $"#\"{this._value}\")";
-    }
+		internal override string DebuggerDisplay => $"#\"{this._value}\")";
+	}
 }

--- a/Project2015To2017.Core/Reading/Conditionals/OperandExpressionNode.cs
+++ b/Project2015To2017.Core/Reading/Conditionals/OperandExpressionNode.cs
@@ -3,23 +3,23 @@
 
 namespace Project2015To2017.Reading.Conditionals
 {
-    /// <summary>
-    /// Base class for all nodes that are operands (are leaves in the parse tree)
-    /// </summary>
-    internal abstract class OperandExpressionNode : GenericExpressionNode
-    {
-        #region REMOVE_COMPAT_WARNING
+	/// <summary>
+	/// Base class for all nodes that are operands (are leaves in the parse tree)
+	/// </summary>
+	internal abstract class OperandExpressionNode : GenericExpressionNode
+	{
+		#region REMOVE_COMPAT_WARNING
 
-        internal override bool DetectAnd()
-        {
-            return false;
-        }
+		internal override bool DetectAnd()
+		{
+			return false;
+		}
 
-        internal override bool DetectOr()
-        {
-            return false;
-        }
-        #endregion
+		internal override bool DetectOr()
+		{
+			return false;
+		}
+		#endregion
 
-    }
+	}
 }

--- a/Project2015To2017.Core/Reading/Conditionals/OperatorExpressionNode.cs
+++ b/Project2015To2017.Core/Reading/Conditionals/OperatorExpressionNode.cs
@@ -9,137 +9,137 @@ namespace Project2015To2017.Reading.Conditionals
 	/// Base class for nodes that are operators (have children in the parse tree)
 	/// </summary>
 	internal abstract class OperatorExpressionNode : GenericExpressionNode
-    {
-        /// <summary>
-        /// Numeric evaluation is never allowed for operators
-        /// </summary>
-        internal override double NumericEvaluate(IConditionEvaluationState state)
-        {
-            // Should be unreachable: all calls check CanNumericEvaluate() first
-            ErrorUtilities.VerifyThrow(false, "Cannot numeric evaluate an operator");
-            return 0.0D;
-        }
+	{
+		/// <summary>
+		/// Numeric evaluation is never allowed for operators
+		/// </summary>
+		internal override double NumericEvaluate(IConditionEvaluationState state)
+		{
+			// Should be unreachable: all calls check CanNumericEvaluate() first
+			ErrorUtilities.VerifyThrow(false, "Cannot numeric evaluate an operator");
+			return 0.0D;
+		}
 
-        /// <summary>
-        /// Version evaluation is never allowed for operators
-        /// </summary>
-        internal override Version VersionEvaluate(IConditionEvaluationState state)
-        {
-            ErrorUtilities.VerifyThrow(false, "Cannot version evaluate an operator");
-            return null;
-        }
+		/// <summary>
+		/// Version evaluation is never allowed for operators
+		/// </summary>
+		internal override Version VersionEvaluate(IConditionEvaluationState state)
+		{
+			ErrorUtilities.VerifyThrow(false, "Cannot version evaluate an operator");
+			return null;
+		}
 
-        /// <summary>
-        /// Whether boolean evaluation is allowed: always allowed for operators
-        /// </summary>
-        internal override bool CanBoolEvaluate(IConditionEvaluationState state)
-        {
-            return true;
-        }
+		/// <summary>
+		/// Whether boolean evaluation is allowed: always allowed for operators
+		/// </summary>
+		internal override bool CanBoolEvaluate(IConditionEvaluationState state)
+		{
+			return true;
+		}
 
-        /// <summary>
-        /// Whether the node can be evaluated as a numeric: by default,
-        /// this is not allowed
-        /// </summary>
-        internal override bool CanNumericEvaluate(IConditionEvaluationState state)
-        {
-            return false;
-        }
+		/// <summary>
+		/// Whether the node can be evaluated as a numeric: by default,
+		/// this is not allowed
+		/// </summary>
+		internal override bool CanNumericEvaluate(IConditionEvaluationState state)
+		{
+			return false;
+		}
 
-        /// <summary>
-        /// Whether the node can be evaluated as a version: by default,
-        /// this is not allowed
-        /// </summary>
-        internal override bool CanVersionEvaluate(IConditionEvaluationState state)
-        {
-            return false;
-        }
+		/// <summary>
+		/// Whether the node can be evaluated as a version: by default,
+		/// this is not allowed
+		/// </summary>
+		internal override bool CanVersionEvaluate(IConditionEvaluationState state)
+		{
+			return false;
+		}
 
-        /// <summary>
-        /// Value after any item and property expressions are expanded
-        /// </summary>
-        /// <returns></returns>
-        internal override string GetExpandedValue(IConditionEvaluationState state)
-        {
-            return null;
-        }
+		/// <summary>
+		/// Value after any item and property expressions are expanded
+		/// </summary>
+		/// <returns></returns>
+		internal override string GetExpandedValue(IConditionEvaluationState state)
+		{
+			return null;
+		}
 
-        /// <summary>
-        /// Value before any item and property expressions are expanded
-        /// </summary>
-        /// <returns></returns>
-        internal override string GetUnexpandedValue(IConditionEvaluationState state)
-        {
-            return null;
-        }
+		/// <summary>
+		/// Value before any item and property expressions are expanded
+		/// </summary>
+		/// <returns></returns>
+		internal override string GetUnexpandedValue(IConditionEvaluationState state)
+		{
+			return null;
+		}
 
-        /// <summary>
-        /// If any expression nodes cache any state for the duration of evaluation,
-        /// now's the time to clean it up
-        /// </summary>
-        internal override void ResetState()
-        {
-            if (this.LeftChild != null)
-            {
+		/// <summary>
+		/// If any expression nodes cache any state for the duration of evaluation,
+		/// now's the time to clean it up
+		/// </summary>
+		internal override void ResetState()
+		{
+			if (this.LeftChild != null)
+			{
 				this.LeftChild.ResetState();
-            }
+			}
 
-            if (this.RightChild != null)
-            {
+			if (this.RightChild != null)
+			{
 				this.RightChild.ResetState();
-            }
-        }
+			}
+		}
 
-        /// <summary>
-        /// Storage for the left child
-        /// </summary>
-        internal GenericExpressionNode LeftChild { set; get; }
+		/// <summary>
+		/// Storage for the left child
+		/// </summary>
+		internal GenericExpressionNode LeftChild { set; get; }
 
-        /// <summary>
-        /// Storage for the right child
-        /// </summary>
-        internal GenericExpressionNode RightChild { set; get; }
+		/// <summary>
+		/// Storage for the right child
+		/// </summary>
+		internal GenericExpressionNode RightChild { set; get; }
 
-        #region REMOVE_COMPAT_WARNING
-        internal override bool DetectAnd()
-        {
-            // Read the state of the current node
-            bool detectedAnd = this.PossibleAndCollision;
-            // Reset the flags on the current node
-            this.PossibleAndCollision = false;
-            // Process the children of the node if preset
-            bool detectAndRChild = false;
-            bool detectAndLChild = false;
-            if (this.RightChild != null)
-            {
-                detectAndRChild = this.RightChild.DetectAnd();
-            }
-            if (this.LeftChild != null)
-            {
-                detectAndLChild = this.LeftChild.DetectAnd();
-            }
-            return detectedAnd || detectAndRChild || detectAndLChild;
-        }
+		#region REMOVE_COMPAT_WARNING
+		internal override bool DetectAnd()
+		{
+			// Read the state of the current node
+			bool detectedAnd = this.PossibleAndCollision;
+			// Reset the flags on the current node
+			this.PossibleAndCollision = false;
+			// Process the children of the node if preset
+			bool detectAndRChild = false;
+			bool detectAndLChild = false;
+			if (this.RightChild != null)
+			{
+				detectAndRChild = this.RightChild.DetectAnd();
+			}
+			if (this.LeftChild != null)
+			{
+				detectAndLChild = this.LeftChild.DetectAnd();
+			}
+			return detectedAnd || detectAndRChild || detectAndLChild;
+		}
 
-        internal override bool DetectOr()
-        {
-            // Read the state of the current node
-            bool detectedOr = this.PossibleOrCollision;
-            // Reset the flags on the current node
-            this.PossibleOrCollision = false;
-            // Process the children of the node if preset
-            bool detectOrRChild = false;
-            bool detectOrLChild = false;
-            if (this.RightChild != null)
-            {
-                detectOrRChild = this.RightChild.DetectOr();
-            }
-            if (this.LeftChild != null)
-            {
-                detectOrLChild = this.LeftChild.DetectOr();
-            }
-            return detectedOr || detectOrRChild || detectOrLChild;
-        }
-        #endregion
-    }
+		internal override bool DetectOr()
+		{
+			// Read the state of the current node
+			bool detectedOr = this.PossibleOrCollision;
+			// Reset the flags on the current node
+			this.PossibleOrCollision = false;
+			// Process the children of the node if preset
+			bool detectOrRChild = false;
+			bool detectOrLChild = false;
+			if (this.RightChild != null)
+			{
+				detectOrRChild = this.RightChild.DetectOr();
+			}
+			if (this.LeftChild != null)
+			{
+				detectOrLChild = this.LeftChild.DetectOr();
+			}
+			return detectedOr || detectOrRChild || detectOrLChild;
+		}
+		#endregion
+	}
 }

--- a/Project2015To2017.Core/Reading/Conditionals/OrExpressionNode.cs
+++ b/Project2015To2017.Core/Reading/Conditionals/OrExpressionNode.cs
@@ -5,38 +5,38 @@ using System.Diagnostics;
 
 namespace Project2015To2017.Reading.Conditionals
 {
-    /// <summary>
-    /// Performs logical OR on children
-    /// Does not update conditioned properties table
-    /// </summary>
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    internal sealed class OrExpressionNode : OperatorExpressionNode
-    {
-        /// <summary>
-        /// Evaluate as boolean
-        /// </summary>
-        internal override bool BoolEvaluate(IConditionEvaluationState state)
-        {
-            if (this.LeftChild.BoolEvaluate(state))
-            {
-                // Short circuit
-                return true;
-            }
-            else
-            {
-                return this.RightChild.BoolEvaluate(state);
-            }
-        }
+	/// <summary>
+	/// Performs logical OR on children
+	/// Does not update conditioned properties table
+	/// </summary>
+	[DebuggerDisplay("{DebuggerDisplay,nq}")]
+	internal sealed class OrExpressionNode : OperatorExpressionNode
+	{
+		/// <summary>
+		/// Evaluate as boolean
+		/// </summary>
+		internal override bool BoolEvaluate(IConditionEvaluationState state)
+		{
+			if (this.LeftChild.BoolEvaluate(state))
+			{
+				// Short circuit
+				return true;
+			}
+			else
+			{
+				return this.RightChild.BoolEvaluate(state);
+			}
+		}
 
-        internal override string DebuggerDisplay => $"(or {this.LeftChild.DebuggerDisplay} {this.RightChild.DebuggerDisplay})";
+		internal override string DebuggerDisplay => $"(or {this.LeftChild.DebuggerDisplay} {this.RightChild.DebuggerDisplay})";
 
-        #region REMOVE_COMPAT_WARNING
-        private bool _possibleOrCollision = true;
-        internal override bool PossibleOrCollision
-        {
-            set { this._possibleOrCollision = value; }
-            get { return this._possibleOrCollision; }
-        }
-        #endregion
-    }
+		#region REMOVE_COMPAT_WARNING
+		private bool _possibleOrCollision = true;
+		internal override bool PossibleOrCollision
+		{
+			set { this._possibleOrCollision = value; }
+			get { return this._possibleOrCollision; }
+		}
+		#endregion
+	}
 }

--- a/Project2015To2017.Core/Reading/Conditionals/Parser.cs
+++ b/Project2015To2017.Core/Reading/Conditionals/Parser.cs
@@ -6,317 +6,317 @@ using System.Collections.Generic;
 
 namespace Project2015To2017.Reading.Conditionals
 {
-    [Flags]
+	[Flags]
 	internal enum ParserOptions
-    {
-        None = 0x0,
-        AllowProperties = 0x1,
-        AllowItemLists = 0x2,
-        AllowPropertiesAndItemLists = AllowProperties | AllowItemLists,
-        AllowBuiltInMetadata = 0x4,
-        AllowCustomMetadata = 0x8,
-        AllowItemMetadata = AllowBuiltInMetadata | AllowCustomMetadata,
-        AllowPropertiesAndItemMetadata = AllowProperties | AllowItemMetadata,
-        AllowPropertiesAndCustomMetadata = AllowProperties | AllowCustomMetadata,
-        AllowAll = AllowProperties | AllowItemLists | AllowItemMetadata
-    };
+	{
+		None = 0x0,
+		AllowProperties = 0x1,
+		AllowItemLists = 0x2,
+		AllowPropertiesAndItemLists = AllowProperties | AllowItemLists,
+		AllowBuiltInMetadata = 0x4,
+		AllowCustomMetadata = 0x8,
+		AllowItemMetadata = AllowBuiltInMetadata | AllowCustomMetadata,
+		AllowPropertiesAndItemMetadata = AllowProperties | AllowItemMetadata,
+		AllowPropertiesAndCustomMetadata = AllowProperties | AllowCustomMetadata,
+		AllowAll = AllowProperties | AllowItemLists | AllowItemMetadata
+	};
 
-    /// <summary>
-    /// This class implements the grammar for complex conditionals.
-    ///
-    /// The expression tree can then be evaluated and re-evaluated as needed.
-    /// </summary>
-    /// <remarks>
-    /// UNDONE: When we copied over the conditionals code, we didn't copy over the unit tests for scanner, parser, and expression tree.
-    /// </remarks>
-    internal sealed class Parser
-    {
-        private Scanner _lexer;
-        private ParserOptions _options;
-        internal int errorPosition = 0; // useful for unit tests
+	/// <summary>
+	/// This class implements the grammar for complex conditionals.
+	///
+	/// The expression tree can then be evaluated and re-evaluated as needed.
+	/// </summary>
+	/// <remarks>
+	/// UNDONE: When we copied over the conditionals code, we didn't copy over the unit tests for scanner, parser, and expression tree.
+	/// </remarks>
+	internal sealed class Parser
+	{
+		private Scanner _lexer;
+		private ParserOptions _options;
+		internal int errorPosition = 0; // useful for unit tests
 
-	    public Parser()
-        {
-            // nothing to see here, move along.
-        }
+		public Parser()
+		{
+			// nothing to see here, move along.
+		}
 
 		//
 		// Main entry point for parser.
 		// You pass in the expression you want to parse, and you get an
 		// ExpressionTree out the back end.
 		//
-	    public GenericExpressionNode Parse(string expression, ParserOptions optionSettings)
-        {
-            // We currently have no support (and no scenarios) for disallowing property references
-            // in Conditions.
-            ErrorUtilities.VerifyThrow(0 != (optionSettings & ParserOptions.AllowProperties),
-                "Properties should always be allowed.");
+		public GenericExpressionNode Parse(string expression, ParserOptions optionSettings)
+		{
+			// We currently have no support (and no scenarios) for disallowing property references
+			// in Conditions.
+			ErrorUtilities.VerifyThrow(0 != (optionSettings & ParserOptions.AllowProperties),
+				"Properties should always be allowed.");
 
 			this._options = optionSettings;
 
 			this._lexer = new Scanner(expression, this._options);
-            if (!this._lexer.Advance())
-            {
+			if (!this._lexer.Advance())
+			{
 				this.errorPosition = this._lexer.GetErrorPosition();
-            }
-            GenericExpressionNode node = Expr(expression);
-            if (!this._lexer.IsNext(Token.TokenType.EndOfInput))
-            {
+			}
+			GenericExpressionNode node = Expr(expression);
+			if (!this._lexer.IsNext(Token.TokenType.EndOfInput))
+			{
 				this.errorPosition = this._lexer.GetErrorPosition();
-            }
-            return node;
-        }
+			}
+			return node;
+		}
 
-        //
-        // Top node of grammar
-        //    See grammar for how the following methods relate to each
-        //    other.
-        //
-        private GenericExpressionNode Expr(string expression)
-        {
-            GenericExpressionNode node = BooleanTerm(expression);
-            if (!this._lexer.IsNext(Token.TokenType.EndOfInput))
-            {
-                node = ExprPrime(expression, node);
-            }
+		//
+		// Top node of grammar
+		//    See grammar for how the following methods relate to each
+		//    other.
+		//
+		private GenericExpressionNode Expr(string expression)
+		{
+			GenericExpressionNode node = BooleanTerm(expression);
+			if (!this._lexer.IsNext(Token.TokenType.EndOfInput))
+			{
+				node = ExprPrime(expression, node);
+			}
 
-            return node;
-        }
+			return node;
+		}
 
-        private GenericExpressionNode ExprPrime(string expression, GenericExpressionNode lhs)
-        {
-            if (Same(expression, Token.TokenType.EndOfInput))
-            {
-                return lhs;
-            }
-            else if (Same(expression, Token.TokenType.Or))
-            {
-                OperatorExpressionNode orNode = new OrExpressionNode();
-                GenericExpressionNode rhs = BooleanTerm(expression);
-                orNode.LeftChild = lhs;
-                orNode.RightChild = rhs;
-                return ExprPrime(expression, orNode);
-            }
-            else
-            {
-                // I think this is ok.  ExprPrime always shows up at
-                // the rightmost side of the grammar rhs, the EndOfInput case
-                // takes care of things
-                return lhs;
-            }
-        }
+		private GenericExpressionNode ExprPrime(string expression, GenericExpressionNode lhs)
+		{
+			if (Same(expression, Token.TokenType.EndOfInput))
+			{
+				return lhs;
+			}
+			else if (Same(expression, Token.TokenType.Or))
+			{
+				OperatorExpressionNode orNode = new OrExpressionNode();
+				GenericExpressionNode rhs = BooleanTerm(expression);
+				orNode.LeftChild = lhs;
+				orNode.RightChild = rhs;
+				return ExprPrime(expression, orNode);
+			}
+			else
+			{
+				// I think this is ok.  ExprPrime always shows up at
+				// the rightmost side of the grammar rhs, the EndOfInput case
+				// takes care of things
+				return lhs;
+			}
+		}
 
-        private GenericExpressionNode BooleanTerm(string expression)
-        {
-            GenericExpressionNode node = RelationalExpr(expression);
-            if (null == node)
-            {
+		private GenericExpressionNode BooleanTerm(string expression)
+		{
+			GenericExpressionNode node = RelationalExpr(expression);
+			if (null == node)
+			{
 				this.errorPosition = this._lexer.GetErrorPosition();
-            }
+			}
 
-            if (!this._lexer.IsNext(Token.TokenType.EndOfInput))
-            {
-                node = BooleanTermPrime(expression, node);
-            }
-            return node;
-        }
+			if (!this._lexer.IsNext(Token.TokenType.EndOfInput))
+			{
+				node = BooleanTermPrime(expression, node);
+			}
+			return node;
+		}
 
-        private GenericExpressionNode BooleanTermPrime(string expression, GenericExpressionNode lhs)
-        {
-            if (this._lexer.IsNext(Token.TokenType.EndOfInput))
-            {
-                return lhs;
-            }
-            else if (Same(expression, Token.TokenType.And))
-            {
-                GenericExpressionNode rhs = RelationalExpr(expression);
-                if (null == rhs)
-                {
+		private GenericExpressionNode BooleanTermPrime(string expression, GenericExpressionNode lhs)
+		{
+			if (this._lexer.IsNext(Token.TokenType.EndOfInput))
+			{
+				return lhs;
+			}
+			else if (Same(expression, Token.TokenType.And))
+			{
+				GenericExpressionNode rhs = RelationalExpr(expression);
+				if (null == rhs)
+				{
 					this.errorPosition = this._lexer.GetErrorPosition();
-                }
+				}
 
-                OperatorExpressionNode andNode = new AndExpressionNode();
-                andNode.LeftChild = lhs;
-                andNode.RightChild = rhs;
-                return BooleanTermPrime(expression, andNode);
-            }
-            else
-            {
-                // Should this be error case?
-                return lhs;
-            }
-        }
+				OperatorExpressionNode andNode = new AndExpressionNode();
+				andNode.LeftChild = lhs;
+				andNode.RightChild = rhs;
+				return BooleanTermPrime(expression, andNode);
+			}
+			else
+			{
+				// Should this be error case?
+				return lhs;
+			}
+		}
 
-        private GenericExpressionNode RelationalExpr(string expression)
-        {
-            {
-                GenericExpressionNode lhs = Factor(expression);
-                if (null == lhs)
-                {
+		private GenericExpressionNode RelationalExpr(string expression)
+		{
+			{
+				GenericExpressionNode lhs = Factor(expression);
+				if (null == lhs)
+				{
 					this.errorPosition = this._lexer.GetErrorPosition();
-                }
+				}
 
-                OperatorExpressionNode node = RelationalOperation(expression);
-                if (node == null)
-                {
-                    return lhs;
-                }
-                GenericExpressionNode rhs = Factor(expression);
-                node.LeftChild = lhs;
-                node.RightChild = rhs;
-                return node;
-            }
-        }
+				OperatorExpressionNode node = RelationalOperation(expression);
+				if (node == null)
+				{
+					return lhs;
+				}
+				GenericExpressionNode rhs = Factor(expression);
+				node.LeftChild = lhs;
+				node.RightChild = rhs;
+				return node;
+			}
+		}
 
 
-        private OperatorExpressionNode RelationalOperation(string expression)
-        {
-            OperatorExpressionNode node = null;
-            if (Same(expression, Token.TokenType.LessThan))
-            {
-                node = new LessThanExpressionNode();
-            }
-            else if (Same(expression, Token.TokenType.GreaterThan))
-            {
-                node = new GreaterThanExpressionNode();
-            }
-            else if (Same(expression, Token.TokenType.LessThanOrEqualTo))
-            {
-                node = new LessThanOrEqualExpressionNode();
-            }
-            else if (Same(expression, Token.TokenType.GreaterThanOrEqualTo))
-            {
-                node = new GreaterThanOrEqualExpressionNode();
-            }
-            else if (Same(expression, Token.TokenType.EqualTo))
-            {
-                node = new EqualExpressionNode();
-            }
-            else if (Same(expression, Token.TokenType.NotEqualTo))
-            {
-                node = new NotEqualExpressionNode();
-            }
-            return node;
-        }
+		private OperatorExpressionNode RelationalOperation(string expression)
+		{
+			OperatorExpressionNode node = null;
+			if (Same(expression, Token.TokenType.LessThan))
+			{
+				node = new LessThanExpressionNode();
+			}
+			else if (Same(expression, Token.TokenType.GreaterThan))
+			{
+				node = new GreaterThanExpressionNode();
+			}
+			else if (Same(expression, Token.TokenType.LessThanOrEqualTo))
+			{
+				node = new LessThanOrEqualExpressionNode();
+			}
+			else if (Same(expression, Token.TokenType.GreaterThanOrEqualTo))
+			{
+				node = new GreaterThanOrEqualExpressionNode();
+			}
+			else if (Same(expression, Token.TokenType.EqualTo))
+			{
+				node = new EqualExpressionNode();
+			}
+			else if (Same(expression, Token.TokenType.NotEqualTo))
+			{
+				node = new NotEqualExpressionNode();
+			}
+			return node;
+		}
 
-        private GenericExpressionNode Factor(string expression)
-        {
-            // Checks for TokenTypes String, Numeric, Property, ItemMetadata, and ItemList.
-            GenericExpressionNode arg = this.Arg(expression);
+		private GenericExpressionNode Factor(string expression)
+		{
+			// Checks for TokenTypes String, Numeric, Property, ItemMetadata, and ItemList.
+			GenericExpressionNode arg = this.Arg(expression);
 
-            // If it's one of those, return it.
-            if (arg != null)
-            {
-                return arg;
-            }
+			// If it's one of those, return it.
+			if (arg != null)
+			{
+				return arg;
+			}
 
-            // If it's not one of those, check for other TokenTypes.
-            Token current = this._lexer.CurrentToken;
-            if (Same(expression, Token.TokenType.Function))
-            {
-                if (!Same(expression, Token.TokenType.LeftParenthesis))
-                {
+			// If it's not one of those, check for other TokenTypes.
+			Token current = this._lexer.CurrentToken;
+			if (Same(expression, Token.TokenType.Function))
+			{
+				if (!Same(expression, Token.TokenType.LeftParenthesis))
+				{
 					this.errorPosition = this._lexer.GetErrorPosition();
-                    return null;
-                }
-                var arglist = new List<GenericExpressionNode>();
-                Arglist(expression, arglist);
-                if (!Same(expression, Token.TokenType.RightParenthesis))
-                {
+					return null;
+				}
+				var arglist = new List<GenericExpressionNode>();
+				Arglist(expression, arglist);
+				if (!Same(expression, Token.TokenType.RightParenthesis))
+				{
 					this.errorPosition = this._lexer.GetErrorPosition();
-                    return null;
-                }
-                return new FunctionCallExpressionNode(current.String, arglist);
-            }
-            else if (Same(expression, Token.TokenType.LeftParenthesis))
-            {
-                GenericExpressionNode child = Expr(expression);
-                if (Same(expression, Token.TokenType.RightParenthesis))
-                    return child;
-                else
-                {
+					return null;
+				}
+				return new FunctionCallExpressionNode(current.String, arglist);
+			}
+			else if (Same(expression, Token.TokenType.LeftParenthesis))
+			{
+				GenericExpressionNode child = Expr(expression);
+				if (Same(expression, Token.TokenType.RightParenthesis))
+					return child;
+				else
+				{
 					this.errorPosition = this._lexer.GetErrorPosition();
-                }
-            }
-            else if (Same(expression, Token.TokenType.Not))
-            {
-                OperatorExpressionNode notNode = new NotExpressionNode();
-                GenericExpressionNode expr = Factor(expression);
-                if (expr == null)
-                {
+				}
+			}
+			else if (Same(expression, Token.TokenType.Not))
+			{
+				OperatorExpressionNode notNode = new NotExpressionNode();
+				GenericExpressionNode expr = Factor(expression);
+				if (expr == null)
+				{
 					this.errorPosition = this._lexer.GetErrorPosition();
-                }
-                notNode.LeftChild = expr;
-                return notNode;
-            }
-            else
-            {
+				}
+				notNode.LeftChild = expr;
+				return notNode;
+			}
+			else
+			{
 				this.errorPosition = this._lexer.GetErrorPosition();
-            }
-            return null;
-        }
+			}
+			return null;
+		}
 
-        private void Arglist(string expression, List<GenericExpressionNode> arglist)
-        {
-            if (!this._lexer.IsNext(Token.TokenType.RightParenthesis))
-            {
-                Args(expression, arglist);
-            }
-        }
+		private void Arglist(string expression, List<GenericExpressionNode> arglist)
+		{
+			if (!this._lexer.IsNext(Token.TokenType.RightParenthesis))
+			{
+				Args(expression, arglist);
+			}
+		}
 
-        private void Args(string expression, List<GenericExpressionNode> arglist)
-        {
-            GenericExpressionNode arg = Arg(expression);
-            arglist.Add(arg);
-            if (Same(expression, Token.TokenType.Comma))
-            {
-                Args(expression, arglist);
-            }
-        }
+		private void Args(string expression, List<GenericExpressionNode> arglist)
+		{
+			GenericExpressionNode arg = Arg(expression);
+			arglist.Add(arg);
+			if (Same(expression, Token.TokenType.Comma))
+			{
+				Args(expression, arglist);
+			}
+		}
 
-        private GenericExpressionNode Arg(string expression)
-        {
-            Token current = this._lexer.CurrentToken;
-            if (Same(expression, Token.TokenType.String))
-            {
-                return new StringExpressionNode(current.String, current.Expandable);
-            }
-            else if (Same(expression, Token.TokenType.Numeric))
-            {
-                return new NumericExpressionNode(current.String);
-            }
-            else if (Same(expression, Token.TokenType.Property))
-            {
-                return new StringExpressionNode(current.String, true /* requires expansion */);
-            }
-            else if (Same(expression, Token.TokenType.ItemMetadata))
-            {
-                return new StringExpressionNode(current.String, true /* requires expansion */);
-            }
-            else if (Same(expression, Token.TokenType.ItemList))
-            {
-                return new StringExpressionNode(current.String, true /* requires expansion */);
-            }
-            else
-            {
-                return null;
-            }
-        }
+		private GenericExpressionNode Arg(string expression)
+		{
+			Token current = this._lexer.CurrentToken;
+			if (Same(expression, Token.TokenType.String))
+			{
+				return new StringExpressionNode(current.String, current.Expandable);
+			}
+			else if (Same(expression, Token.TokenType.Numeric))
+			{
+				return new NumericExpressionNode(current.String);
+			}
+			else if (Same(expression, Token.TokenType.Property))
+			{
+				return new StringExpressionNode(current.String, true /* requires expansion */);
+			}
+			else if (Same(expression, Token.TokenType.ItemMetadata))
+			{
+				return new StringExpressionNode(current.String, true /* requires expansion */);
+			}
+			else if (Same(expression, Token.TokenType.ItemList))
+			{
+				return new StringExpressionNode(current.String, true /* requires expansion */);
+			}
+			else
+			{
+				return null;
+			}
+		}
 
-        private bool Same(string expression, Token.TokenType token)
-        {
-            if (this._lexer.IsNext(token))
-            {
-                if (!this._lexer.Advance())
-                {
+		private bool Same(string expression, Token.TokenType token)
+		{
+			if (this._lexer.IsNext(token))
+			{
+				if (!this._lexer.Advance())
+				{
 					this.errorPosition = this._lexer.GetErrorPosition();
-                }
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-    }
+				}
+				return true;
+			}
+			else
+			{
+				return false;
+			}
+		}
+	}
 }

--- a/Project2015To2017.Core/Reading/Conditionals/Scanner.cs
+++ b/Project2015To2017.Core/Reading/Conditionals/Scanner.cs
@@ -7,303 +7,303 @@ using System.Globalization;
 
 namespace Project2015To2017.Reading.Conditionals
 {
-    /// <summary>
-    /// Class:       Scanner
-    /// This class does the scanning of the input and returns tokens.
-    /// The usage pattern is:
-    ///    Scanner s = new Scanner(expression, CultureInfo)
-    ///    do {
-    ///      s.Advance();
-    ///    while (s.IsNext(Token.EndOfInput));
-    /// 
-    ///  After Advance() is called, you can get the current token (s.CurrentToken),
-    ///  check it's type (s.IsNext()), get the string for it (s.NextString()).
-    /// </summary>
-    internal sealed class Scanner
-    {
-        private string _expression;
-        private int _parsePoint;
-        private Token _lookahead;
-        private bool _errorState;
-        private int _errorPosition;
-        // What we found instead of what we were looking for
-        private string _unexpectedlyFound = null;
-        private ParserOptions _options;
-        private string _errorResource = null;
-        private static string s_endOfInput = null;
+	/// <summary>
+	/// Class:       Scanner
+	/// This class does the scanning of the input and returns tokens.
+	/// The usage pattern is:
+	///    Scanner s = new Scanner(expression, CultureInfo)
+	///    do {
+	///      s.Advance();
+	///    while (s.IsNext(Token.EndOfInput));
+	/// 
+	///  After Advance() is called, you can get the current token (s.CurrentToken),
+	///  check it's type (s.IsNext()), get the string for it (s.NextString()).
+	/// </summary>
+	internal sealed class Scanner
+	{
+		private string _expression;
+		private int _parsePoint;
+		private Token _lookahead;
+		private bool _errorState;
+		private int _errorPosition;
+		// What we found instead of what we were looking for
+		private string _unexpectedlyFound = null;
+		private ParserOptions _options;
+		private string _errorResource = null;
+		private static string s_endOfInput = null;
 
-        /// <summary>
-        /// Lazily format resource string to help avoid (in some perf critical cases) even loading
-        /// resources at all.
-        /// </summary>
-        private string EndOfInput
-        {
-            get
-            {
-                if (s_endOfInput == null)
-                {
-                    s_endOfInput = "EndOfInputTokenName";
-                }
+		/// <summary>
+		/// Lazily format resource string to help avoid (in some perf critical cases) even loading
+		/// resources at all.
+		/// </summary>
+		private string EndOfInput
+		{
+			get
+			{
+				if (s_endOfInput == null)
+				{
+					s_endOfInput = "EndOfInputTokenName";
+				}
 
-                return s_endOfInput;
-            }
-        }
+				return s_endOfInput;
+			}
+		}
 
-        private Scanner() { }
-        //
-        // Constructor takes the string to parse and the culture.
-        //
-        internal Scanner(string expressionToParse, ParserOptions options)
-        {
-            // We currently have no support (and no scenarios) for disallowing property references
-            // in Conditions.
-            ErrorUtilities.VerifyThrow(0 != (options & ParserOptions.AllowProperties),
-                "Properties should always be allowed.");
+		private Scanner() { }
+		//
+		// Constructor takes the string to parse and the culture.
+		//
+		internal Scanner(string expressionToParse, ParserOptions options)
+		{
+			// We currently have no support (and no scenarios) for disallowing property references
+			// in Conditions.
+			ErrorUtilities.VerifyThrow(0 != (options & ParserOptions.AllowProperties),
+				"Properties should always be allowed.");
 
 			this._expression = expressionToParse;
 			this._parsePoint = 0;
 			this._errorState = false;
 			this._errorPosition = -1; // invalid
 			this._options = options;
-        }
+		}
 
-        /// <summary>
-        /// If the lexer errors, it has the best knowledge of the error message to show. For example,
-        /// 'unexpected character' or 'illformed operator'. This method returns the name of the resource
-        /// string that the parser should display.
-        /// </summary>
-        /// <remarks>Intentionally not a property getter to avoid the debugger triggering the Assert dialog</remarks>
-        /// <returns></returns>
-        internal string GetErrorResource()
-        {
-            if (this._errorResource == null)
-            {
-                // I do not believe this is reachable, but provide a reasonable default.
-                Debug.Assert(false, "What code path did not set an appropriate error resource? Expression: " + this._expression);
+		/// <summary>
+		/// If the lexer errors, it has the best knowledge of the error message to show. For example,
+		/// 'unexpected character' or 'illformed operator'. This method returns the name of the resource
+		/// string that the parser should display.
+		/// </summary>
+		/// <remarks>Intentionally not a property getter to avoid the debugger triggering the Assert dialog</remarks>
+		/// <returns></returns>
+		internal string GetErrorResource()
+		{
+			if (this._errorResource == null)
+			{
+				// I do not believe this is reachable, but provide a reasonable default.
+				Debug.Assert(false, "What code path did not set an appropriate error resource? Expression: " + this._expression);
 				this._unexpectedlyFound = this.EndOfInput;
-                return "UnexpectedCharacterInCondition";
-            }
-            else
-            {
-                return this._errorResource;
-            }
-        }
+				return "UnexpectedCharacterInCondition";
+			}
+			else
+			{
+				return this._errorResource;
+			}
+		}
 
-        internal bool IsNext(Token.TokenType type)
-        {
-            return this._lookahead.IsToken(type);
-        }
+		internal bool IsNext(Token.TokenType type)
+		{
+			return this._lookahead.IsToken(type);
+		}
 
-        internal string IsNextString()
-        {
-            return this._lookahead.String;
-        }
+		internal string IsNextString()
+		{
+			return this._lookahead.String;
+		}
 
-        internal Token CurrentToken
-        {
-            get { return this._lookahead; }
-        }
+		internal Token CurrentToken
+		{
+			get { return this._lookahead; }
+		}
 
-        internal int GetErrorPosition()
-        {
-            Debug.Assert(-1 != this._errorPosition); // We should have set it
-            return this._errorPosition;
-        }
+		internal int GetErrorPosition()
+		{
+			Debug.Assert(-1 != this._errorPosition); // We should have set it
+			return this._errorPosition;
+		}
 
-        // The string (usually a single character) we found unexpectedly. 
-        // We might want to show it in the error message, to help the user spot the error.
-        internal string UnexpectedlyFound
-        {
-            get
-            {
-                return this._unexpectedlyFound;
-            }
-        }
+		// The string (usually a single character) we found unexpectedly. 
+		// We might want to show it in the error message, to help the user spot the error.
+		internal string UnexpectedlyFound
+		{
+			get
+			{
+				return this._unexpectedlyFound;
+			}
+		}
 
-        /// <summary>
-        /// Advance
-        /// returns true on successful advance
-        ///     and false on an erroneous token
-        ///
-        /// Doesn't return error until the bogus input is encountered.
-        /// Advance() returns true even after EndOfInput is encountered.
-        /// </summary>
-        internal bool Advance()
-        {
-            if (this._errorState)
-                return false;
+		/// <summary>
+		/// Advance
+		/// returns true on successful advance
+		///     and false on an erroneous token
+		///
+		/// Doesn't return error until the bogus input is encountered.
+		/// Advance() returns true even after EndOfInput is encountered.
+		/// </summary>
+		internal bool Advance()
+		{
+			if (this._errorState)
+				return false;
 
-            if (this._lookahead != null && this._lookahead.IsToken(Token.TokenType.EndOfInput))
-                return true;
+			if (this._lookahead != null && this._lookahead.IsToken(Token.TokenType.EndOfInput))
+				return true;
 
-            SkipWhiteSpace();
+			SkipWhiteSpace();
 
 			// Update error position after skipping whitespace
 			this._errorPosition = this._parsePoint + 1;
 
-            if (this._parsePoint >= this._expression.Length)
-            {
+			if (this._parsePoint >= this._expression.Length)
+			{
 				this._lookahead = Token.EndOfInput;
-            }
-            else
-            {
-                switch (this._expression[this._parsePoint])
-                {
-                    case ',':
+			}
+			else
+			{
+				switch (this._expression[this._parsePoint])
+				{
+					case ',':
 						this._lookahead = Token.Comma;
 						this._parsePoint++;
-                        break;
-                    case '(':
+						break;
+					case '(':
 						this._lookahead = Token.LeftParenthesis;
 						this._parsePoint++;
-                        break;
-                    case ')':
+						break;
+					case ')':
 						this._lookahead = Token.RightParenthesis;
 						this._parsePoint++;
-                        break;
-                    case '$':
-                        if (!ParseProperty())
-                            return false;
-                        break;
-                    case '%':
-                        if (!ParseItemMetadata())
-                            return false;
-                        break;
-                    case '@':
-                        int start = this._parsePoint;
-                        // If the caller specified that he DOESN'T want to allow item lists ...
-                        if ((this._options & ParserOptions.AllowItemLists) == 0)
-                        {
-                            if ((this._parsePoint + 1) < this._expression.Length && this._expression[this._parsePoint + 1] == '(')
-                            {
+						break;
+					case '$':
+						if (!ParseProperty())
+							return false;
+						break;
+					case '%':
+						if (!ParseItemMetadata())
+							return false;
+						break;
+					case '@':
+						int start = this._parsePoint;
+						// If the caller specified that he DOESN'T want to allow item lists ...
+						if ((this._options & ParserOptions.AllowItemLists) == 0)
+						{
+							if ((this._parsePoint + 1) < this._expression.Length && this._expression[this._parsePoint + 1] == '(')
+							{
 								this._errorPosition = start + 1;
 								this._errorState = true;
 								this._errorResource = "ItemListNotAllowedInThisConditional";
-                                return false;
-                            }
-                        }
-                        if (!ParseItemList())
-                            return false;
-                        break;
-                    case '!':
-                        // negation and not-equal
-                        if ((this._parsePoint + 1) < this._expression.Length && this._expression[this._parsePoint + 1] == '=')
-                        {
+								return false;
+							}
+						}
+						if (!ParseItemList())
+							return false;
+						break;
+					case '!':
+						// negation and not-equal
+						if ((this._parsePoint + 1) < this._expression.Length && this._expression[this._parsePoint + 1] == '=')
+						{
 							this._lookahead = Token.NotEqualTo;
 							this._parsePoint += 2;
-                        }
-                        else
-                        {
+						}
+						else
+						{
 							this._lookahead = Token.Not;
 							this._parsePoint++;
-                        }
-                        break;
-                    case '>':
-                        // gt and gte
-                        if ((this._parsePoint + 1) < this._expression.Length && this._expression[this._parsePoint + 1] == '=')
-                        {
+						}
+						break;
+					case '>':
+						// gt and gte
+						if ((this._parsePoint + 1) < this._expression.Length && this._expression[this._parsePoint + 1] == '=')
+						{
 							this._lookahead = Token.GreaterThanOrEqualTo;
 							this._parsePoint += 2;
-                        }
-                        else
-                        {
+						}
+						else
+						{
 							this._lookahead = Token.GreaterThan;
 							this._parsePoint++;
-                        }
-                        break;
-                    case '<':
-                        // lt and lte
-                        if ((this._parsePoint + 1) < this._expression.Length && this._expression[this._parsePoint + 1] == '=')
-                        {
+						}
+						break;
+					case '<':
+						// lt and lte
+						if ((this._parsePoint + 1) < this._expression.Length && this._expression[this._parsePoint + 1] == '=')
+						{
 							this._lookahead = Token.LessThanOrEqualTo;
 							this._parsePoint += 2;
-                        }
-                        else
-                        {
+						}
+						else
+						{
 							this._lookahead = Token.LessThan;
 							this._parsePoint++;
-                        }
-                        break;
-                    case '=':
-                        if ((this._parsePoint + 1) < this._expression.Length && this._expression[this._parsePoint + 1] == '=')
-                        {
+						}
+						break;
+					case '=':
+						if ((this._parsePoint + 1) < this._expression.Length && this._expression[this._parsePoint + 1] == '=')
+						{
 							this._lookahead = Token.EqualTo;
 							this._parsePoint += 2;
-                        }
-                        else
-                        {
+						}
+						else
+						{
 							this._errorPosition = this._parsePoint + 2; // expression[parsePoint + 1], counting from 1
 							this._errorResource = "IllFormedEqualsInCondition";
-                            if ((this._parsePoint + 1) < this._expression.Length)
-                            {
+							if ((this._parsePoint + 1) < this._expression.Length)
+							{
 								// store the char we found instead
 								this._unexpectedlyFound = Convert.ToString(this._expression[this._parsePoint + 1], CultureInfo.InvariantCulture);
-                            }
-                            else
-                            {
+							}
+							else
+							{
 								this._unexpectedlyFound = this.EndOfInput;
-                            }
+							}
 							this._parsePoint++;
 							this._errorState = true;
-                            return false;
-                        }
-                        break;
-                    case '\'':
-                        if (!ParseQuotedString())
-                            return false;
-                        break;
-                    default:
-                        // Simple strings, function calls, decimal numbers, hex numbers
-                        if (!ParseRemaining())
-                            return false;
-                        break;
-                }
-            }
-            return true;
-        }
+							return false;
+						}
+						break;
+					case '\'':
+						if (!ParseQuotedString())
+							return false;
+						break;
+					default:
+						// Simple strings, function calls, decimal numbers, hex numbers
+						if (!ParseRemaining())
+							return false;
+						break;
+				}
+			}
+			return true;
+		}
 
-        /// <summary>
-        /// Parses either the $(propertyname) syntax or the %(metadataname) syntax, 
-        /// and returns the parsed string beginning with the '$' or '%', and ending with the
-        /// closing parenthesis.
-        /// </summary>
-        /// <returns></returns>
-        private string ParsePropertyOrItemMetadata()
-        {
-            int start = this._parsePoint; // set start so that we include "$(" or "%("
+		/// <summary>
+		/// Parses either the $(propertyname) syntax or the %(metadataname) syntax, 
+		/// and returns the parsed string beginning with the '$' or '%', and ending with the
+		/// closing parenthesis.
+		/// </summary>
+		/// <returns></returns>
+		private string ParsePropertyOrItemMetadata()
+		{
+			int start = this._parsePoint; // set start so that we include "$(" or "%("
 			this._parsePoint++;
 
-            if (this._parsePoint < this._expression.Length && this._expression[this._parsePoint] != '(')
-            {
+			if (this._parsePoint < this._expression.Length && this._expression[this._parsePoint] != '(')
+			{
 				this._errorState = true;
 				this._errorPosition = start + 1;
 				this._errorResource = "IllFormedPropertyOpenParenthesisInCondition";
 				this._unexpectedlyFound = Convert.ToString(this._expression[this._parsePoint], CultureInfo.InvariantCulture);
-                return null;
-            }
+				return null;
+			}
 
 			this._parsePoint = ScanForPropertyExpressionEnd(this._expression, this._parsePoint++);
 
-            // Maybe we need to generate an error for invalid characters in property/metadata name?
-            // For now, just wait and let the property/metadata evaluation handle the error case.
-            if (this._parsePoint >= this._expression.Length)
-            {
+			// Maybe we need to generate an error for invalid characters in property/metadata name?
+			// For now, just wait and let the property/metadata evaluation handle the error case.
+			if (this._parsePoint >= this._expression.Length)
+			{
 				this._errorState = true;
 				this._errorPosition = start + 1;
 				this._errorResource = "IllFormedPropertyCloseParenthesisInCondition";
 				this._unexpectedlyFound = this.EndOfInput;
-                return null;
-            }
+				return null;
+			}
 
 			this._parsePoint++;
-            return this._expression.Substring(start, this._parsePoint - start);
-        }
+			return this._expression.Substring(start, this._parsePoint - start);
+		}
 
-        /// <summary>
-        /// Scan for the end of the property expression
-        /// </summary>
-        private static int ScanForPropertyExpressionEnd(string expression, int index)
-        {
+		/// <summary>
+		/// Scan for the end of the property expression
+		/// </summary>
+		private static int ScanForPropertyExpressionEnd(string expression, int index)
+		{
 			int nestLevel = 0;
 
 			while (index < expression.Length)
@@ -334,350 +334,350 @@ namespace Project2015To2017.Reading.Conditionals
 			return index;
 		}
 
-        /// <summary>
-        /// Parses a string of the form $(propertyname).
-        /// </summary>
-        /// <returns></returns>
-        private bool ParseProperty()
-        {
-            string propertyExpression = this.ParsePropertyOrItemMetadata();
+		/// <summary>
+		/// Parses a string of the form $(propertyname).
+		/// </summary>
+		/// <returns></returns>
+		private bool ParseProperty()
+		{
+			string propertyExpression = this.ParsePropertyOrItemMetadata();
 
-            if (propertyExpression == null)
-            {
-                return false;
-            }
-            else
-            {
+			if (propertyExpression == null)
+			{
+				return false;
+			}
+			else
+			{
 				this._lookahead = new Token(Token.TokenType.Property, propertyExpression);
-                return true;
-            }
-        }
+				return true;
+			}
+		}
 
-        /// <summary>
-        /// Parses a string of the form %(itemmetadataname).
-        /// </summary>
-        /// <returns></returns>
-        private bool ParseItemMetadata()
-        {
-            string itemMetadataExpression = this.ParsePropertyOrItemMetadata();
+		/// <summary>
+		/// Parses a string of the form %(itemmetadataname).
+		/// </summary>
+		/// <returns></returns>
+		private bool ParseItemMetadata()
+		{
+			string itemMetadataExpression = this.ParsePropertyOrItemMetadata();
 
-            if (itemMetadataExpression == null)
-            {
+			if (itemMetadataExpression == null)
+			{
 				// The ParsePropertyOrItemMetadata method returns the correct error resources
 				// for parsing properties such as $(propertyname).  At this stage in the Whidbey
 				// cycle, we're not allowed to add new string resources, so I can't add a new
 				// resource specific to item metadata, so here, we just change the error to
 				// the generic "UnexpectedCharacter".
 				this._errorResource = "UnexpectedCharacterInCondition";
-                return false;
-            }
+				return false;
+			}
 
 			this._lookahead = new Token(Token.TokenType.ItemMetadata, itemMetadataExpression);
 
-            if (!CheckForUnexpectedMetadata(itemMetadataExpression))
-            {
-                return false;
-            }
+			if (!CheckForUnexpectedMetadata(itemMetadataExpression))
+			{
+				return false;
+			}
 
-            return true;
-        }
+			return true;
+		}
 
-        /// <summary>
-        /// Helper to verify that any AllowBuiltInMetadata or AllowCustomMetadata
-        /// specifications are not respected.
-        /// Returns true if it is ok, otherwise false.
-        /// </summary>
-        private bool CheckForUnexpectedMetadata(string expression)
-        {
-            if ((this._options & ParserOptions.AllowItemMetadata) == ParserOptions.AllowItemMetadata)
-            {
-                return true;
-            }
+		/// <summary>
+		/// Helper to verify that any AllowBuiltInMetadata or AllowCustomMetadata
+		/// specifications are not respected.
+		/// Returns true if it is ok, otherwise false.
+		/// </summary>
+		private bool CheckForUnexpectedMetadata(string expression)
+		{
+			if ((this._options & ParserOptions.AllowItemMetadata) == ParserOptions.AllowItemMetadata)
+			{
+				return true;
+			}
 
-            return true;
-        }
+			return true;
+		}
 
-        private bool ParseInternalItemList()
-        {
-            int start = this._parsePoint;
+		private bool ParseInternalItemList()
+		{
+			int start = this._parsePoint;
 			this._parsePoint++;
 
-            if (this._parsePoint < this._expression.Length && this._expression[this._parsePoint] != '(')
-            {
+			if (this._parsePoint < this._expression.Length && this._expression[this._parsePoint] != '(')
+			{
 				// @ was not followed by (
 				this._errorPosition = start + 1;
 				this._errorResource = "IllFormedItemListOpenParenthesisInCondition";
 				// Not useful to set unexpectedlyFound here. The message is going to be detailed enough.
 				this._errorState = true;
-                return false;
-            }
+				return false;
+			}
 			this._parsePoint++;
-            // Maybe we need to generate an error for invalid characters in itemgroup name?
-            // For now, just let item evaluation handle the error.
-            bool fInReplacement = false;
-            int parenToClose = 0;
-            while (this._parsePoint < this._expression.Length)
-            {
-                if (this._expression[this._parsePoint] == '\'')
-                {
-                    fInReplacement = !fInReplacement;
-                }
-                else if (this._expression[this._parsePoint] == '(' && !fInReplacement)
-                {
-                    parenToClose++;
-                }
-                else if (this._expression[this._parsePoint] == ')' && !fInReplacement)
-                {
-                    if (parenToClose == 0)
-                    {
-                        break;
-                    }
-                    else { parenToClose--; }
-                }
+			// Maybe we need to generate an error for invalid characters in itemgroup name?
+			// For now, just let item evaluation handle the error.
+			bool fInReplacement = false;
+			int parenToClose = 0;
+			while (this._parsePoint < this._expression.Length)
+			{
+				if (this._expression[this._parsePoint] == '\'')
+				{
+					fInReplacement = !fInReplacement;
+				}
+				else if (this._expression[this._parsePoint] == '(' && !fInReplacement)
+				{
+					parenToClose++;
+				}
+				else if (this._expression[this._parsePoint] == ')' && !fInReplacement)
+				{
+					if (parenToClose == 0)
+					{
+						break;
+					}
+					else { parenToClose--; }
+				}
 				this._parsePoint++;
-            }
-            if (this._parsePoint >= this._expression.Length)
-            {
+			}
+			if (this._parsePoint >= this._expression.Length)
+			{
 				this._errorPosition = start + 1;
-                if (fInReplacement)
-                {
+				if (fInReplacement)
+				{
 					// @( ... ' was never followed by a closing quote before the closing parenthesis
 					this._errorResource = "IllFormedItemListQuoteInCondition";
-                }
-                else
-                {
+				}
+				else
+				{
 					// @( was never followed by a )
 					this._errorResource = "IllFormedItemListCloseParenthesisInCondition";
-                }
+				}
 				// Not useful to set unexpectedlyFound here. The message is going to be detailed enough.
 				this._errorState = true;
-                return false;
-            }
+				return false;
+			}
 			this._parsePoint++;
-            return true;
-        }
+			return true;
+		}
 
-        private bool ParseItemList()
-        {
-            int start = this._parsePoint;
-            if (!ParseInternalItemList())
-            {
-                return false;
-            }
+		private bool ParseItemList()
+		{
+			int start = this._parsePoint;
+			if (!ParseInternalItemList())
+			{
+				return false;
+			}
 			this._lookahead = new Token(Token.TokenType.ItemList, this._expression.Substring(start, this._parsePoint - start));
-            return true;
-        }
+			return true;
+		}
 
-        /// <summary>
-        /// Parse any part of the conditional expression that is quoted. It may contain a property, item, or 
-        /// metadata element that needs expansion during evaluation.
-        /// </summary>
-        private bool ParseQuotedString()
-        {
+		/// <summary>
+		/// Parse any part of the conditional expression that is quoted. It may contain a property, item, or 
+		/// metadata element that needs expansion during evaluation.
+		/// </summary>
+		private bool ParseQuotedString()
+		{
 			this._parsePoint++;
-            int start = this._parsePoint;
-            bool expandable = false;
-            while (this._parsePoint < this._expression.Length && this._expression[this._parsePoint] != '\'')
-            {
-                // Standalone percent-sign must be allowed within a condition because it's
-                // needed to escape special characters.  However, percent-sign followed
-                // by open-parenthesis is an indication of an item metadata reference, and
-                // that is only allowed in certain contexts.
-                if ((this._expression[this._parsePoint] == '%') && ((this._parsePoint + 1) < this._expression.Length) && (this._expression[this._parsePoint + 1] == '('))
-                {
-                    expandable = true;
-                    string name = String.Empty;
+			int start = this._parsePoint;
+			bool expandable = false;
+			while (this._parsePoint < this._expression.Length && this._expression[this._parsePoint] != '\'')
+			{
+				// Standalone percent-sign must be allowed within a condition because it's
+				// needed to escape special characters.  However, percent-sign followed
+				// by open-parenthesis is an indication of an item metadata reference, and
+				// that is only allowed in certain contexts.
+				if ((this._expression[this._parsePoint] == '%') && ((this._parsePoint + 1) < this._expression.Length) && (this._expression[this._parsePoint + 1] == '('))
+				{
+					expandable = true;
+					string name = String.Empty;
 
-                    int endOfName = this._expression.IndexOf(')', this._parsePoint) - 1;
-                    if (endOfName < 0)
-                    {
-                        endOfName = this._expression.Length - 1;
-                    }
+					int endOfName = this._expression.IndexOf(')', this._parsePoint) - 1;
+					if (endOfName < 0)
+					{
+						endOfName = this._expression.Length - 1;
+					}
 
-                    // If it's %(a.b) the name is just 'b'
-                    if (this._parsePoint + 3 < this._expression.Length)
-                    {
-                        name = this._expression.Substring(this._parsePoint + 2, (endOfName - this._parsePoint - 2 + 1));
-                    }
+					// If it's %(a.b) the name is just 'b'
+					if (this._parsePoint + 3 < this._expression.Length)
+					{
+						name = this._expression.Substring(this._parsePoint + 2, (endOfName - this._parsePoint - 2 + 1));
+					}
 
-                    if (!CheckForUnexpectedMetadata(name))
-                    {
-                        return false;
-                    }
-                }
-                else if (this._expression[this._parsePoint] == '@' && ((this._parsePoint + 1) < this._expression.Length) && (this._expression[this._parsePoint + 1] == '('))
-                {
-                    expandable = true;
+					if (!CheckForUnexpectedMetadata(name))
+					{
+						return false;
+					}
+				}
+				else if (this._expression[this._parsePoint] == '@' && ((this._parsePoint + 1) < this._expression.Length) && (this._expression[this._parsePoint + 1] == '('))
+				{
+					expandable = true;
 
-                    // If the caller specified that he DOESN'T want to allow item lists ...
-                    if ((this._options & ParserOptions.AllowItemLists) == 0)
-                    {
+					// If the caller specified that he DOESN'T want to allow item lists ...
+					if ((this._options & ParserOptions.AllowItemLists) == 0)
+					{
 						this._errorPosition = start + 1;
 						this._errorState = true;
 						this._errorResource = "ItemListNotAllowedInThisConditional";
-                        return false;
-                    }
+						return false;
+					}
 
-                    // Item lists have to be parsed because of the replacement syntax e.g. @(Foo,'_').
-                    // I have to know how to parse those so I can skip over the tic marks.  I don't
-                    // have to do that with other things like propertygroups, hence itemlists are
-                    // treated specially.
+					// Item lists have to be parsed because of the replacement syntax e.g. @(Foo,'_').
+					// I have to know how to parse those so I can skip over the tic marks.  I don't
+					// have to do that with other things like propertygroups, hence itemlists are
+					// treated specially.
 
-                    ParseInternalItemList();
-                    continue;
-                }
-                else if (this._expression[this._parsePoint] == '$' && ((this._parsePoint + 1) < this._expression.Length) && (this._expression[this._parsePoint + 1] == '('))
-                {
-                    expandable = true;
-                }
-                else if (this._expression[this._parsePoint] == '%')
-                {
-                    // There may be some escaped characters in the expression
-                    expandable = true;
-                }
+					ParseInternalItemList();
+					continue;
+				}
+				else if (this._expression[this._parsePoint] == '$' && ((this._parsePoint + 1) < this._expression.Length) && (this._expression[this._parsePoint + 1] == '('))
+				{
+					expandable = true;
+				}
+				else if (this._expression[this._parsePoint] == '%')
+				{
+					// There may be some escaped characters in the expression
+					expandable = true;
+				}
 				this._parsePoint++;
-            }
+			}
 
-            if (this._parsePoint >= this._expression.Length)
-            {
+			if (this._parsePoint >= this._expression.Length)
+			{
 				// Quoted string wasn't closed
 				this._errorState = true;
 				this._errorPosition = start; // The message is going to say "expected after position n" so don't add 1 here.
 				this._errorResource = "IllFormedQuotedStringInCondition";
-                // Not useful to set unexpectedlyFound here. By definition it got to the end of the string.
-                return false;
-            }
-            string originalTokenString = this._expression.Substring(start, this._parsePoint - start);
+				// Not useful to set unexpectedlyFound here. By definition it got to the end of the string.
+				return false;
+			}
+			string originalTokenString = this._expression.Substring(start, this._parsePoint - start);
 
 			this._lookahead = new Token(Token.TokenType.String, originalTokenString, expandable);
 			this._parsePoint++;
-            return true;
-        }
+			return true;
+		}
 
-        private bool ParseRemaining()
-        {
-            int start = this._parsePoint;
-            if (CharacterUtilities.IsNumberStart(this._expression[this._parsePoint])) // numeric
-            {
-                if (!ParseNumeric(start))
-                    return false;
-            }
-            else if (CharacterUtilities.IsSimpleStringStart(this._expression[this._parsePoint])) // simple string (handle 'and' and 'or')
-            {
-                if (!ParseSimpleStringOrFunction(start))
-                    return false;
-            }
-            else
-            {
+		private bool ParseRemaining()
+		{
+			int start = this._parsePoint;
+			if (CharacterUtilities.IsNumberStart(this._expression[this._parsePoint])) // numeric
+			{
+				if (!ParseNumeric(start))
+					return false;
+			}
+			else if (CharacterUtilities.IsSimpleStringStart(this._expression[this._parsePoint])) // simple string (handle 'and' and 'or')
+			{
+				if (!ParseSimpleStringOrFunction(start))
+					return false;
+			}
+			else
+			{
 				// Something that wasn't a number or a letter, like a newline (%0a)
 				this._errorState = true;
 				this._errorPosition = start + 1;
 				this._errorResource = "UnexpectedCharacterInCondition";
 				this._unexpectedlyFound = Convert.ToString(this._expression[this._parsePoint], CultureInfo.InvariantCulture);
-                return false;
-            }
-            return true;
-        }
+				return false;
+			}
+			return true;
+		}
 
-        // There is a bug here that spaces are not required around 'and' and 'or'. For example,
-        // this works perfectly well:
-        // Condition="%(a.Identity)!=''and%(a.m)=='1'"
-        // Since people now depend on this behavior, we must not change it.
-        private bool ParseSimpleStringOrFunction(int start)
-        {
-            SkipSimpleStringChars();
-            if (0 == string.Compare(this._expression.Substring(start, this._parsePoint - start), "and", StringComparison.OrdinalIgnoreCase))
-            {
+		// There is a bug here that spaces are not required around 'and' and 'or'. For example,
+		// this works perfectly well:
+		// Condition="%(a.Identity)!=''and%(a.m)=='1'"
+		// Since people now depend on this behavior, we must not change it.
+		private bool ParseSimpleStringOrFunction(int start)
+		{
+			SkipSimpleStringChars();
+			if (0 == string.Compare(this._expression.Substring(start, this._parsePoint - start), "and", StringComparison.OrdinalIgnoreCase))
+			{
 				this._lookahead = Token.And;
-            }
-            else if (0 == string.Compare(this._expression.Substring(start, this._parsePoint - start), "or", StringComparison.OrdinalIgnoreCase))
-            {
+			}
+			else if (0 == string.Compare(this._expression.Substring(start, this._parsePoint - start), "or", StringComparison.OrdinalIgnoreCase))
+			{
 				this._lookahead = Token.Or;
-            }
-            else
-            {
-                int end = this._parsePoint;
-                SkipWhiteSpace();
-                if (this._parsePoint < this._expression.Length && this._expression[this._parsePoint] == '(')
-                {
+			}
+			else
+			{
+				int end = this._parsePoint;
+				SkipWhiteSpace();
+				if (this._parsePoint < this._expression.Length && this._expression[this._parsePoint] == '(')
+				{
 					this._lookahead = new Token(Token.TokenType.Function, this._expression.Substring(start, end - start));
-                }
-                else
-                {
-                    string tokenValue = this._expression.Substring(start, end - start);
+				}
+				else
+				{
+					string tokenValue = this._expression.Substring(start, end - start);
 					this._lookahead = new Token(Token.TokenType.String, tokenValue);
-                }
-            }
-            return true;
-        }
-        private bool ParseNumeric(int start)
-        {
-            if ((this._expression.Length - this._parsePoint) > 2 && this._expression[this._parsePoint] == '0' && (this._expression[this._parsePoint + 1] == 'x' || this._expression[this._parsePoint + 1] == 'X'))
-            {
+				}
+			}
+			return true;
+		}
+		private bool ParseNumeric(int start)
+		{
+			if ((this._expression.Length - this._parsePoint) > 2 && this._expression[this._parsePoint] == '0' && (this._expression[this._parsePoint + 1] == 'x' || this._expression[this._parsePoint + 1] == 'X'))
+			{
 				// Hex number
 				this._parsePoint += 2;
-                SkipHexDigits();
+				SkipHexDigits();
 				this._lookahead = new Token(Token.TokenType.Numeric, this._expression.Substring(start, this._parsePoint - start));
-            }
-            else if (CharacterUtilities.IsNumberStart(this._expression[this._parsePoint]))
-            {
-                // Decimal number
-                if (this._expression[this._parsePoint] == '+')
-                {
+			}
+			else if (CharacterUtilities.IsNumberStart(this._expression[this._parsePoint]))
+			{
+				// Decimal number
+				if (this._expression[this._parsePoint] == '+')
+				{
 					this._parsePoint++;
-                }
-                else if (this._expression[this._parsePoint] == '-')
-                {
+				}
+				else if (this._expression[this._parsePoint] == '-')
+				{
 					this._parsePoint++;
-                }
-                do
-                {
-                    SkipDigits();
-                    if (this._parsePoint < this._expression.Length && this._expression[this._parsePoint] == '.')
-                    {
+				}
+				do
+				{
+					SkipDigits();
+					if (this._parsePoint < this._expression.Length && this._expression[this._parsePoint] == '.')
+					{
 						this._parsePoint++;
-                    }
-                    if (this._parsePoint < this._expression.Length)
-                    {
-                        SkipDigits();
-                    }
-                } while (this._parsePoint < this._expression.Length && this._expression[this._parsePoint] == '.');
+					}
+					if (this._parsePoint < this._expression.Length)
+					{
+						SkipDigits();
+					}
+				} while (this._parsePoint < this._expression.Length && this._expression[this._parsePoint] == '.');
 				// Do we need to error on malformed input like 0.00.00)? or will the conversion handle it?
 				// For now, let the conversion generate the error.
 				this._lookahead = new Token(Token.TokenType.Numeric, this._expression.Substring(start, this._parsePoint - start));
-            }
-            else
-            {
+			}
+			else
+			{
 				// Unreachable
 				this._errorState = true;
 				this._errorPosition = start + 1;
-                return false;
-            }
-            return true;
-        }
-        private void SkipWhiteSpace()
-        {
-            while (this._parsePoint < this._expression.Length && char.IsWhiteSpace(this._expression[this._parsePoint]))
+				return false;
+			}
+			return true;
+		}
+		private void SkipWhiteSpace()
+		{
+			while (this._parsePoint < this._expression.Length && char.IsWhiteSpace(this._expression[this._parsePoint]))
 				this._parsePoint++;
-            return;
-        }
-        private void SkipDigits()
-        {
-            while (this._parsePoint < this._expression.Length && char.IsDigit(this._expression[this._parsePoint]))
+			return;
+		}
+		private void SkipDigits()
+		{
+			while (this._parsePoint < this._expression.Length && char.IsDigit(this._expression[this._parsePoint]))
 				this._parsePoint++;
-            return;
-        }
-        private void SkipHexDigits()
-        {
-            while (this._parsePoint < this._expression.Length && CharacterUtilities.IsHexDigit(this._expression[this._parsePoint]))
+			return;
+		}
+		private void SkipHexDigits()
+		{
+			while (this._parsePoint < this._expression.Length && CharacterUtilities.IsHexDigit(this._expression[this._parsePoint]))
 				this._parsePoint++;
-            return;
-        }
-        private void SkipSimpleStringChars()
-        {
-            while (this._parsePoint < this._expression.Length && CharacterUtilities.IsSimpleStringChar(this._expression[this._parsePoint]))
+			return;
+		}
+		private void SkipSimpleStringChars()
+		{
+			while (this._parsePoint < this._expression.Length && CharacterUtilities.IsSimpleStringChar(this._expression[this._parsePoint]))
 				this._parsePoint++;
-            return;
-        }
-    }
+			return;
+		}
+	}
 }

--- a/Project2015To2017.Core/Reading/Conditionals/StringExpressionNode.cs
+++ b/Project2015To2017.Core/Reading/Conditionals/StringExpressionNode.cs
@@ -6,139 +6,139 @@ using System.Diagnostics;
 
 namespace Project2015To2017.Reading.Conditionals
 {
-    /// <summary>
-    /// Node representing a string
-    /// </summary>
-    [DebuggerDisplay("{DebuggerDisplay,nq}")]
-    internal sealed class StringExpressionNode : OperandExpressionNode
-    {
-        private string _value;
-        private string _cachedExpandedValue;
+	/// <summary>
+	/// Node representing a string
+	/// </summary>
+	[DebuggerDisplay("{DebuggerDisplay,nq}")]
+	internal sealed class StringExpressionNode : OperandExpressionNode
+	{
+		private string _value;
+		private string _cachedExpandedValue;
 
-        /// <summary>
-        /// Whether the string potentially has expandable content,
-        /// such as a property expression or escaped character.
-        /// </summary>
-        private bool _expandable;
+		/// <summary>
+		/// Whether the string potentially has expandable content,
+		/// such as a property expression or escaped character.
+		/// </summary>
+		private bool _expandable;
 
-        internal StringExpressionNode(string value, bool expandable)
-        {
+		internal StringExpressionNode(string value, bool expandable)
+		{
 			this._value = value;
 			this._expandable = expandable;
-        }
+		}
 
-        /// <summary>
-        /// Evaluate as boolean
-        /// </summary>
-        internal override bool BoolEvaluate(IConditionEvaluationState state)
-        {
-            return ConversionUtilities.ConvertStringToBool(GetExpandedValue(state));
-        }
+		/// <summary>
+		/// Evaluate as boolean
+		/// </summary>
+		internal override bool BoolEvaluate(IConditionEvaluationState state)
+		{
+			return ConversionUtilities.ConvertStringToBool(GetExpandedValue(state));
+		}
 
-        /// <summary>
-        /// Evaluate as numeric
-        /// </summary>
-        internal override double NumericEvaluate(IConditionEvaluationState state)
-        {
-            return ConversionUtilities.ConvertDecimalOrHexToDouble(GetExpandedValue(state));
-        }
+		/// <summary>
+		/// Evaluate as numeric
+		/// </summary>
+		internal override double NumericEvaluate(IConditionEvaluationState state)
+		{
+			return ConversionUtilities.ConvertDecimalOrHexToDouble(GetExpandedValue(state));
+		}
 
-        internal override Version VersionEvaluate(IConditionEvaluationState state)
-        {
-            return Version.Parse(GetExpandedValue(state));
-        }
+		internal override Version VersionEvaluate(IConditionEvaluationState state)
+		{
+			return Version.Parse(GetExpandedValue(state));
+		}
 
-        internal override bool CanBoolEvaluate(IConditionEvaluationState state)
-        {
-            return ConversionUtilities.CanConvertStringToBool(GetExpandedValue(state));
-        }
+		internal override bool CanBoolEvaluate(IConditionEvaluationState state)
+		{
+			return ConversionUtilities.CanConvertStringToBool(GetExpandedValue(state));
+		}
 
-        internal override bool CanNumericEvaluate(IConditionEvaluationState state)
-        {
-            return ConversionUtilities.ValidDecimalOrHexNumber(GetExpandedValue(state));
-        }
+		internal override bool CanNumericEvaluate(IConditionEvaluationState state)
+		{
+			return ConversionUtilities.ValidDecimalOrHexNumber(GetExpandedValue(state));
+		}
 
-        internal override bool CanVersionEvaluate(IConditionEvaluationState state)
-        {
-            Version unused;
-            return Version.TryParse(GetExpandedValue(state), out unused);
-        }
+		internal override bool CanVersionEvaluate(IConditionEvaluationState state)
+		{
+			Version unused;
+			return Version.TryParse(GetExpandedValue(state), out unused);
+		}
 
-        /// <summary>
-        /// Returns true if this node evaluates to an empty string,
-        /// otherwise false.
-        /// It may be cheaper to determine whether an expression will evaluate
-        /// to empty than to fully evaluate it.
-        /// Implementations should cache the result so that calls after the first are free.
-        /// </summary>
-        internal override bool EvaluatesToEmpty(IConditionEvaluationState state)
-        {
-            if (this._cachedExpandedValue == null)
-            {
-                if (this._expandable)
-                {
-                    string expandBreakEarly = state.ExpandIntoStringBreakEarly(this._value);
+		/// <summary>
+		/// Returns true if this node evaluates to an empty string,
+		/// otherwise false.
+		/// It may be cheaper to determine whether an expression will evaluate
+		/// to empty than to fully evaluate it.
+		/// Implementations should cache the result so that calls after the first are free.
+		/// </summary>
+		internal override bool EvaluatesToEmpty(IConditionEvaluationState state)
+		{
+			if (this._cachedExpandedValue == null)
+			{
+				if (this._expandable)
+				{
+					string expandBreakEarly = state.ExpandIntoStringBreakEarly(this._value);
 
-                    if (expandBreakEarly == null)
-                    {
-                        // It broke early: we can't store the value, we just
-                        // know it's non empty
-                        return false;
-                    }
+					if (expandBreakEarly == null)
+					{
+						// It broke early: we can't store the value, we just
+						// know it's non empty
+						return false;
+					}
 
 					// It didn't break early, the result is accurate,
 					// so store it so the work isn't done again.
 					this._cachedExpandedValue = expandBreakEarly;
-                }
-                else
-                {
+				}
+				else
+				{
 					this._cachedExpandedValue = this._value;
-                }
-            }
+				}
+			}
 
-            return (this._cachedExpandedValue.Length == 0);
-        }
+			return (this._cachedExpandedValue.Length == 0);
+		}
 
 
-        /// <summary>
-        /// Value before any item and property expressions are expanded
-        /// </summary>
-        /// <returns></returns>
-        internal override string GetUnexpandedValue(IConditionEvaluationState state)
-        {
-            return this._value;
-        }
+		/// <summary>
+		/// Value before any item and property expressions are expanded
+		/// </summary>
+		/// <returns></returns>
+		internal override string GetUnexpandedValue(IConditionEvaluationState state)
+		{
+			return this._value;
+		}
 
-        /// <summary>
-        /// Value after any item and property expressions are expanded
-        /// </summary>
-        /// <returns></returns>
-        internal override string GetExpandedValue(IConditionEvaluationState state)
-        {
-            if (this._cachedExpandedValue == null)
-            {
-                if (this._expandable)
-                {
+		/// <summary>
+		/// Value after any item and property expressions are expanded
+		/// </summary>
+		/// <returns></returns>
+		internal override string GetExpandedValue(IConditionEvaluationState state)
+		{
+			if (this._cachedExpandedValue == null)
+			{
+				if (this._expandable)
+				{
 					this._cachedExpandedValue = state.ExpandIntoString(this._value);
-                }
-                else
-                {
+				}
+				else
+				{
 					this._cachedExpandedValue = this._value;
-                }
-            }
+				}
+			}
 
-            return this._cachedExpandedValue;
-        }
+			return this._cachedExpandedValue;
+		}
 
-        /// <summary>
-        /// If any expression nodes cache any state for the duration of evaluation, 
-        /// now's the time to clean it up
-        /// </summary>
-        internal override void ResetState()
-        {
+		/// <summary>
+		/// If any expression nodes cache any state for the duration of evaluation, 
+		/// now's the time to clean it up
+		/// </summary>
+		internal override void ResetState()
+		{
 			this._cachedExpandedValue = null;
-        }
+		}
 
-        internal override string DebuggerDisplay => $"\"{this._value}\"";
-    }
+		internal override string DebuggerDisplay => $"\"{this._value}\"";
+	}
 }

--- a/Project2015To2017.Core/Reading/Conditionals/Token.cs
+++ b/Project2015To2017.Core/Reading/Conditionals/Token.cs
@@ -3,153 +3,153 @@
 
 namespace Project2015To2017.Reading.Conditionals
 {
-    /// <summary>
-    /// This class represents a token in the Complex Conditionals grammar.  It's
-    /// really just a bag that contains the type of the token and the string that
-    /// was parsed into the token.  This isn't very useful for operators, but
-    /// is useful for strings and such.
-    /// </summary>
-    internal sealed class Token
-    {
-        internal readonly static Token Comma = new Token(TokenType.Comma);
-        internal readonly static Token LeftParenthesis = new Token(TokenType.LeftParenthesis);
-        internal readonly static Token RightParenthesis = new Token(TokenType.RightParenthesis);
-        internal readonly static Token LessThan = new Token(TokenType.LessThan);
-        internal readonly static Token GreaterThan = new Token(TokenType.GreaterThan);
-        internal readonly static Token LessThanOrEqualTo = new Token(TokenType.LessThanOrEqualTo);
-        internal readonly static Token GreaterThanOrEqualTo = new Token(TokenType.GreaterThanOrEqualTo);
-        internal readonly static Token And = new Token(TokenType.And);
-        internal readonly static Token Or = new Token(TokenType.Or);
-        internal readonly static Token EqualTo = new Token(TokenType.EqualTo);
-        internal readonly static Token NotEqualTo = new Token(TokenType.NotEqualTo);
-        internal readonly static Token Not = new Token(TokenType.Not);
-        internal readonly static Token EndOfInput = new Token(TokenType.EndOfInput);
+	/// <summary>
+	/// This class represents a token in the Complex Conditionals grammar.  It's
+	/// really just a bag that contains the type of the token and the string that
+	/// was parsed into the token.  This isn't very useful for operators, but
+	/// is useful for strings and such.
+	/// </summary>
+	internal sealed class Token
+	{
+		internal readonly static Token Comma = new Token(TokenType.Comma);
+		internal readonly static Token LeftParenthesis = new Token(TokenType.LeftParenthesis);
+		internal readonly static Token RightParenthesis = new Token(TokenType.RightParenthesis);
+		internal readonly static Token LessThan = new Token(TokenType.LessThan);
+		internal readonly static Token GreaterThan = new Token(TokenType.GreaterThan);
+		internal readonly static Token LessThanOrEqualTo = new Token(TokenType.LessThanOrEqualTo);
+		internal readonly static Token GreaterThanOrEqualTo = new Token(TokenType.GreaterThanOrEqualTo);
+		internal readonly static Token And = new Token(TokenType.And);
+		internal readonly static Token Or = new Token(TokenType.Or);
+		internal readonly static Token EqualTo = new Token(TokenType.EqualTo);
+		internal readonly static Token NotEqualTo = new Token(TokenType.NotEqualTo);
+		internal readonly static Token Not = new Token(TokenType.Not);
+		internal readonly static Token EndOfInput = new Token(TokenType.EndOfInput);
 
-        /// <summary>
-        /// Valid tokens
-        /// </summary>
-        internal enum TokenType
-        {
-            Comma, LeftParenthesis, RightParenthesis,
-            LessThan, GreaterThan, LessThanOrEqualTo, GreaterThanOrEqualTo,
-            And, Or,
-            EqualTo, NotEqualTo, Not,
-            Property, String, Numeric, ItemList, ItemMetadata, Function,
-            EndOfInput
-        };
+		/// <summary>
+		/// Valid tokens
+		/// </summary>
+		internal enum TokenType
+		{
+			Comma, LeftParenthesis, RightParenthesis,
+			LessThan, GreaterThan, LessThanOrEqualTo, GreaterThanOrEqualTo,
+			And, Or,
+			EqualTo, NotEqualTo, Not,
+			Property, String, Numeric, ItemList, ItemMetadata, Function,
+			EndOfInput
+		};
 
-        private TokenType _tokenType;
-        private string _tokenString;
+		private TokenType _tokenType;
+		private string _tokenString;
 
-        /// <summary>
-        /// Constructor for types that don't have values
-        /// </summary>
-        /// <param name="tokenType"></param>
-        private Token(TokenType tokenType)
-        {
+		/// <summary>
+		/// Constructor for types that don't have values
+		/// </summary>
+		/// <param name="tokenType"></param>
+		private Token(TokenType tokenType)
+		{
 			this._tokenType = tokenType;
 			this._tokenString = null;
-        }
+		}
 
-        /// <summary>
-        /// Constructor takes the token type and the string that
-        /// represents the token
-        /// </summary>
-        /// <param name="type"></param>
-        /// <param name="tokenString"></param>
-        internal Token(TokenType type, string tokenString)
-            : this(type, tokenString, false /* not expandable */)
-        { }
+		/// <summary>
+		/// Constructor takes the token type and the string that
+		/// represents the token
+		/// </summary>
+		/// <param name="type"></param>
+		/// <param name="tokenString"></param>
+		internal Token(TokenType type, string tokenString)
+			: this(type, tokenString, false /* not expandable */)
+		{ }
 
-        /// <summary>
-        /// Constructor takes the token type and the string that
-        /// represents the token.
-        /// If the string may contain content that needs expansion, expandable is set.
-        /// </summary>
-        internal Token(TokenType type, string tokenString, bool expandable)
-        {
-            ErrorUtilities.VerifyThrow
-                (
-                type == TokenType.Property ||
-                type == TokenType.String ||
-                type == TokenType.Numeric ||
-                type == TokenType.ItemList ||
-                type == TokenType.ItemMetadata ||
-                type == TokenType.Function,
-                "Unexpected token type"
-                );
+		/// <summary>
+		/// Constructor takes the token type and the string that
+		/// represents the token.
+		/// If the string may contain content that needs expansion, expandable is set.
+		/// </summary>
+		internal Token(TokenType type, string tokenString, bool expandable)
+		{
+			ErrorUtilities.VerifyThrow
+				(
+				type == TokenType.Property ||
+				type == TokenType.String ||
+				type == TokenType.Numeric ||
+				type == TokenType.ItemList ||
+				type == TokenType.ItemMetadata ||
+				type == TokenType.Function,
+				"Unexpected token type"
+				);
 
-            ErrorUtilities.VerifyThrowInternalNull(tokenString, "tokenString");
+			ErrorUtilities.VerifyThrowInternalNull(tokenString, "tokenString");
 
 			this._tokenType = type;
 			this._tokenString = tokenString;
-            this.Expandable = expandable;
-        }
+			this.Expandable = expandable;
+		}
 
-        /// <summary>
-        /// Whether the content potentially has expandable content,
-        /// such as a property expression or escaped character.
-        /// </summary>
-        internal bool Expandable
-        {
-            get;
-            set;
-        }
+		/// <summary>
+		/// Whether the content potentially has expandable content,
+		/// such as a property expression or escaped character.
+		/// </summary>
+		internal bool Expandable
+		{
+			get;
+			set;
+		}
 
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="type"></param>
-        /// <returns></returns>
-        internal bool IsToken(TokenType type)
-        {
-            return this._tokenType == type;
-        }
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="type"></param>
+		/// <returns></returns>
+		internal bool IsToken(TokenType type)
+		{
+			return this._tokenType == type;
+		}
 
-        internal string String
-        {
-            get
-            {
-                if (this._tokenString != null)
-                {
-                    return this._tokenString;
-                }
+		internal string String
+		{
+			get
+			{
+				if (this._tokenString != null)
+				{
+					return this._tokenString;
+				}
 
-                // Return a token string for 
-                // an error message.
-                switch (this._tokenType)
-                {
-                    case TokenType.Comma:
-                        return ",";
-                    case TokenType.LeftParenthesis:
-                        return "(";
-                    case TokenType.RightParenthesis:
-                        return ")";
-                    case TokenType.LessThan:
-                        return "<";
-                    case TokenType.GreaterThan:
-                        return ">";
-                    case TokenType.LessThanOrEqualTo:
-                        return "<=";
-                    case TokenType.GreaterThanOrEqualTo:
-                        return ">=";
-                    case TokenType.And:
-                        return "and";
-                    case TokenType.Or:
-                        return "or";
-                    case TokenType.EqualTo:
-                        return "==";
-                    case TokenType.NotEqualTo:
-                        return "!=";
-                    case TokenType.Not:
-                        return "!";
-                    case TokenType.EndOfInput:
-                        return null;
-                    default:
-                        ErrorUtilities.ThrowInternalErrorUnreachable();
-                        return null;
-                }
-            }
-        }
-    }
+				// Return a token string for 
+				// an error message.
+				switch (this._tokenType)
+				{
+					case TokenType.Comma:
+						return ",";
+					case TokenType.LeftParenthesis:
+						return "(";
+					case TokenType.RightParenthesis:
+						return ")";
+					case TokenType.LessThan:
+						return "<";
+					case TokenType.GreaterThan:
+						return ">";
+					case TokenType.LessThanOrEqualTo:
+						return "<=";
+					case TokenType.GreaterThanOrEqualTo:
+						return ">=";
+					case TokenType.And:
+						return "and";
+					case TokenType.Or:
+						return "or";
+					case TokenType.EqualTo:
+						return "==";
+					case TokenType.NotEqualTo:
+						return "!=";
+					case TokenType.Not:
+						return "!";
+					case TokenType.EndOfInput:
+						return null;
+					default:
+						ErrorUtilities.ThrowInternalErrorUnreachable();
+						return null;
+				}
+			}
+		}
+	}
 }

--- a/Project2015To2017.Core/Reading/NuSpecReader.cs
+++ b/Project2015To2017.Core/Reading/NuSpecReader.cs
@@ -19,7 +19,7 @@ namespace Project2015To2017.Reading
 		public PackageConfiguration Read(FileInfo projectFile)
 		{
 			var nuspecFiles = projectFile.Directory
-										 .EnumerateFiles("*.nuspec", SearchOption.TopDirectoryOnly)								
+										 .EnumerateFiles("*.nuspec", SearchOption.TopDirectoryOnly)
 										 .ToArray();
 
 			if (nuspecFiles.Length == 0)
@@ -90,7 +90,8 @@ namespace Project2015To2017.Reading
 									   ?.Elements(ns + "dependency")
 										.ToList();
 
-			var packageConfig = new PackageConfiguration {
+			var packageConfig = new PackageConfiguration
+			{
 				Id = id,
 				Version = version,
 				Authors = GetElement(metadata, ns + "authors"),

--- a/Project2015To2017.Core/Reading/ProjectPropertiesReader.cs
+++ b/Project2015To2017.Core/Reading/ProjectPropertiesReader.cs
@@ -46,7 +46,7 @@ namespace Project2015To2017.Reading
 
 			// Ref.: https://www.codeproject.com/Reference/720512/List-of-Visual-Studio-Project-Type-GUIDs
 			if (project.PropertyGroups.ElementsAnyNamespace("TestProjectType").Any() ||
-			    project.IterateProjectTypeGuids().Any(x => x.guid == TestProjectTypeGuid))
+				project.IterateProjectTypeGuids().Any(x => x.guid == TestProjectTypeGuid))
 			{
 				project.Type = ApplicationType.TestProject;
 			}
@@ -143,14 +143,14 @@ namespace Project2015To2017.Reading
 				return last.Contains("$") ? null : last;
 			}
 
-			IReadOnlyList<string> ProcessTargetFrameworkVersion(string s) => new[] {ToTargetFramework(s)};
+			IReadOnlyList<string> ProcessTargetFrameworkVersion(string s) => new[] { ToTargetFramework(s) };
 
 			IReadOnlyList<string> ProcessTargetFrameworks(string s) => s
-				.Split(new[] {';'}, StringSplitOptions.RemoveEmptyEntries)
+				.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
 				.Select(x => x.Trim())
 				.ToImmutableArray();
 
-			IReadOnlyList<string> ProcessTargetFramework(string s) => new[] {s.Trim()};
+			IReadOnlyList<string> ProcessTargetFramework(string s) => new[] { s.Trim() };
 		}
 
 		private static (List<string> configurations, List<string> platforms)
@@ -195,7 +195,7 @@ namespace Project2015To2017.Reading
 
 			string[] ParseFromProperty(string name) => project.Property(name)
 				?.Value
-				.Split(new[] {';'}, StringSplitOptions.RemoveEmptyEntries);
+				.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
 		}
 
 		internal static void ReadPropertyGroups(Project project)

--- a/Project2015To2017.Core/Reading/ProjectReader.cs
+++ b/Project2015To2017.Core/Reading/ProjectReader.cs
@@ -186,7 +186,7 @@ namespace Project2015To2017.Reading
 						{
 							Id = includeAttribute.Value,
 							Version = x.Attribute("Version")?.Value ??
-							          x.Element(project.XmlNamespace + "Version")?.Value,
+									  x.Element(project.XmlNamespace + "Version")?.Value,
 							IsDevelopmentDependency = x.Element(project.XmlNamespace + "PrivateAssets") != null,
 							DefinitionElement = x
 						};

--- a/Project2015To2017.Core/Reading/SolutionReader.cs
+++ b/Project2015To2017.Core/Reading/SolutionReader.cs
@@ -137,11 +137,11 @@ namespace Project2015To2017.Reading
 			}
 
 			return (string.Compare(projectTypeGuid, vbProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
-			       (string.Compare(projectTypeGuid, csProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
-			       (string.Compare(projectTypeGuid, cpsProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
-			       (string.Compare(projectTypeGuid, cpsCsProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
-			       (string.Compare(projectTypeGuid, cpsVbProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
-			       (string.Compare(projectTypeGuid, fsProjectGuid, StringComparison.OrdinalIgnoreCase) == 0);
+				   (string.Compare(projectTypeGuid, csProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
+				   (string.Compare(projectTypeGuid, cpsProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
+				   (string.Compare(projectTypeGuid, cpsCsProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
+				   (string.Compare(projectTypeGuid, cpsVbProjectGuid, StringComparison.OrdinalIgnoreCase) == 0) ||
+				   (string.Compare(projectTypeGuid, fsProjectGuid, StringComparison.OrdinalIgnoreCase) == 0);
 		}
 	}
 }

--- a/Project2015To2017.Core/Transforms/AssemblyAttributeTransformation.cs
+++ b/Project2015To2017.Core/Transforms/AssemblyAttributeTransformation.cs
@@ -56,14 +56,14 @@ namespace Project2015To2017.Transforms
 			{
 				definition.Deletions = definition
 					.Deletions
-					.Concat(new[] {definition.AssemblyAttributes.File})
+					.Concat(new[] { definition.AssemblyAttributes.File })
 					.ToArray();
 
 				if (AssemblyInfoFolderJustAssemblyInfo(definition.AssemblyAttributes))
 				{
 					definition.Deletions = definition
 						.Deletions
-						.Concat(new[] {definition.AssemblyAttributes.File.Directory})
+						.Concat(new[] { definition.AssemblyAttributes.File.Directory })
 						.ToArray();
 				}
 			}

--- a/Project2015To2017.Core/Transforms/EmptyGroupRemoveTransformation.cs
+++ b/Project2015To2017.Core/Transforms/EmptyGroupRemoveTransformation.cs
@@ -18,7 +18,7 @@ namespace Project2015To2017.Transforms
 		{
 			var (keep, remove) = groups
 				.Split(x => x.HasElements
-				            || (x.HasAttributes && x.Attributes().Any(a => a.Name.LocalName != "Condition")));
+							|| (x.HasAttributes && x.Attributes().Any(a => a.Name.LocalName != "Condition")));
 			foreach (var element in remove)
 			{
 				element.Remove();

--- a/Project2015To2017.Core/Transforms/ITransformation.cs
+++ b/Project2015To2017.Core/Transforms/ITransformation.cs
@@ -3,11 +3,11 @@ using Project2015To2017.Definition;
 namespace Project2015To2017.Transforms
 {
 	public interface ITransformation
-    {
+	{
 		/// <summary>
 		/// Alter the provided project in some way
 		/// </summary>
 		/// <param name="definition"></param>
-        void Transform(Project definition);
-    }
+		void Transform(Project definition);
+	}
 }

--- a/Project2015To2017.Core/Transforms/PrimaryProjectPropertiesUpdateTransformation.cs
+++ b/Project2015To2017.Core/Transforms/PrimaryProjectPropertiesUpdateTransformation.cs
@@ -17,7 +17,7 @@ namespace Project2015To2017.Transforms
 			{
 				// ignore default "Debug;Release" configuration set
 				if (configurations.Count != 2 || !configurations.Contains("Debug") ||
-				    !configurations.Contains("Release"))
+					!configurations.Contains("Release"))
 				{
 					project.SetProperty("Configurations", string.Join(";", configurations));
 				}

--- a/Project2015To2017.Core/Transforms/PropertySimplificationTransformation.cs
+++ b/Project2015To2017.Core/Transforms/PropertySimplificationTransformation.cs
@@ -90,7 +90,7 @@ namespace Project2015To2017.Transforms
 				var parentConditionConfigurationLower = parentConditionConfiguration?.ToLowerInvariant();
 				var isDebugOnly = parentConditionHasConfiguration && parentConditionConfigurationLower == "debug";
 				var isReleaseOnly = parentConditionHasConfiguration &&
-				                    parentConditionConfigurationLower == "release";
+									parentConditionConfigurationLower == "release";
 
 				var tagLocalName = child.Name.LocalName;
 				var valueLower = child.Value.ToLowerInvariant();
@@ -157,12 +157,12 @@ namespace Project2015To2017.Transforms
 					case "TargetRuntime" when ValidateDefaultValue("managed"):
 					case "Utf8Output" when ValidateDefaultValue("true"):
 					case "PlatformName" when ValidateDefaultValue("$(platform)")
-					                         ||
-					                         (
-						                         parentConditionHasPlatform
-						                         &&
-						                         ValidateDefaultValue(parentConditionPlatformLower)
-					                         ):
+											 ||
+											 (
+												 parentConditionHasPlatform
+												 &&
+												 ValidateDefaultValue(parentConditionPlatformLower)
+											 ):
 					case "RestorePackages" when ValidateDefaultValue("true"):
 					case "SchemaVersion" when ValidateDefaultValue("2.0"):
 					case "AssemblyVersion" when ValidateDefaultVersion():
@@ -170,37 +170,37 @@ namespace Project2015To2017.Transforms
 					case "Version" when ValidateDefaultValue("1.0.0"):
 					// Conditional platform default values
 					case "PlatformTarget" when parentConditionHasPlatform
-					                           && child.Value == parentConditionPlatform
-					                           && !hasGlobalOverride:
+											   && child.Value == parentConditionPlatform
+											   && !hasGlobalOverride:
 					// Conditional configuration (Debug/Release) default values
 					case "DefineConstants" when isDebugOnly
-					                            && ValidateDefaultConstants(valueLower, "debug", "trace")
-					                            && !hasGlobalOverride:
+												&& ValidateDefaultConstants(valueLower, "debug", "trace")
+												&& !hasGlobalOverride:
 					case "DefineConstants" when isReleaseOnly
-					                            && ValidateDefaultConstants(valueLower, "trace")
-					                            && !hasGlobalOverride:
+												&& ValidateDefaultConstants(valueLower, "trace")
+												&& !hasGlobalOverride:
 					case "Optimize" when isDebugOnly && valueLower == "false" && !hasGlobalOverride:
 					case "Optimize" when isReleaseOnly && valueLower == "true" && !hasGlobalOverride:
 					case "DebugSymbols" when isDebugOnly && valueLower == "true" && !hasGlobalOverride:
 					// Default project values for Platform and Configuration
 					case "Platform" when ValidateEmptyConditionValue()
-					                     && valueLower == "anycpu":
+										 && valueLower == "anycpu":
 					case "Configuration" when ValidateEmptyConditionValue()
-					                          && valueLower == "debug":
+											  && valueLower == "debug":
 					case "Platforms" when !hasParentCondition
-					                      && ValidateDefaultConstants(valueLower, "anycpu"):
+										  && ValidateDefaultConstants(valueLower, "anycpu"):
 					case "Configurations" when !hasParentCondition
-					                           && ValidateDefaultConstants(valueLower, "debug", "release"):
+											   && ValidateDefaultConstants(valueLower, "debug", "release"):
 					// Extra ProjectName duplicates
 					case "RootNamespace" when IsDefaultProjectNameValued():
 					case "AssemblyName" when IsDefaultProjectNameValued():
 					case "TargetName" when IsDefaultProjectNameValued():
 					case "ProjectGuid" when ProjectGuidMatchesSolutionProjectGuid():
 					case "Service" when IncludeMatchesSpecificGuid():
-					{
-						removeQueue.Add(child);
-						break;
-					}
+						{
+							removeQueue.Add(child);
+							break;
+						}
 				}
 
 				if (parentConditionHasConfiguration || parentConditionHasPlatform)
@@ -211,11 +211,11 @@ namespace Project2015To2017.Transforms
 						case "IntermediateOutputPath":
 						case "DocumentationFile":
 						case "CodeAnalysisRuleSet":
-						{
-							child.Value = ReplaceWithPlaceholders(child.Value);
+							{
+								child.Value = ReplaceWithPlaceholders(child.Value);
 
-							break;
-						}
+								break;
+							}
 					}
 				}
 
@@ -223,7 +223,7 @@ namespace Project2015To2017.Transforms
 				bool ValidateDefaultValue(string @default)
 				{
 					return (!hasParentCondition && valueLower == @default) ||
-					       (hasParentCondition && ValidateConditionedDefaultValue(@default));
+						   (hasParentCondition && ValidateConditionedDefaultValue(@default));
 				}
 
 				bool ValidateConditionedDefaultValue(string @default)
@@ -234,9 +234,9 @@ namespace Project2015To2017.Transforms
 				bool ValidateDefaultVersion()
 				{
 					return ValidateDefaultValue("1.0.0.0")
-					       || ValidateDefaultValue("1.0.0")
-					       || ValidateDefaultValue("1.0")
-					       || ValidateDefaultValue("1");
+						   || ValidateDefaultValue("1.0.0")
+						   || ValidateDefaultValue("1.0")
+						   || ValidateDefaultValue("1");
 				}
 
 				string ReplaceWithPlaceholders(string value)
@@ -267,11 +267,11 @@ namespace Project2015To2017.Transforms
 				bool IsDefaultProjectNameValued()
 				{
 					return ValidateEmptyConditionValue()
-					       && (
-						       child.Value == msbuildProjectName
-						       ||
-						       IgnoreProjectNameValues.Contains(child.Value)
-					       );
+						   && (
+							   child.Value == msbuildProjectName
+							   ||
+							   IgnoreProjectNameValues.Contains(child.Value)
+						   );
 				}
 
 				bool IncludeMatchesSpecificGuid()
@@ -302,7 +302,7 @@ namespace Project2015To2017.Transforms
 			bool ProjectGuidMatchesSolutionProjectGuid()
 			{
 				return project.Solution != null && project.Solution.ProjectPaths
-					       .Any(x => x.ProjectName == project.ProjectName && x.ProjectGuid == project.ProjectGuid);
+						   .Any(x => x.ProjectName == project.ProjectName && x.ProjectGuid == project.ProjectGuid);
 			}
 		}
 
@@ -341,7 +341,7 @@ namespace Project2015To2017.Transforms
 
 		private static bool ValidateDefaultConstants(string value, params string[] expected)
 		{
-			var defines = value.Split(new[] {';'}, StringSplitOptions.RemoveEmptyEntries);
+			var defines = value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
 			return Extensions.ValidateSet(defines, expected);
 		}
 	}

--- a/Project2015To2017.Migrate2017.Library/Project2015To2017.Migrate2017.Library.csproj
+++ b/Project2015To2017.Migrate2017.Library/Project2015To2017.Migrate2017.Library.csproj
@@ -1,12 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <RootNamespace>Project2015To2017.Migrate2017</RootNamespace>
+	<TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+	<RootNamespace>Project2015To2017.Migrate2017</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Project2015To2017.Core\Project2015To2017.Core.csproj" />
+	<ProjectReference Include="..\Project2015To2017.Core\Project2015To2017.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Project2015To2017.Migrate2017.Library/SystemNuGetPackages.cs
+++ b/Project2015To2017.Migrate2017.Library/SystemNuGetPackages.cs
@@ -137,7 +137,7 @@ namespace Project2015To2017.Migrate2017
 
 		private const string MaxTargetFramework = "net499";
 		private const string MaxTargetStandard = "netstandard9.9";
-		private static readonly string[] IncompatiblePrefixes = {"net1", "net2", "net3", "net40"};
+		private static readonly string[] IncompatiblePrefixes = { "net1", "net2", "net3", "net40" };
 
 		public static IReadOnlyList<(string name, string version, AssemblyReference reference)>
 			DetectUpgradeableReferences(Project project)
@@ -159,12 +159,12 @@ namespace Project2015To2017.Migrate2017
 				}
 
 				if (framework.StartsWith("netstandard", comparison) &&
-				    string.Compare(minTargetStandard, framework, comparison) > 0)
+					string.Compare(minTargetStandard, framework, comparison) > 0)
 				{
 					minTargetStandard = framework;
 				}
 				else if (framework.StartsWith("net4", comparison) &&
-				         string.Compare(minTargetFramework, framework, comparison) > 0)
+						 string.Compare(minTargetFramework, framework, comparison) > 0)
 				{
 					minTargetFramework = framework;
 				}

--- a/Project2015To2017.Migrate2017.Library/Transforms/FileTransformation.cs
+++ b/Project2015To2017.Migrate2017.Library/Transforms/FileTransformation.cs
@@ -143,7 +143,8 @@ namespace Project2015To2017.Migrate2017.Transforms
 			switch (tagName)
 			{
 				case "Import"
-					when include != null: return true;
+					when include != null:
+					return true;
 				case "Compile":
 				case "EmbeddedResource"
 					when include != null && include.EndsWith(".resx", StringComparison.OrdinalIgnoreCase):
@@ -157,7 +158,7 @@ namespace Project2015To2017.Migrate2017.Transforms
 
 			// Visual Studio Test Projects
 			if (tagName == "Service" && string.Equals(include,
-				    "{82a7f48d-3b50-4b1e-b82e-3ada8210c358}", StringComparison.OrdinalIgnoreCase))
+					"{82a7f48d-3b50-4b1e-b82e-3ada8210c358}", StringComparison.OrdinalIgnoreCase))
 			{
 				return true;
 			}

--- a/Project2015To2017.Migrate2017.Library/Transforms/TestProjectPackageReferenceTransformation.cs
+++ b/Project2015To2017.Migrate2017.Library/Transforms/TestProjectPackageReferenceTransformation.cs
@@ -19,7 +19,7 @@ namespace Project2015To2017.Migrate2017.Transforms
 			var existingPackageReferences = definition.PackageReferences;
 
 			if (definition.Type != ApplicationType.TestProject ||
-			    existingPackageReferences.Any(x => x.Id == "Microsoft.NET.Test.Sdk")) return;
+				existingPackageReferences.Any(x => x.Id == "Microsoft.NET.Test.Sdk")) return;
 
 			var testReferences = new[]
 			{

--- a/Project2015To2017.Migrate2017.Library/Transforms/UpgradeFrameworkAssembliesToNuGetTransformation.cs
+++ b/Project2015To2017.Migrate2017.Library/Transforms/UpgradeFrameworkAssembliesToNuGetTransformation.cs
@@ -28,7 +28,7 @@ namespace Project2015To2017.Migrate2017.Transforms
 				.ToImmutableArray();
 
 			var packageReferences = references
-				.Select(x => new PackageReference {Id = x.name, Version = x.version})
+				.Select(x => new PackageReference { Id = x.name, Version = x.version })
 				.ToImmutableArray();
 
 			var adjustedPackageReferences = definition.PackageReferences

--- a/Project2015To2017.Migrate2017.Library/Transforms/XamlPagesTransformation.cs
+++ b/Project2015To2017.Migrate2017.Library/Transforms/XamlPagesTransformation.cs
@@ -45,7 +45,7 @@ namespace Project2015To2017.Migrate2017.Transforms
 			logger.LogDebug($"Removed {count} XAML items thanks to MSBuild.Sdk.Extras defaults");
 		}
 
-		private static readonly string[] FilteredTags = {"Page", "ApplicationDefinition", "Compile", "None"};
+		private static readonly string[] FilteredTags = { "Page", "ApplicationDefinition", "Compile", "None" };
 		private readonly ILogger logger;
 
 		private static bool XamlPageFilter(XElement x, Project definition)
@@ -100,7 +100,7 @@ namespace Project2015To2017.Migrate2017.Transforms
 				}
 
 				return link.EndsWith(".xaml.cs", StringComparison.OrdinalIgnoreCase)
-				       && x.Descendants().All(VerifyDefaultXamlCompileItem);
+					   && x.Descendants().All(VerifyDefaultXamlCompileItem);
 			}
 
 			if (update != null)
@@ -116,7 +116,7 @@ namespace Project2015To2017.Migrate2017.Transforms
 				var lastGenOutput = x.Element("LastGenOutput")?.Value ?? ".cs";
 
 				return string.Equals(generator, "SettingsSingleFileGenerator")
-				       && lastGenOutput.EndsWith(".cs", StringComparison.OrdinalIgnoreCase);
+					   && lastGenOutput.EndsWith(".cs", StringComparison.OrdinalIgnoreCase);
 			}
 
 			return include.EndsWith(".xaml", StringComparison.OrdinalIgnoreCase);

--- a/Project2015To2017.Migrate2017.Tool/CommandLogic.cs
+++ b/Project2015To2017.Migrate2017.Tool/CommandLogic.cs
@@ -279,10 +279,10 @@ namespace Project2015To2017.Migrate2017.Tool
 			Log.Information("Please, enter target frameworks to use (comma or space separated):");
 			Console.Out.Flush();
 			var tfms = Console.ReadLine()
-				           ?.Trim()
-				           .Split(new[] {',', ' '}, StringSplitOptions.RemoveEmptyEntries)
-				           .Where(s => !string.IsNullOrWhiteSpace(s))
-				           .ToImmutableArray() ?? ImmutableArray<string>.Empty;
+						   ?.Trim()
+						   .Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries)
+						   .Where(s => !string.IsNullOrWhiteSpace(s))
+						   .ToImmutableArray() ?? ImmutableArray<string>.Empty;
 
 			if (tfms.IsDefaultOrEmpty)
 			{

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/Accept.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/Accept.cs
@@ -9,256 +9,256 @@ using static Microsoft.DotNet.Cli.CommandLine.ValidationMessages;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public static class Accept
-    {
-        public static ArgumentsRule AnyOneOf(params string[] values) =>
-            ExactlyOneArgument()
-                .And(
-                    new ArgumentsRule(o =>
-                    {
-                        var arg = o.Arguments.Single();
+	public static class Accept
+	{
+		public static ArgumentsRule AnyOneOf(params string[] values) =>
+			ExactlyOneArgument()
+				.And(
+					new ArgumentsRule(o =>
+					{
+						var arg = o.Arguments.Single();
 
-                        return !values.Contains(arg, StringComparer.OrdinalIgnoreCase)
-                                   ? UnrecognizedArgument(arg, values)
-                                   : "";
-                    }, values));
+						return !values.Contains(arg, StringComparer.OrdinalIgnoreCase)
+								   ? UnrecognizedArgument(arg, values)
+								   : "";
+					}, values));
 
-        public static ArgumentsRule AnyOneOf(
-            Func<IEnumerable<string>> getValues) =>
-            ExactlyOneArgument()
-                .And(
-                    new ArgumentsRule(o =>
-                    {
-                        var values = getValues().ToArray();
+		public static ArgumentsRule AnyOneOf(
+			Func<IEnumerable<string>> getValues) =>
+			ExactlyOneArgument()
+				.And(
+					new ArgumentsRule(o =>
+					{
+						var values = getValues().ToArray();
 
-                        var arg = o.Arguments.Single();
+						var arg = o.Arguments.Single();
 
-                        return !values
-                                   .Contains(arg, StringComparer.OrdinalIgnoreCase)
-                                   ? UnrecognizedArgument(arg, values)
-                                   : "";
-                    }, null))
-                .WithSuggestionsFrom(_ => getValues());
+						return !values
+								   .Contains(arg, StringComparer.OrdinalIgnoreCase)
+								   ? UnrecognizedArgument(arg, values)
+								   : "";
+					}, null))
+				.WithSuggestionsFrom(_ => getValues());
 
-        public static ArgumentsRule ExactlyOneArgument(
-            Func<AppliedOption, string> errorMessage = null) =>
-            new ArgumentsRule(o =>
-                              {
-                                  var argumentCount = o.Arguments.Count;
+		public static ArgumentsRule ExactlyOneArgument(
+			Func<AppliedOption, string> errorMessage = null) =>
+			new ArgumentsRule(o =>
+							  {
+								  var argumentCount = o.Arguments.Count;
 
-                                  if (argumentCount == 0)
-                                  {
-                                      if (errorMessage == null)
-                                      {
-                                          return o.Option.IsCommand
-                                                     ? RequiredArgumentMissingForCommand(o.Option.ToString())
-                                                     : RequiredArgumentMissingForOption(o.Option.ToString());
-                                      }
-                                      else
-                                      {
-                                          return errorMessage(o);
-                                      }
-                                  }
+								  if (argumentCount == 0)
+								  {
+									  if (errorMessage == null)
+									  {
+										  return o.Option.IsCommand
+													 ? RequiredArgumentMissingForCommand(o.Option.ToString())
+													 : RequiredArgumentMissingForOption(o.Option.ToString());
+									  }
+									  else
+									  {
+										  return errorMessage(o);
+									  }
+								  }
 
-                                  if (argumentCount > 1)
-                                  {
-                                      if (errorMessage == null)
-                                      {
-                                          return o.Option.IsCommand
-                                                     ? CommandAcceptsOnlyOneArgument(o.Option.ToString(), argumentCount)
-                                                     : OptionAcceptsOnlyOneArgument(o.Option.ToString(), argumentCount);
-                                      }
-                                      else
-                                      {
-                                          return errorMessage(o);
-                                      }
-                                  }
+								  if (argumentCount > 1)
+								  {
+									  if (errorMessage == null)
+									  {
+										  return o.Option.IsCommand
+													 ? CommandAcceptsOnlyOneArgument(o.Option.ToString(), argumentCount)
+													 : OptionAcceptsOnlyOneArgument(o.Option.ToString(), argumentCount);
+									  }
+									  else
+									  {
+										  return errorMessage(o);
+									  }
+								  }
 
-                                  return null;
-                              },
-                              materialize: o => o.Arguments.SingleOrDefault());
+								  return null;
+							  },
+							  materialize: o => o.Arguments.SingleOrDefault());
 
-        public static ArgumentsRule ExistingFilesOnly(
-            this ArgumentsRule rule) =>
-            rule.And(new ArgumentsRule(o => o.Arguments
-                                             .Where(filePath => !File.Exists(filePath) &&
-                                                                !Directory.Exists(filePath))
-                                             .Select(FileDoesNotExist)
-                                             .FirstOrDefault()));
+		public static ArgumentsRule ExistingFilesOnly(
+			this ArgumentsRule rule) =>
+			rule.And(new ArgumentsRule(o => o.Arguments
+											 .Where(filePath => !File.Exists(filePath) &&
+																!Directory.Exists(filePath))
+											 .Select(FileDoesNotExist)
+											 .FirstOrDefault()));
 
-        public static ArgumentsRule LegalFilePathsOnly(
-            this ArgumentsRule rule) =>
-            rule.And(new ArgumentsRule(o =>
-            {
-                foreach (var arg in o.Arguments)
-                {
-                    try
-                    {
-                        var fileInfo = new FileInfo(arg);
-                    }
-                    catch (NotSupportedException ex)
-                    {
-                        return ex.Message;
-                    }
-                    catch (ArgumentException ex)
-                    {
-                        return ex.Message;
-                    }
-                }
+		public static ArgumentsRule LegalFilePathsOnly(
+			this ArgumentsRule rule) =>
+			rule.And(new ArgumentsRule(o =>
+			{
+				foreach (var arg in o.Arguments)
+				{
+					try
+					{
+						var fileInfo = new FileInfo(arg);
+					}
+					catch (NotSupportedException ex)
+					{
+						return ex.Message;
+					}
+					catch (ArgumentException ex)
+					{
+						return ex.Message;
+					}
+				}
 
-                return null;
-            }));
+				return null;
+			}));
 
-        public static ArgumentsRule WithSuggestionsFrom(
-            params string[] values) =>
-            new ArgumentsRule(
-                _ => null,
-                suggest: parseResult => values.FindSuggestions(parseResult.TextToMatch()));
+		public static ArgumentsRule WithSuggestionsFrom(
+			params string[] values) =>
+			new ArgumentsRule(
+				_ => null,
+				suggest: parseResult => values.FindSuggestions(parseResult.TextToMatch()));
 
-        public static ArgumentsRule WithSuggestionsFrom(
-            Func<string, IEnumerable<string>> suggest) =>
-            new ArgumentsRule(
-                _ => null,
-                suggest: parseResult => suggest(parseResult.TextToMatch()));
+		public static ArgumentsRule WithSuggestionsFrom(
+			Func<string, IEnumerable<string>> suggest) =>
+			new ArgumentsRule(
+				_ => null,
+				suggest: parseResult => suggest(parseResult.TextToMatch()));
 
-        public static ArgumentsRule WithSuggestionsFrom(
-            this ArgumentsRule rule,
-            Func<string, IEnumerable<string>> suggest) =>
-            rule.And(WithSuggestionsFrom(suggest));
+		public static ArgumentsRule WithSuggestionsFrom(
+			this ArgumentsRule rule,
+			Func<string, IEnumerable<string>> suggest) =>
+			rule.And(WithSuggestionsFrom(suggest));
 
-        public static ArgumentsRule WithSuggestionsFrom(
-            this ArgumentsRule rule,
-            params string[] values) =>
-            rule.And(WithSuggestionsFrom(values));
+		public static ArgumentsRule WithSuggestionsFrom(
+			this ArgumentsRule rule,
+			params string[] values) =>
+			rule.And(WithSuggestionsFrom(values));
 
-        public static ArgumentsRule ZeroOrOneArgument() =>
-            new ArgumentsRule(o =>
-                              {
-                                  if (o.Arguments.Count > 1)
-                                  {
-                                      return o.Option.IsCommand
-                                                 ? CommandAcceptsOnlyOneArgument(o.Option.ToString(), o.Arguments.Count)
-                                                 : OptionAcceptsOnlyOneArgument(o.Option.ToString(), o.Arguments.Count);
-                                  }
+		public static ArgumentsRule ZeroOrOneArgument() =>
+			new ArgumentsRule(o =>
+							  {
+								  if (o.Arguments.Count > 1)
+								  {
+									  return o.Option.IsCommand
+												 ? CommandAcceptsOnlyOneArgument(o.Option.ToString(), o.Arguments.Count)
+												 : OptionAcceptsOnlyOneArgument(o.Option.ToString(), o.Arguments.Count);
+								  }
 
-                                  return null;
-                              },
-                              materialize: o => o.Arguments.SingleOrDefault());
+								  return null;
+							  },
+							  materialize: o => o.Arguments.SingleOrDefault());
 
-        internal static ArgumentsRule ExactlyOneCommandRequired(
-            Func<AppliedOption, string> errorMessage = null) =>
-            new ArgumentsRule(o =>
-            {
-                var optionCount = o.AppliedOptions.Count;
+		internal static ArgumentsRule ExactlyOneCommandRequired(
+			Func<AppliedOption, string> errorMessage = null) =>
+			new ArgumentsRule(o =>
+			{
+				var optionCount = o.AppliedOptions.Count;
 
-                if (optionCount == 0)
-                {
-                    if (errorMessage == null)
-                    {
-                        return RequiredArgumentMissingForCommand(o.Option.ToString());
-                    }
-                    else
-                    {
-                        return errorMessage(o);
-                    }
-                }
+				if (optionCount == 0)
+				{
+					if (errorMessage == null)
+					{
+						return RequiredArgumentMissingForCommand(o.Option.ToString());
+					}
+					else
+					{
+						return errorMessage(o);
+					}
+				}
 
-                if (optionCount > 1)
-                {
-                    if (errorMessage == null)
-                    {
-                        return CommandAcceptsOnlyOneSubcommand(
-                            o.Option.ToString(),
-                            string.Join(", ", o.AppliedOptions.Select(a => a.Option)));
-                    }
-                    else
-                    {
-                        return errorMessage(o);
-                    }
-                }
+				if (optionCount > 1)
+				{
+					if (errorMessage == null)
+					{
+						return CommandAcceptsOnlyOneSubcommand(
+							o.Option.ToString(),
+							string.Join(", ", o.AppliedOptions.Select(a => a.Option)));
+					}
+					else
+					{
+						return errorMessage(o);
+					}
+				}
 
-                return null;
-            });
+				return null;
+			});
 
-        public static ArgumentsRule NoArguments(
-            Func<AppliedOption, string> errorMessage = null) =>
-            new ArgumentsRule(o =>
-                              {
-                                  if (!o.Arguments.Any())
-                                  {
-                                      return null;
-                                  }
+		public static ArgumentsRule NoArguments(
+			Func<AppliedOption, string> errorMessage = null) =>
+			new ArgumentsRule(o =>
+							  {
+								  if (!o.Arguments.Any())
+								  {
+									  return null;
+								  }
 
-                                  if (errorMessage == null)
-                                  {
-                                      return NoArgumentsAllowed(o.Option.ToString());
-                                  }
-                                  else
-                                  {
-                                      return errorMessage(o);
-                                  }
-                              },
-                              materialize: _ => true);
+								  if (errorMessage == null)
+								  {
+									  return NoArgumentsAllowed(o.Option.ToString());
+								  }
+								  else
+								  {
+									  return errorMessage(o);
+								  }
+							  },
+							  materialize: _ => true);
 
-        public static ArgumentsRule OneOrMoreArguments(
-            Func<AppliedOption, string> errorMessage = null) =>
-            new ArgumentsRule(o =>
-                              {
-                                  var optionCount = o.Arguments.Count;
+		public static ArgumentsRule OneOrMoreArguments(
+			Func<AppliedOption, string> errorMessage = null) =>
+			new ArgumentsRule(o =>
+							  {
+								  var optionCount = o.Arguments.Count;
 
-                                  if (optionCount == 0)
-                                  {
-                                      if (errorMessage == null)
-                                      {
-                                          return
-                                              o.Option.IsCommand
-                                                  ? RequiredArgumentMissingForCommand(o.Option.ToString())
-                                                  : RequiredArgumentMissingForOption(o.Option.ToString());
-                                      }
-                                      else
-                                      {
-                                          return errorMessage(o);
-                                      }
-                                  }
+								  if (optionCount == 0)
+								  {
+									  if (errorMessage == null)
+									  {
+										  return
+											  o.Option.IsCommand
+												  ? RequiredArgumentMissingForCommand(o.Option.ToString())
+												  : RequiredArgumentMissingForOption(o.Option.ToString());
+									  }
+									  else
+									  {
+										  return errorMessage(o);
+									  }
+								  }
 
-                                  return null;
-                              },
-                              materialize: o => o.Arguments);
+								  return null;
+							  },
+							  materialize: o => o.Arguments);
 
-        internal static ArgumentsRule ZeroOrMoreOf(params Option[] options)
-        {
-            var values = options
-                .SelectMany(o => o.RawAliases)
-                .ToArray();
+		internal static ArgumentsRule ZeroOrMoreOf(params Option[] options)
+		{
+			var values = options
+				.SelectMany(o => o.RawAliases)
+				.ToArray();
 
-            var completionValues = options
-                .Where(o => !o.IsHidden())
-                .SelectMany(o => o.RawAliases)
-                .ToArray();
+			var completionValues = options
+				.Where(o => !o.IsHidden())
+				.SelectMany(o => o.RawAliases)
+				.ToArray();
 
-            return
-                new ArgumentsRule(
-                    o =>
-                    {
-                        var unrecognized = values
-                            .FirstOrDefault(v => !o.Option
-                                                   .DefinedOptions
-                                                   .Any(oo => oo.HasAlias(v)));
+			return
+				new ArgumentsRule(
+					o =>
+					{
+						var unrecognized = values
+							.FirstOrDefault(v => !o.Option
+												   .DefinedOptions
+												   .Any(oo => oo.HasAlias(v)));
 
-                        if (unrecognized != null)
-                        {
-                            return UnrecognizedOption(unrecognized, values);
-                        }
-                        else
-                        {
-                            return null;
-                        }
-                    },
-                    completionValues);
-        }
+						if (unrecognized != null)
+						{
+							return UnrecognizedOption(unrecognized, values);
+						}
+						else
+						{
+							return null;
+						}
+					},
+					completionValues);
+		}
 
-        public static ArgumentsRule ZeroOrMoreArguments() =>
-            new ArgumentsRule(_ => null,
-                              materialize: o => o.Arguments);
-    }
+		public static ArgumentsRule ZeroOrMoreArguments() =>
+			new ArgumentsRule(_ => null,
+							  materialize: o => o.Arguments);
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/AppliedOption.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/AppliedOption.cs
@@ -7,174 +7,174 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public class AppliedOption
-    {
-        private readonly List<string> arguments = new List<string>();
-        private readonly Lazy<string> defaultValue;
-        private readonly Func<object> materialize;
-        private readonly AppliedOptionSet appliedOptions = new AppliedOptionSet();
-        private bool considerAcceptingAnotherArgument = true;
+	public class AppliedOption
+	{
+		private readonly List<string> arguments = new List<string>();
+		private readonly Lazy<string> defaultValue;
+		private readonly Func<object> materialize;
+		private readonly AppliedOptionSet appliedOptions = new AppliedOptionSet();
+		private bool considerAcceptingAnotherArgument = true;
 
-        public AppliedOption(Option option, string token = null)
-        {
-            if (option == null)
-            {
-                throw new ArgumentNullException(nameof(option));
-            }
+		public AppliedOption(Option option, string token = null)
+		{
+			if (option == null)
+			{
+				throw new ArgumentNullException(nameof(option));
+			}
 
-            Option = option;
+			Option = option;
 
-            defaultValue = new Lazy<string>(option.ArgumentsRule.GetDefaultValue);
+			defaultValue = new Lazy<string>(option.ArgumentsRule.GetDefaultValue);
 
-            Token = token ?? option.ToString();
+			Token = token ?? option.ToString();
 
-            materialize = () => option.ArgumentsRule.Materialize(this);
-        }
+			materialize = () => option.ArgumentsRule.Materialize(this);
+		}
 
-        public AppliedOptionSet AppliedOptions =>
-            appliedOptions;
+		public AppliedOptionSet AppliedOptions =>
+			appliedOptions;
 
-        public IReadOnlyCollection<string> Arguments
-        {
-            get
-            {
-                if (arguments.Any() ||
-                    defaultValue.Value == null)
-                {
-                    return arguments.ToArray();
-                }
+		public IReadOnlyCollection<string> Arguments
+		{
+			get
+			{
+				if (arguments.Any() ||
+					defaultValue.Value == null)
+				{
+					return arguments.ToArray();
+				}
 
-                return new[] { defaultValue.Value };
-            }
-        }
+				return new[] { defaultValue.Value };
+			}
+		}
 
-        public string Name => Option.Name;
+		public string Name => Option.Name;
 
-        public Option Option { get; }
+		public Option Option { get; }
 
-        public string Token { get; }
+		public string Token { get; }
 
-        public AppliedOption TryTakeToken(Token token)
-        {
-            var option = TryTakeArgument(token) ??
-                         TryTakeOptionOrCommand(token);
-            considerAcceptingAnotherArgument = false;
-            return option;
-        }
+		public AppliedOption TryTakeToken(Token token)
+		{
+			var option = TryTakeArgument(token) ??
+						 TryTakeOptionOrCommand(token);
+			considerAcceptingAnotherArgument = false;
+			return option;
+		}
 
-        private AppliedOption TryTakeArgument(Token token)
-        {
-            if (token.Type != TokenType.Argument)
-            {
-                return null;
-            }
+		private AppliedOption TryTakeArgument(Token token)
+		{
+			if (token.Type != TokenType.Argument)
+			{
+				return null;
+			}
 
-            if (!considerAcceptingAnotherArgument &&
-                !Option.IsCommand)
-            {
-                // Options must be respecified in order to accept additional arguments. This is 
-                // not the case for commands.
-                return null;
-            }
+			if (!considerAcceptingAnotherArgument &&
+				!Option.IsCommand)
+			{
+				// Options must be respecified in order to accept additional arguments. This is 
+				// not the case for commands.
+				return null;
+			}
 
-            foreach (var appliedOption in appliedOptions)
-            {
-                var a = appliedOption.TryTakeToken(token);
-                if (a != null)
-                {
-                    return a;
-                }
-            }
+			foreach (var appliedOption in appliedOptions)
+			{
+				var a = appliedOption.TryTakeToken(token);
+				if (a != null)
+				{
+					return a;
+				}
+			}
 
-            arguments.Add(token.Value);
+			arguments.Add(token.Value);
 
-            if (Validate() == null)
-            {
-                considerAcceptingAnotherArgument = false;
-                return this;
-            }
+			if (Validate() == null)
+			{
+				considerAcceptingAnotherArgument = false;
+				return this;
+			}
 
-            arguments.RemoveAt(arguments.Count - 1);
-            return null;
-        }
+			arguments.RemoveAt(arguments.Count - 1);
+			return null;
+		}
 
-        private AppliedOption TryTakeOptionOrCommand(Token token)
-        {
-            var childOption = appliedOptions
-                .SingleOrDefault(o =>
-                                     o.Option.DefinedOptions
-                                      .Any(oo => oo.RawAliases.Contains(token.Value)));
+		private AppliedOption TryTakeOptionOrCommand(Token token)
+		{
+			var childOption = appliedOptions
+				.SingleOrDefault(o =>
+									 o.Option.DefinedOptions
+									  .Any(oo => oo.RawAliases.Contains(token.Value)));
 
-            if (childOption != null)
-            {
-                return childOption.TryTakeToken(token);
-            }
+			if (childOption != null)
+			{
+				return childOption.TryTakeToken(token);
+			}
 
-            if (token.Type == TokenType.Command &&
-                appliedOptions.Any(o => o.Option.IsCommand && !o.HasAlias(token.Value)))
-            {
-                // if a subcommand has already been applied, don't accept this one
-                return null;
-            }
+			if (token.Type == TokenType.Command &&
+				appliedOptions.Any(o => o.Option.IsCommand && !o.HasAlias(token.Value)))
+			{
+				// if a subcommand has already been applied, don't accept this one
+				return null;
+			}
 
-            var applied =
-                appliedOptions.SingleOrDefault(o => o.Option.HasRawAlias(token.Value));
+			var applied =
+				appliedOptions.SingleOrDefault(o => o.Option.HasRawAlias(token.Value));
 
-            if (applied != null)
-            {
-                applied.OptionWasRespecified();
-                return applied;
-            }
+			if (applied != null)
+			{
+				applied.OptionWasRespecified();
+				return applied;
+			}
 
-            applied =
-                Option.DefinedOptions
-                      .Where(o => o.RawAliases.Contains(token.Value))
-                      .Select(o => new AppliedOption(o, token.Value))
-                      .SingleOrDefault();
+			applied =
+				Option.DefinedOptions
+					  .Where(o => o.RawAliases.Contains(token.Value))
+					  .Select(o => new AppliedOption(o, token.Value))
+					  .SingleOrDefault();
 
-            if (applied != null)
-            {
-                appliedOptions.Add(applied);
-            }
+			if (applied != null)
+			{
+				appliedOptions.Add(applied);
+			}
 
-            return applied;
-        }
+			return applied;
+		}
 
-        internal void OptionWasRespecified() => considerAcceptingAnotherArgument = true;
+		internal void OptionWasRespecified() => considerAcceptingAnotherArgument = true;
 
-        internal OptionError Validate()
-        {
-            var error = Option.ArgumentsRule.Validate(this);
-            return string.IsNullOrWhiteSpace(error)
-                       ? null
-                       : new OptionError(error, Token, this);
-        }
+		internal OptionError Validate()
+		{
+			var error = Option.ArgumentsRule.Validate(this);
+			return string.IsNullOrWhiteSpace(error)
+					   ? null
+					   : new OptionError(error, Token, this);
+		}
 
-        public AppliedOption this[string alias] => AppliedOptions[alias];
+		public AppliedOption this[string alias] => AppliedOptions[alias];
 
-        public IReadOnlyCollection<string> Aliases => Option.Aliases;
+		public IReadOnlyCollection<string> Aliases => Option.Aliases;
 
-        public bool HasAlias(string alias) => Option.HasAlias(alias);
+		public bool HasAlias(string alias) => Option.HasAlias(alias);
 
-        public T Value<T>() => (T) Value();
+		public T Value<T>() => (T)Value();
 
-        public object Value()
-        {
-            try
-            {
-                return materialize();
-            }
-            catch (Exception exception)
-            {
-                var argumentsDescription = Arguments.Any()
-                                               ? string.Join(", ", Arguments)
-                                               : " (none)";
-                throw new ParseException(
-                    $"An exception occurred while getting the value for option '{Option.Name}' based on argument(s): {argumentsDescription}.",
-                    exception);
-            }
-        }
+		public object Value()
+		{
+			try
+			{
+				return materialize();
+			}
+			catch (Exception exception)
+			{
+				var argumentsDescription = Arguments.Any()
+											   ? string.Join(", ", Arguments)
+											   : " (none)";
+				throw new ParseException(
+					$"An exception occurred while getting the value for option '{Option.Name}' based on argument(s): {argumentsDescription}.",
+					exception);
+			}
+		}
 
-        public override string ToString() => this.Diagram();
-    }
+		public override string ToString() => this.Diagram();
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/AppliedOptionExtensions.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/AppliedOptionExtensions.cs
@@ -7,40 +7,40 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public static class AppliedOptionExtensions
-    {
-        public static IEnumerable<OptionError> ValidateAll(
-            this AppliedOption option) =>
-            new[] { option.Validate() }
-                .Concat(
-                    option.AppliedOptions
-                          .SelectMany(ValidateAll))
-                .Where(o => o != null);
+	public static class AppliedOptionExtensions
+	{
+		public static IEnumerable<OptionError> ValidateAll(
+			this AppliedOption option) =>
+			new[] { option.Validate() }
+				.Concat(
+					option.AppliedOptions
+						  .SelectMany(ValidateAll))
+				.Where(o => o != null);
 
-        internal static IEnumerable<AppliedOption> FlattenBreadthFirst(
-            this IEnumerable<AppliedOption> options)
-        {
-            if (options == null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
+		internal static IEnumerable<AppliedOption> FlattenBreadthFirst(
+			this IEnumerable<AppliedOption> options)
+		{
+			if (options == null)
+			{
+				throw new ArgumentNullException(nameof(options));
+			}
 
-            foreach (var item in options.FlattenBreadthFirst(o => o.AppliedOptions))
-            {
-                yield return item;
-            }
-        }
+			foreach (var item in options.FlattenBreadthFirst(o => o.AppliedOptions))
+			{
+				yield return item;
+			}
+		}
 
-        public static bool HasOption(
-            this AppliedOption option,
-            string alias)
-        {
-            if (option == null)
-            {
-                throw new ArgumentNullException(nameof(option));
-            }
+		public static bool HasOption(
+			this AppliedOption option,
+			string alias)
+		{
+			if (option == null)
+			{
+				throw new ArgumentNullException(nameof(option));
+			}
 
-            return option.AppliedOptions.Contains(alias);
-        }
-    }
+			return option.AppliedOptions.Contains(alias);
+		}
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/AppliedOptionSet.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/AppliedOptionSet.cs
@@ -2,23 +2,23 @@ using System.Collections.Generic;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public class AppliedOptionSet : OptionSet<AppliedOption>
-    {
-        public AppliedOptionSet()
-        {
-        }
+	public class AppliedOptionSet : OptionSet<AppliedOption>
+	{
+		public AppliedOptionSet()
+		{
+		}
 
-        public AppliedOptionSet(IReadOnlyCollection<AppliedOption> options) : base(options)
-        {
-        }
+		public AppliedOptionSet(IReadOnlyCollection<AppliedOption> options) : base(options)
+		{
+		}
 
-        protected override bool HasAlias(AppliedOption option, string alias) =>
-            option.Option.HasAlias(alias);
+		protected override bool HasAlias(AppliedOption option, string alias) =>
+			option.Option.HasAlias(alias);
 
-        protected override bool HasRawAlias(AppliedOption option, string alias) =>
-            option.Option.HasRawAlias(alias);
+		protected override bool HasRawAlias(AppliedOption option, string alias) =>
+			option.Option.HasRawAlias(alias);
 
-        protected override IReadOnlyCollection<string> RawAliasesFor(AppliedOption option) =>
-            option.Option.RawAliases;
-    }
+		protected override IReadOnlyCollection<string> RawAliasesFor(AppliedOption option) =>
+			option.Option.RawAliases;
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/ArgumentsRule.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/ArgumentsRule.cs
@@ -7,66 +7,66 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public class ArgumentsRule
-    {
-        private readonly Func<AppliedOption, string> validate;
-        private readonly Func<AppliedOption, object> materialize;
-        private readonly Func<ParseResult, IEnumerable<string>> suggest;
-        private readonly Func<string> defaultValue;
+	public class ArgumentsRule
+	{
+		private readonly Func<AppliedOption, string> validate;
+		private readonly Func<AppliedOption, object> materialize;
+		private readonly Func<ParseResult, IEnumerable<string>> suggest;
+		private readonly Func<string> defaultValue;
 
-        public ArgumentsRule(Func<AppliedOption, string> validate) : this(validate, null)
-        {
-        }
+		public ArgumentsRule(Func<AppliedOption, string> validate) : this(validate, null)
+		{
+		}
 
-        internal ArgumentsRule(
-            Func<AppliedOption, string> validate,
-            IReadOnlyCollection<string> allowedValues = null,
-            Func<string> defaultValue = null,
-            string description = null,
-            string name = null,
-            Func<ParseResult, IEnumerable<string>> suggest = null,
-            Func<AppliedOption, object> materialize = null)
-        {
-            this.validate = validate ?? throw new ArgumentNullException(nameof(validate));
+		internal ArgumentsRule(
+			Func<AppliedOption, string> validate,
+			IReadOnlyCollection<string> allowedValues = null,
+			Func<string> defaultValue = null,
+			string description = null,
+			string name = null,
+			Func<ParseResult, IEnumerable<string>> suggest = null,
+			Func<AppliedOption, object> materialize = null)
+		{
+			this.validate = validate ?? throw new ArgumentNullException(nameof(validate));
 
-            this.defaultValue = defaultValue ?? (() => null);
-            Description = description;
-            Name = name;
+			this.defaultValue = defaultValue ?? (() => null);
+			Description = description;
+			Name = name;
 
-            if (suggest == null)
-            {
-                this.suggest = result =>
-                    AllowedValues.FindSuggestions(result);
-            }
-            else
-            {
-                this.suggest = result =>
-                    suggest(result).ToArray()
-                                   .FindSuggestions(
-                                       result.TextToMatch());
-            }
+			if (suggest == null)
+			{
+				this.suggest = result =>
+					AllowedValues.FindSuggestions(result);
+			}
+			else
+			{
+				this.suggest = result =>
+					suggest(result).ToArray()
+								   .FindSuggestions(
+									   result.TextToMatch());
+			}
 
-            AllowedValues = allowedValues ?? Array.Empty<string>();
+			AllowedValues = allowedValues ?? Array.Empty<string>();
 
-            this.materialize = materialize;
-        }
+			this.materialize = materialize;
+		}
 
-        public string Validate(AppliedOption option) => validate(option);
+		public string Validate(AppliedOption option) => validate(option);
 
-        public IReadOnlyCollection<string> AllowedValues { get; }
+		public IReadOnlyCollection<string> AllowedValues { get; }
 
-        internal Func<string> GetDefaultValue => () => defaultValue();
+		internal Func<string> GetDefaultValue => () => defaultValue();
 
-        public string Description { get; }
+		public string Description { get; }
 
-        public string Name { get; }
+		public string Name { get; }
 
-        internal Func<AppliedOption, object> Materializer => materialize;
+		internal Func<AppliedOption, object> Materializer => materialize;
 
-        internal IEnumerable<string> Suggest(ParseResult parseResult) =>
-            suggest(parseResult);
+		internal IEnumerable<string> Suggest(ParseResult parseResult) =>
+			suggest(parseResult);
 
-        internal object Materialize(AppliedOption appliedOption) => 
-            materialize?.Invoke(appliedOption);
-    }
+		internal object Materialize(AppliedOption appliedOption) =>
+			materialize?.Invoke(appliedOption);
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/ArgumentsRuleExtensions.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/ArgumentsRuleExtensions.cs
@@ -6,71 +6,71 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public static class ArgumentsRuleExtensions
-    {
-        public static ArgumentsRule And(
-            this ArgumentsRule rule,
-            Func<AppliedOption, string> error)
-        {
-            return rule.And(new ArgumentsRule(error));
-        }
+	public static class ArgumentsRuleExtensions
+	{
+		public static ArgumentsRule And(
+			this ArgumentsRule rule,
+			Func<AppliedOption, string> error)
+		{
+			return rule.And(new ArgumentsRule(error));
+		}
 
-        public static ArgumentsRule And(
-            this ArgumentsRule rule,
-            ArgumentsRule rule2)
-        {
-            var rules = new[] { rule, rule2 };
+		public static ArgumentsRule And(
+			this ArgumentsRule rule,
+			ArgumentsRule rule2)
+		{
+			var rules = new[] { rule, rule2 };
 
-            return new ArgumentsRule(
-                validate: option => rules.Select(r => r.Validate(option))
-                                         .FirstOrDefault(result => !string.IsNullOrWhiteSpace(result)),
-                allowedValues: rules.SelectMany(r => r.AllowedValues)
-                                    .Distinct()
-                                    .ToArray(),
-                suggest: result => rules.SelectMany(r => r.Suggest(result)),
-                name: rule.Name ?? rule2.Name,
-                description: rule.Description ?? rule2.Description,
-                defaultValue: rule.GetDefaultValue ?? rule2.GetDefaultValue,
-                materialize: rule.Materializer ?? rule2.Materializer);
-        }
+			return new ArgumentsRule(
+				validate: option => rules.Select(r => r.Validate(option))
+										 .FirstOrDefault(result => !string.IsNullOrWhiteSpace(result)),
+				allowedValues: rules.SelectMany(r => r.AllowedValues)
+									.Distinct()
+									.ToArray(),
+				suggest: result => rules.SelectMany(r => r.Suggest(result)),
+				name: rule.Name ?? rule2.Name,
+				description: rule.Description ?? rule2.Description,
+				defaultValue: rule.GetDefaultValue ?? rule2.GetDefaultValue,
+				materialize: rule.Materializer ?? rule2.Materializer);
+		}
 
-        public static ArgumentsRule MaterializeAs<T>(
-            this ArgumentsRule rule,
-            Func<AppliedOption, T> materialize)
-        {
-            if (rule == null)
-            {
-                throw new ArgumentNullException(nameof(rule));
-            }
-            if (materialize == null)
-            {
-                throw new ArgumentNullException(nameof(materialize));
-            }
+		public static ArgumentsRule MaterializeAs<T>(
+			this ArgumentsRule rule,
+			Func<AppliedOption, T> materialize)
+		{
+			if (rule == null)
+			{
+				throw new ArgumentNullException(nameof(rule));
+			}
+			if (materialize == null)
+			{
+				throw new ArgumentNullException(nameof(materialize));
+			}
 
-            return rule.With(materialize: o => materialize(o));
-        }
+			return rule.With(materialize: o => materialize(o));
+		}
 
-        public static ArgumentsRule With(
-            this ArgumentsRule rule,
-            string description = null,
-            string name = null,
-            Func<string> defaultValue = null,
-            Func<AppliedOption, object> materialize = null)
-        {
-            if (rule == null)
-            {
-                throw new ArgumentNullException(nameof(rule));
-            }
+		public static ArgumentsRule With(
+			this ArgumentsRule rule,
+			string description = null,
+			string name = null,
+			Func<string> defaultValue = null,
+			Func<AppliedOption, object> materialize = null)
+		{
+			if (rule == null)
+			{
+				throw new ArgumentNullException(nameof(rule));
+			}
 
-            return new ArgumentsRule(
-                validate: rule.Validate,
-                allowedValues: rule.AllowedValues,
-                defaultValue: defaultValue ??
-                              rule.GetDefaultValue,
-                name: name ?? rule.Name,
-                description: description ?? rule.Description,
-                suggest: rule.Suggest,
-                materialize: materialize ?? rule.Materialize);
-        }
-    }
+			return new ArgumentsRule(
+				validate: rule.Validate,
+				allowedValues: rule.AllowedValues,
+				defaultValue: defaultValue ??
+							  rule.GetDefaultValue,
+				name: name ?? rule.Name,
+				description: description ?? rule.Description,
+				suggest: rule.Suggest,
+				materialize: materialize ?? rule.Materialize);
+		}
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/Command.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/Command.cs
@@ -7,35 +7,35 @@ using static Microsoft.DotNet.Cli.CommandLine.Accept;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public class Command : Option
-    {
-        public Command(
-            string name,
-            string help,
-            Option[] options = null,
-            ArgumentsRule arguments = null,
-            bool treatUnmatchedTokensAsErrors = true) :
-            base(new[] { name }, help, arguments, options)
-        {
-            TreatUnmatchedTokensAsErrors = treatUnmatchedTokensAsErrors;
-        }
+	public class Command : Option
+	{
+		public Command(
+			string name,
+			string help,
+			Option[] options = null,
+			ArgumentsRule arguments = null,
+			bool treatUnmatchedTokensAsErrors = true) :
+			base(new[] { name }, help, arguments, options)
+		{
+			TreatUnmatchedTokensAsErrors = treatUnmatchedTokensAsErrors;
+		}
 
-        public Command(
-            string name,
-            string help,
-            Command[] subcommands) :
-            base(new[] { name }, help, options: subcommands)
-        {
-            var commandNames = subcommands.SelectMany(o => o.Aliases).ToArray();
+		public Command(
+			string name,
+			string help,
+			Command[] subcommands) :
+			base(new[] { name }, help, options: subcommands)
+		{
+			var commandNames = subcommands.SelectMany(o => o.Aliases).ToArray();
 
-            ArgumentsRule =
-                ExactlyOneCommandRequired()
-                    .WithSuggestionsFrom(commandNames)
-                    .And(ArgumentsRule);
-        }
+			ArgumentsRule =
+				ExactlyOneCommandRequired()
+					.WithSuggestionsFrom(commandNames)
+					.And(ArgumentsRule);
+		}
 
-        internal override bool IsCommand => true;
+		internal override bool IsCommand => true;
 
-        public bool TreatUnmatchedTokensAsErrors { get; } = true;
-    }
+		public bool TreatUnmatchedTokensAsErrors { get; } = true;
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/CommandExecutionResult.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/CommandExecutionResult.cs
@@ -7,40 +7,40 @@ using System.Text;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public class CommandExecutionResult
-    {
-        private readonly ParseResult parseResult;
+	public class CommandExecutionResult
+	{
+		private readonly ParseResult parseResult;
 
-        public CommandExecutionResult(ParseResult parseResult, object value = null)
-        {
-            if (parseResult == null)
-            {
-                throw new ArgumentNullException(nameof(parseResult));
-            }
-            this.parseResult = parseResult;
-        }
+		public CommandExecutionResult(ParseResult parseResult, object value = null)
+		{
+			if (parseResult == null)
+			{
+				throw new ArgumentNullException(nameof(parseResult));
+			}
+			this.parseResult = parseResult;
+		}
 
-        public int Code => parseResult.Errors.Any()
-                               ? 1
-                               : 0;
+		public int Code => parseResult.Errors.Any()
+							   ? 1
+							   : 0;
 
-        public override string ToString()
-        {
-            if (parseResult.Errors.Any())
-            {
-                var builder = new StringBuilder();
+		public override string ToString()
+		{
+			if (parseResult.Errors.Any())
+			{
+				var builder = new StringBuilder();
 
-                foreach (var error in parseResult.Errors)
-                {
-                    builder.AppendLine(error.ToString());
-                }
+				foreach (var error in parseResult.Errors)
+				{
+					builder.AppendLine(error.ToString());
+				}
 
-                builder.Append(parseResult.Command().HelpView());
+				builder.Append(parseResult.Command().HelpView());
 
-                return builder.ToString();
-            }
+				return builder.ToString();
+			}
 
-            return "";
-        }
-    }
+			return "";
+		}
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/Create.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/Create.cs
@@ -8,67 +8,67 @@ using System.Reflection;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public static class Create
-    {
-        public static Option Option(
-            string aliases,
-            string help,
-            ArgumentsRule arguments = null) =>
-            new Option(
-                aliases.Split(
-                    new[] { '|', ' ' }, StringSplitOptions.RemoveEmptyEntries), help, arguments);
+	public static class Create
+	{
+		public static Option Option(
+			string aliases,
+			string help,
+			ArgumentsRule arguments = null) =>
+			new Option(
+				aliases.Split(
+					new[] { '|', ' ' }, StringSplitOptions.RemoveEmptyEntries), help, arguments);
 
-      [Obsolete("Do not use this overload. It will be removed. materialize argument is unused.", error: true)]
-      public static Option Option(
-            string aliases,
-            string help,
-            ArgumentsRule arguments,
-            Func<AppliedOption, object> materialize) =>
-            Option(aliases, help, arguments);
+		[Obsolete("Do not use this overload. It will be removed. materialize argument is unused.", error: true)]
+		public static Option Option(
+			  string aliases,
+			  string help,
+			  ArgumentsRule arguments,
+			  Func<AppliedOption, object> materialize) =>
+			  Option(aliases, help, arguments);
 
-        public static Command Command(
-            string name,
-            string help) =>
-            new Command(name, help);
+		public static Command Command(
+			string name,
+			string help) =>
+			new Command(name, help);
 
-        public static Command Command(
-            string name,
-            string help,
-            params Option[] options) =>
-            new Command(name, help, options);
+		public static Command Command(
+			string name,
+			string help,
+			params Option[] options) =>
+			new Command(name, help, options);
 
-        public static Command Command(
-            string name,
-            string help,
-            bool treatUnmatchedTokensAsErrors,
-            params Option[] options) =>
-            new Command(name, help, options, treatUnmatchedTokensAsErrors: treatUnmatchedTokensAsErrors);
+		public static Command Command(
+			string name,
+			string help,
+			bool treatUnmatchedTokensAsErrors,
+			params Option[] options) =>
+			new Command(name, help, options, treatUnmatchedTokensAsErrors: treatUnmatchedTokensAsErrors);
 
-        public static Command Command(
-            string name,
-            string help,
-            ArgumentsRule arguments,
-            params Option[] options) =>
-            new Command(name, help, options, arguments);
+		public static Command Command(
+			string name,
+			string help,
+			ArgumentsRule arguments,
+			params Option[] options) =>
+			new Command(name, help, options, arguments);
 
-        public static Command Command(
-            string name,
-            string help,
-            ArgumentsRule arguments,
-            bool treatUnmatchedTokensAsErrors,
-            params Option[] options) =>
-            new Command(name, help, options, arguments, treatUnmatchedTokensAsErrors);
+		public static Command Command(
+			string name,
+			string help,
+			ArgumentsRule arguments,
+			bool treatUnmatchedTokensAsErrors,
+			params Option[] options) =>
+			new Command(name, help, options, arguments, treatUnmatchedTokensAsErrors);
 
-        public static Command Command(
-            string name,
-            string help,
-            params Command[] commands) =>
-            new Command(name, help, commands);
+		public static Command Command(
+			string name,
+			string help,
+			params Command[] commands) =>
+			new Command(name, help, commands);
 
-        private static readonly Lazy<string> executableName =
-            new Lazy<string>(() => Path.GetFileNameWithoutExtension(Assembly.GetEntryAssembly().Location));
+		private static readonly Lazy<string> executableName =
+			new Lazy<string>(() => Path.GetFileNameWithoutExtension(Assembly.GetEntryAssembly().Location));
 
-        public static Command RootCommand(params Option[] options) =>
-            Command(executableName.Value, "", Accept.NoArguments(), options);
-    }
+		public static Command RootCommand(params Option[] options) =>
+			Command(executableName.Value, "", Accept.NoArguments(), options);
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/DefaultHelpViewText.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/DefaultHelpViewText.cs
@@ -6,32 +6,32 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public class DefaultHelpViewText
-    {
-        public static string AdditionalArgumentsSection { get; set; } =
-            $"{Environment.NewLine}Additional Arguments:{Environment.NewLine}  Arguments passed to the application that is being run.";
+	public class DefaultHelpViewText
+	{
+		public static string AdditionalArgumentsSection { get; set; } =
+			$"{Environment.NewLine}Additional Arguments:{Environment.NewLine}  Arguments passed to the application that is being run.";
 
-        public static class ArgumentsSection
-        {
-            public static string Title { get; set; } = "Arguments:";
-        }
+		public static class ArgumentsSection
+		{
+			public static string Title { get; set; } = "Arguments:";
+		}
 
-        public static class CommandsSection
-        {
-            public static string Title { get; set; } = "Commands:";
-        }
+		public static class CommandsSection
+		{
+			public static string Title { get; set; } = "Commands:";
+		}
 
-        public static class OptionsSection
-        {
-            public static string Title { get; set; } = "Options:";
-        }
+		public static class OptionsSection
+		{
+			public static string Title { get; set; } = "Options:";
+		}
 
-        public static class Synopsis
-        {
-            public static string AdditionalArguments { get; set; } = " [[--] <additional arguments>...]]";
-            public static string Command { get; set; } = " [command]";
-            public static string Options { get; set; } = " [options]";
-            public static string Title { get; set; } = "Usage:";
-        }
-    }
+		public static class Synopsis
+		{
+			public static string AdditionalArguments { get; set; } = " [[--] <additional arguments>...]]";
+			public static string Command { get; set; } = " [command]";
+			public static string Options { get; set; } = " [options]";
+			public static string Title { get; set; } = "Usage:";
+		}
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/DefaultValidationMessages.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/DefaultValidationMessages.cs
@@ -5,39 +5,39 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    internal class DefaultValidationMessages : IValidationMessages
-    {
-        public string CommandAcceptsOnlyOneArgument(string command, int argumentCount) =>
-            $"Command '{command}' only accepts a single argument but {argumentCount} were provided.";
+	internal class DefaultValidationMessages : IValidationMessages
+	{
+		public string CommandAcceptsOnlyOneArgument(string command, int argumentCount) =>
+			$"Command '{command}' only accepts a single argument but {argumentCount} were provided.";
 
-        public string CommandAcceptsOnlyOneSubcommand(string command, string subcommandsSpecified) =>
-            $"Command '{command}' only accepts a single subcommand but multiple were provided: {subcommandsSpecified}";
+		public string CommandAcceptsOnlyOneSubcommand(string command, string subcommandsSpecified) =>
+			$"Command '{command}' only accepts a single subcommand but multiple were provided: {subcommandsSpecified}";
 
-        public string FileDoesNotExist(string filePath) =>
-            $"File does not exist: {filePath}";
+		public string FileDoesNotExist(string filePath) =>
+			$"File does not exist: {filePath}";
 
-        public string NoArgumentsAllowed(string option) =>
-            $"Arguments not allowed for option: {option}";
+		public string NoArgumentsAllowed(string option) =>
+			$"Arguments not allowed for option: {option}";
 
-        public string OptionAcceptsOnlyOneArgument(string option, int argumentCount) =>
-            $"Option '{option}' only accepts a single argument but {argumentCount} were provided.";
+		public string OptionAcceptsOnlyOneArgument(string option, int argumentCount) =>
+			$"Option '{option}' only accepts a single argument but {argumentCount} were provided.";
 
-        public string RequiredArgumentMissingForCommand(string command) =>
-            $"Required argument missing for command: {command}";
+		public string RequiredArgumentMissingForCommand(string command) =>
+			$"Required argument missing for command: {command}";
 
-        public string RequiredArgumentMissingForOption(string option) =>
-            $"Required argument missing for option: {option}";
+		public string RequiredArgumentMissingForOption(string option) =>
+			$"Required argument missing for option: {option}";
 
-        public string RequiredCommandWasNotProvided() =>
-            "Required command was not provided.";
+		public string RequiredCommandWasNotProvided() =>
+			"Required command was not provided.";
 
-        public string UnrecognizedArgument(string unrecognizedArg, string[] allowedValues) =>
-            $"Argument '{unrecognizedArg}' not recognized. Must be one of:\n\t{string.Join("\n\t", allowedValues.Select(v => $"'{v}'"))}";
+		public string UnrecognizedArgument(string unrecognizedArg, string[] allowedValues) =>
+			$"Argument '{unrecognizedArg}' not recognized. Must be one of:\n\t{string.Join("\n\t", allowedValues.Select(v => $"'{v}'"))}";
 
-        public string UnrecognizedCommandOrArgument(string arg) =>
-            $"Unrecognized command or argument '{arg}'";
+		public string UnrecognizedCommandOrArgument(string arg) =>
+			$"Unrecognized command or argument '{arg}'";
 
-        public string UnrecognizedOption(string unrecognizedOption, string[] allowedValues) =>
-            $"Option '{unrecognizedOption}' not recognized. Must be one of:\n\t{string.Join("\n\t", allowedValues.Select(v => $"'{v}'"))}";
-    }
+		public string UnrecognizedOption(string unrecognizedOption, string[] allowedValues) =>
+			$"Option '{unrecognizedOption}' not recognized. Must be one of:\n\t{string.Join("\n\t", allowedValues.Select(v => $"'{v}'"))}";
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/EnumerableExtensions.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/EnumerableExtensions.cs
@@ -7,52 +7,52 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    internal static class EnumerableExtensions
-    {
-        internal static IEnumerable<T> Do<T>(
-            this IEnumerable<T> source,
-            Action<T> action) =>
-            source.Select(x =>
-            {
-                action(x);
-                return x;
-            });
+	internal static class EnumerableExtensions
+	{
+		internal static IEnumerable<T> Do<T>(
+			this IEnumerable<T> source,
+			Action<T> action) =>
+			source.Select(x =>
+			{
+				action(x);
+				return x;
+			});
 
-        internal static IEnumerable<T> FlattenBreadthFirst<T>(
-            this IEnumerable<T> source,
-            Func<T, IEnumerable<T>> children)
-        {
-            var queue = new Queue<T>();
+		internal static IEnumerable<T> FlattenBreadthFirst<T>(
+			this IEnumerable<T> source,
+			Func<T, IEnumerable<T>> children)
+		{
+			var queue = new Queue<T>();
 
-            foreach (var option in source)
-            {
-                queue.Enqueue(option);
-            }
+			foreach (var option in source)
+			{
+				queue.Enqueue(option);
+			}
 
-            while (queue.Count > 0)
-            {
-                var current = queue.Dequeue();
+			while (queue.Count > 0)
+			{
+				var current = queue.Dequeue();
 
-                foreach (var option in children(current))
-                {
-                    queue.Enqueue(option);
-                }
+				foreach (var option in children(current))
+				{
+					queue.Enqueue(option);
+				}
 
-                yield return current;
-            }
-        }
+				yield return current;
+			}
+		}
 
-        internal static IEnumerable<T> RecurseWhileNotNull<T>(
-            this T source,
-            Func<T, T> next)
-            where T : class
-        {
-            yield return source;
+		internal static IEnumerable<T> RecurseWhileNotNull<T>(
+			this T source,
+			Func<T, T> next)
+			where T : class
+		{
+			yield return source;
 
-            while ((source = next(source)) != null)
-            {
-                yield return source;
-            }
-        }
-    }
+			while ((source = next(source)) != null)
+			{
+				yield return source;
+			}
+		}
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/HelpViewExtensions.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/HelpViewExtensions.cs
@@ -9,265 +9,265 @@ using static Microsoft.DotNet.Cli.CommandLine.DefaultHelpViewText;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public static class HelpViewExtensions
-    {
-        private static int columnGutterWidth = 3;
+	public static class HelpViewExtensions
+	{
+		private static int columnGutterWidth = 3;
 
-        public static string HelpView(this Command command)
-        {
-            if (command == null)
-            {
-                throw new ArgumentNullException(nameof(command));
-            }
+		public static string HelpView(this Command command)
+		{
+			if (command == null)
+			{
+				throw new ArgumentNullException(nameof(command));
+			}
 
-            var helpView = new StringBuilder();
+			var helpView = new StringBuilder();
 
-            WriteSynopsis(command, helpView);
+			WriteSynopsis(command, helpView);
 
-            WriteArgumentsSection(command, helpView);
+			WriteArgumentsSection(command, helpView);
 
-            WriteOptionsSection(command, helpView);
+			WriteOptionsSection(command, helpView);
 
-            WriteSubcommandsSection(command, helpView);
+			WriteSubcommandsSection(command, helpView);
 
-            WriteAdditionalArgumentsSection(command, helpView);
+			WriteAdditionalArgumentsSection(command, helpView);
 
-            return helpView.ToString();
-        }
+			return helpView.ToString();
+		}
 
-        private static void WriteAdditionalArgumentsSection(
-            Command command,
-            StringBuilder helpView)
-        {
-            if (command.TreatUnmatchedTokensAsErrors)
-            {
-                return;
-            }
+		private static void WriteAdditionalArgumentsSection(
+			Command command,
+			StringBuilder helpView)
+		{
+			if (command.TreatUnmatchedTokensAsErrors)
+			{
+				return;
+			}
 
-            helpView.Append(AdditionalArgumentsSection);
-        }
+			helpView.Append(AdditionalArgumentsSection);
+		}
 
-        private static void WriteArgumentsSection(
-            Command command,
-            StringBuilder helpView)
-        {
-            var argName = command.ArgumentsRule.Name;
-            var argDescription = command.ArgumentsRule.Description;
+		private static void WriteArgumentsSection(
+			Command command,
+			StringBuilder helpView)
+		{
+			var argName = command.ArgumentsRule.Name;
+			var argDescription = command.ArgumentsRule.Description;
 
-            var shouldWriteCommandArguments =
-                !string.IsNullOrWhiteSpace(argName) &&
-                !string.IsNullOrWhiteSpace(argDescription);
+			var shouldWriteCommandArguments =
+				!string.IsNullOrWhiteSpace(argName) &&
+				!string.IsNullOrWhiteSpace(argDescription);
 
-            var parentCommand = command.Parent as Command;
+			var parentCommand = command.Parent as Command;
 
-            var parentArgName = parentCommand?.ArgumentsRule?.Name;
-            var parentArgDescription = parentCommand?.ArgumentsRule?.Description;
+			var parentArgName = parentCommand?.ArgumentsRule?.Name;
+			var parentArgDescription = parentCommand?.ArgumentsRule?.Description;
 
-            var shouldWriteParentCommandArguments =
-                !string.IsNullOrWhiteSpace(parentArgName) &&
-                !string.IsNullOrWhiteSpace(parentArgDescription);
+			var shouldWriteParentCommandArguments =
+				!string.IsNullOrWhiteSpace(parentArgName) &&
+				!string.IsNullOrWhiteSpace(parentArgDescription);
 
-            if (shouldWriteCommandArguments ||
-                shouldWriteParentCommandArguments)
-            {
-                helpView.AppendLine();
-                helpView.AppendLine(ArgumentsSection.Title);
-            }
-            else
-            {
-                return;
-            }
+			if (shouldWriteCommandArguments ||
+				shouldWriteParentCommandArguments)
+			{
+				helpView.AppendLine();
+				helpView.AppendLine(ArgumentsSection.Title);
+			}
+			else
+			{
+				return;
+			}
 
-            var indent = "  ";
-            var argLeftColumnText = $"{indent}<{argName}>";
-            var parentArgLeftColumnText = $"{indent}<{parentArgName}>";
-            var leftColumnWidth =
-                Math.Max(argLeftColumnText.Length,
-                         parentArgLeftColumnText.Length) +
-                columnGutterWidth;
+			var indent = "  ";
+			var argLeftColumnText = $"{indent}<{argName}>";
+			var parentArgLeftColumnText = $"{indent}<{parentArgName}>";
+			var leftColumnWidth =
+				Math.Max(argLeftColumnText.Length,
+						 parentArgLeftColumnText.Length) +
+				columnGutterWidth;
 
-            if (shouldWriteParentCommandArguments)
-            {
-                WriteColumnizedSummary(
-                    parentArgLeftColumnText,
-                    parentArgDescription,
-                    leftColumnWidth,
-                    helpView);
-            }
+			if (shouldWriteParentCommandArguments)
+			{
+				WriteColumnizedSummary(
+					parentArgLeftColumnText,
+					parentArgDescription,
+					leftColumnWidth,
+					helpView);
+			}
 
-            if (shouldWriteCommandArguments)
-            {
-                WriteColumnizedSummary(
-                    argLeftColumnText,
-                    argDescription,
-                    leftColumnWidth,
-                    helpView);
-            }
-        }
+			if (shouldWriteCommandArguments)
+			{
+				WriteColumnizedSummary(
+					argLeftColumnText,
+					argDescription,
+					leftColumnWidth,
+					helpView);
+			}
+		}
 
-        private static void WriteOptionsSection(
-            Command command,
-            StringBuilder helpView)
-        {
-            var options = command
-                .DefinedOptions
-                .Where(o => !o.IsCommand)
-                .Where(o => !o.IsHidden())
-                .ToArray();
+		private static void WriteOptionsSection(
+			Command command,
+			StringBuilder helpView)
+		{
+			var options = command
+				.DefinedOptions
+				.Where(o => !o.IsCommand)
+				.Where(o => !o.IsHidden())
+				.ToArray();
 
-            if (!options.Any())
-            {
-                return;
-            }
+			if (!options.Any())
+			{
+				return;
+			}
 
-            helpView.AppendLine();
-            helpView.AppendLine(OptionsSection.Title);
+			helpView.AppendLine();
+			helpView.AppendLine(OptionsSection.Title);
 
-            WriteOptionsList(options, helpView);
-        }
+			WriteOptionsList(options, helpView);
+		}
 
-        private static void WriteSubcommandsSection(
-            Command command,
-            StringBuilder helpView)
-        {
-            var subcommands = command
-                .DefinedOptions
-                .Where(o => !o.IsHidden())
-                .OfType<Command>()
-                .ToArray();
+		private static void WriteSubcommandsSection(
+			Command command,
+			StringBuilder helpView)
+		{
+			var subcommands = command
+				.DefinedOptions
+				.Where(o => !o.IsHidden())
+				.OfType<Command>()
+				.ToArray();
 
-            if (!subcommands.Any())
-            {
-                return;
-            }
+			if (!subcommands.Any())
+			{
+				return;
+			}
 
-            helpView.AppendLine();
-            helpView.AppendLine(CommandsSection.Title);
+			helpView.AppendLine();
+			helpView.AppendLine(CommandsSection.Title);
 
-            WriteOptionsList(subcommands, helpView);
-        }
+			WriteOptionsList(subcommands, helpView);
+		}
 
-        private static void WriteOptionsList(
-            Option[] options,
-            StringBuilder helpView)
-        {
-            var leftColumnTextFor = options
-                .ToDictionary(o => o, LeftColumnText);
+		private static void WriteOptionsList(
+			Option[] options,
+			StringBuilder helpView)
+		{
+			var leftColumnTextFor = options
+				.ToDictionary(o => o, LeftColumnText);
 
-            var leftColumnWidth = leftColumnTextFor
-                                      .Values
-                                      .Select(s => s.Length)
-                                      .OrderBy(length => length)
-                                      .Last() + columnGutterWidth;
+			var leftColumnWidth = leftColumnTextFor
+									  .Values
+									  .Select(s => s.Length)
+									  .OrderBy(length => length)
+									  .Last() + columnGutterWidth;
 
-            foreach (var option in options)
-            {
-                WriteColumnizedSummary(leftColumnTextFor[option],
-                                       option.HelpText,
-                                       leftColumnWidth,
-                                       helpView);
-            }
-        }
+			foreach (var option in options)
+			{
+				WriteColumnizedSummary(leftColumnTextFor[option],
+									   option.HelpText,
+									   leftColumnWidth,
+									   helpView);
+			}
+		}
 
-        private static string LeftColumnText(Option option)
-        {
-            var leftColumnText = "  " +
-                                 string.Join(", ",
-                                             option.RawAliases
-                                                   .OrderBy(a => a.Length)
-                                                   .Select(a =>
-                                                   {
-                                                       if (option.IsCommand)
-                                                       {
-                                                           return a.TrimStart(new[] { '-' });
-                                                       }
-                                                       else
-                                                       {
-                                                           return a;
-                                                       }
-                                                   }));
+		private static string LeftColumnText(Option option)
+		{
+			var leftColumnText = "  " +
+								 string.Join(", ",
+											 option.RawAliases
+												   .OrderBy(a => a.Length)
+												   .Select(a =>
+												   {
+													   if (option.IsCommand)
+													   {
+														   return a.TrimStart(new[] { '-' });
+													   }
+													   else
+													   {
+														   return a;
+													   }
+												   }));
 
-            var argumentName = option.ArgumentsRule.Name;
+			var argumentName = option.ArgumentsRule.Name;
 
-            if (!string.IsNullOrWhiteSpace(argumentName))
-            {
-                leftColumnText += $" <{argumentName}>";
-            }
+			if (!string.IsNullOrWhiteSpace(argumentName))
+			{
+				leftColumnText += $" <{argumentName}>";
+			}
 
-            return leftColumnText;
-        }
+			return leftColumnText;
+		}
 
-        private static void WriteColumnizedSummary(
-            string leftColumnText,
-            string rightColumnText,
-            int width,
-            StringBuilder helpView)
-        {
-            helpView.Append(leftColumnText);
+		private static void WriteColumnizedSummary(
+			string leftColumnText,
+			string rightColumnText,
+			int width,
+			StringBuilder helpView)
+		{
+			helpView.Append(leftColumnText);
 
-            if (leftColumnText.Length <= width - 2)
-            {
-                helpView.Append(new string(' ', width - leftColumnText.Length));
-            }
-            else
-            {
-                helpView.AppendLine();
-                helpView.Append(new string(' ', width));
-            }
+			if (leftColumnText.Length <= width - 2)
+			{
+				helpView.Append(new string(' ', width - leftColumnText.Length));
+			}
+			else
+			{
+				helpView.AppendLine();
+				helpView.Append(new string(' ', width));
+			}
 
-            var descriptionWithLineWraps = string.Join(
-                NewLine + new string(' ', width),
-                rightColumnText
-                    .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
-                    .Select(s => s.Trim()));
+			var descriptionWithLineWraps = string.Join(
+				NewLine + new string(' ', width),
+				rightColumnText
+					.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+					.Select(s => s.Trim()));
 
-            helpView.AppendLine(descriptionWithLineWraps);
-        }
+			helpView.AppendLine(descriptionWithLineWraps);
+		}
 
-        private static void WriteSynopsis(
-            Command command,
-            StringBuilder helpView)
-        {
-            helpView.Append(Synopsis.Title);
+		private static void WriteSynopsis(
+			Command command,
+			StringBuilder helpView)
+		{
+			helpView.Append(Synopsis.Title);
 
-            foreach (var subcommand in command
-                .RecurseWhileNotNull(c => c.Parent as Command)
-                .Reverse())
-            {
-                helpView.Append($" {subcommand.Name}");
+			foreach (var subcommand in command
+				.RecurseWhileNotNull(c => c.Parent as Command)
+				.Reverse())
+			{
+				helpView.Append($" {subcommand.Name}");
 
-                var argsName = subcommand.ArgumentsRule.Name;
-                if (subcommand != command &&
-                    !string.IsNullOrWhiteSpace(argsName))
-                {
-                    helpView.Append($" <{argsName}>");
-                }
-            }
+				var argsName = subcommand.ArgumentsRule.Name;
+				if (subcommand != command &&
+					!string.IsNullOrWhiteSpace(argsName))
+				{
+					helpView.Append($" <{argsName}>");
+				}
+			}
 
-            if (command.DefinedOptions
-                       .Any(o => !o.IsCommand &&
-                                 !o.IsHidden()))
-            {
-                helpView.Append(Synopsis.Options);
-            }
+			if (command.DefinedOptions
+					   .Any(o => !o.IsCommand &&
+								 !o.IsHidden()))
+			{
+				helpView.Append(Synopsis.Options);
+			}
 
-            var argumentsName = command.ArgumentsRule.Name;
-            if (!string.IsNullOrWhiteSpace(argumentsName))
-            {
-                helpView.Append($" <{argumentsName}>");
-            }
+			var argumentsName = command.ArgumentsRule.Name;
+			if (!string.IsNullOrWhiteSpace(argumentsName))
+			{
+				helpView.Append($" <{argumentsName}>");
+			}
 
-            if (command.DefinedOptions.OfType<Command>().Any())
-            {
-                helpView.Append(Synopsis.Command);
-            }
+			if (command.DefinedOptions.OfType<Command>().Any())
+			{
+				helpView.Append(Synopsis.Command);
+			}
 
-            if (!command.TreatUnmatchedTokensAsErrors)
-            {
-                helpView.Append(Synopsis.AdditionalArguments);
-            }
+			if (!command.TreatUnmatchedTokensAsErrors)
+			{
+				helpView.Append(Synopsis.AdditionalArguments);
+			}
 
-            helpView.AppendLine();
-        }
-    }
+			helpView.AppendLine();
+		}
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/IValidationMessages.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/IValidationMessages.cs
@@ -3,18 +3,18 @@
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public interface IValidationMessages
-    {
-        string NoArgumentsAllowed(string option);
-        string CommandAcceptsOnlyOneArgument(string command, int argumentCount);
-        string FileDoesNotExist(string filePath);
-        string CommandAcceptsOnlyOneSubcommand(string command, string subcommandsSpecified);
-        string OptionAcceptsOnlyOneArgument(string option, int argumentCount);
-        string RequiredArgumentMissingForCommand(string command);
-        string RequiredArgumentMissingForOption(string option);
-        string RequiredCommandWasNotProvided();
-        string UnrecognizedArgument(string unrecognizedArg, string[] allowedValues);
-        string UnrecognizedCommandOrArgument(string arg);
-        string UnrecognizedOption(string unrecognizedOption, string[] allowedValues);
-    }
+	public interface IValidationMessages
+	{
+		string NoArgumentsAllowed(string option);
+		string CommandAcceptsOnlyOneArgument(string command, int argumentCount);
+		string FileDoesNotExist(string filePath);
+		string CommandAcceptsOnlyOneSubcommand(string command, string subcommandsSpecified);
+		string OptionAcceptsOnlyOneArgument(string option, int argumentCount);
+		string RequiredArgumentMissingForCommand(string command);
+		string RequiredArgumentMissingForOption(string option);
+		string RequiredCommandWasNotProvided();
+		string UnrecognizedArgument(string unrecognizedArg, string[] allowedValues);
+		string UnrecognizedCommandOrArgument(string arg);
+		string UnrecognizedOption(string unrecognizedOption, string[] allowedValues);
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/Option.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/Option.cs
@@ -7,106 +7,106 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public class Option
-    {
-        private readonly HashSet<string> aliases = new HashSet<string>();
+	public class Option
+	{
+		private readonly HashSet<string> aliases = new HashSet<string>();
 
-        private readonly Suggest suggest;
-        private readonly HashSet<string> rawAliases;
+		private readonly Suggest suggest;
+		private readonly HashSet<string> rawAliases;
 
-        public Option(
-            string[] aliases,
-            string help,
-            ArgumentsRule arguments = null) :
-            this(aliases, help, arguments, null)
-        {
-        }
+		public Option(
+			string[] aliases,
+			string help,
+			ArgumentsRule arguments = null) :
+			this(aliases, help, arguments, null)
+		{
+		}
 
-        protected internal Option(
-            string[] aliases,
-            string help,
-            ArgumentsRule arguments = null,
-            Option[] options = null)
-        {
-            if (aliases == null)
-            {
-                throw new ArgumentNullException(nameof(aliases));
-            }
+		protected internal Option(
+			string[] aliases,
+			string help,
+			ArgumentsRule arguments = null,
+			Option[] options = null)
+		{
+			if (aliases == null)
+			{
+				throw new ArgumentNullException(nameof(aliases));
+			}
 
-            if (!aliases.Any())
-            {
-                throw new ArgumentException("An option must have at least one alias.");
-            }
+			if (!aliases.Any())
+			{
+				throw new ArgumentException("An option must have at least one alias.");
+			}
 
-            if (aliases.Any(string.IsNullOrWhiteSpace))
-            {
-                throw new ArgumentException("An option alias cannot be null, empty, or consist entirely of whitespace.");
-            }
+			if (aliases.Any(string.IsNullOrWhiteSpace))
+			{
+				throw new ArgumentException("An option alias cannot be null, empty, or consist entirely of whitespace.");
+			}
 
-            rawAliases = new HashSet<string>(aliases);
+			rawAliases = new HashSet<string>(aliases);
 
-            foreach (var alias in aliases)
-            {
-                this.aliases.Add(alias.RemovePrefix());
-            }
+			foreach (var alias in aliases)
+			{
+				this.aliases.Add(alias.RemovePrefix());
+			}
 
-            HelpText = help;
+			HelpText = help;
 
-            Name = aliases
-                .Select(a => a.RemovePrefix())
-                .OrderBy(a => a.Length)
-                .Last();
+			Name = aliases
+				.Select(a => a.RemovePrefix())
+				.OrderBy(a => a.Length)
+				.Last();
 
-            if (options != null && options.Any())
-            {
-                foreach (var option in options)
-                {
-                    option.Parent = this;
-                    DefinedOptions.Add(option);
-                }
-            }
+			if (options != null && options.Any())
+			{
+				foreach (var option in options)
+				{
+					option.Parent = this;
+					DefinedOptions.Add(option);
+				}
+			}
 
-            ArgumentsRule = arguments ?? Accept.NoArguments();
+			ArgumentsRule = arguments ?? Accept.NoArguments();
 
-            if (options != null)
-            {
-                ArgumentsRule = ArgumentsRule.And(Accept.ZeroOrMoreOf(options));
-            }
+			if (options != null)
+			{
+				ArgumentsRule = ArgumentsRule.And(Accept.ZeroOrMoreOf(options));
+			}
 
-            AllowedValues = ArgumentsRule.AllowedValues;
+			AllowedValues = ArgumentsRule.AllowedValues;
 
-            suggest = ArgumentsRule.Suggest;
-        }
+			suggest = ArgumentsRule.Suggest;
+		}
 
-        public IReadOnlyCollection<string> Aliases => aliases.ToArray();
+		public IReadOnlyCollection<string> Aliases => aliases.ToArray();
 
-        public IReadOnlyCollection<string> RawAliases => rawAliases.ToArray();
+		public IReadOnlyCollection<string> RawAliases => rawAliases.ToArray();
 
-        protected internal virtual IReadOnlyCollection<string> AllowedValues { get; }
+		protected internal virtual IReadOnlyCollection<string> AllowedValues { get; }
 
-        public OptionSet DefinedOptions { get; } = new OptionSet();
+		public OptionSet DefinedOptions { get; } = new OptionSet();
 
-        public string HelpText { get; }
+		public string HelpText { get; }
 
-        public ArgumentsRule ArgumentsRule { get; protected set; }
+		public ArgumentsRule ArgumentsRule { get; protected set; }
 
-        public string Name { get; }
+		public string Name { get; }
 
-        public IEnumerable<string> Suggest(ParseResult parseResult) => suggest(parseResult);
+		public IEnumerable<string> Suggest(ParseResult parseResult) => suggest(parseResult);
 
-        internal virtual bool IsCommand => false;
+		internal virtual bool IsCommand => false;
 
-        public Option Parent { get; protected internal set; }
+		public Option Parent { get; protected internal set; }
 
-        public bool HasAlias(string alias) => aliases.Contains(alias.RemovePrefix());
+		public bool HasAlias(string alias) => aliases.Contains(alias.RemovePrefix());
 
-        public bool HasRawAlias(string alias) => rawAliases.Contains(alias);
+		public bool HasRawAlias(string alias) => rawAliases.Contains(alias);
 
-        public Option this[string alias] => DefinedOptions[alias];
+		public Option this[string alias] => DefinedOptions[alias];
 
-        public override string ToString() =>
-            IsCommand
-                ? Name
-                : RawAliases.Single(a => a.RemovePrefix() == Name);
-    }
+		public override string ToString() =>
+			IsCommand
+				? Name
+				: RawAliases.Single(a => a.RemovePrefix() == Name);
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/OptionError.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/OptionError.cs
@@ -5,33 +5,33 @@ using System;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public class OptionError
-    {
-        public OptionError(
-            string message, 
-            string token,
-            AppliedOption option = null)
-        {
-            if (string.IsNullOrWhiteSpace(message))
-            {
-                throw new ArgumentException("Value cannot be null or whitespace.", nameof(message));
-            }
-            if (string.IsNullOrWhiteSpace(token))
-            {
-                throw new ArgumentException("Value cannot be null or whitespace.", nameof(token));
-            }
+	public class OptionError
+	{
+		public OptionError(
+			string message,
+			string token,
+			AppliedOption option = null)
+		{
+			if (string.IsNullOrWhiteSpace(message))
+			{
+				throw new ArgumentException("Value cannot be null or whitespace.", nameof(message));
+			}
+			if (string.IsNullOrWhiteSpace(token))
+			{
+				throw new ArgumentException("Value cannot be null or whitespace.", nameof(token));
+			}
 
-            Message = message;
-            Option = option;
-            Token = token;
-        }
+			Message = message;
+			Option = option;
+			Token = token;
+		}
 
-        public string Message { get; }
+		public string Message { get; }
 
-        public AppliedOption Option { get; }
+		public AppliedOption Option { get; }
 
-        public string Token { get;  }
+		public string Token { get; }
 
-        public override string ToString() => Message;
-    }
+		public override string ToString() => Message;
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/OptionExtensions.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/OptionExtensions.cs
@@ -7,50 +7,50 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public static class OptionExtensions
-    {
-        internal static IEnumerable<Option> FlattenBreadthFirst(
-            this IEnumerable<Option> options)
-        {
-            foreach (var item in options.FlattenBreadthFirst(o => o.DefinedOptions))
-            {
-                yield return item;
-            }
-        }
+	public static class OptionExtensions
+	{
+		internal static IEnumerable<Option> FlattenBreadthFirst(
+			this IEnumerable<Option> options)
+		{
+			foreach (var item in options.FlattenBreadthFirst(o => o.DefinedOptions))
+			{
+				yield return item;
+			}
+		}
 
-        public static Command Command(this Option option) =>
-            option.RecurseWhileNotNull(o => o.Parent)
-                  .OfType<Command>()
-                  .FirstOrDefault();
+		public static Command Command(this Option option) =>
+			option.RecurseWhileNotNull(o => o.Parent)
+				  .OfType<Command>()
+				  .FirstOrDefault();
 
-        public static bool IsHidden(this Option option) =>
-            string.IsNullOrWhiteSpace(option.HelpText);
+		public static bool IsHidden(this Option option) =>
+			string.IsNullOrWhiteSpace(option.HelpText);
 
-        internal static IEnumerable<AppliedOption> AllOptions(
-            this AppliedOption option)
-        {
-            if (option == null)
-            {
-                throw new ArgumentNullException(nameof(option));
-            }
+		internal static IEnumerable<AppliedOption> AllOptions(
+			this AppliedOption option)
+		{
+			if (option == null)
+			{
+				throw new ArgumentNullException(nameof(option));
+			}
 
-            yield return option;
+			yield return option;
 
-            foreach (var item in option.AppliedOptions.FlattenBreadthFirst(o => o.AppliedOptions))
-            {
-                yield return item;
-            }
-        }
+			foreach (var item in option.AppliedOptions.FlattenBreadthFirst(o => o.AppliedOptions))
+			{
+				yield return item;
+			}
+		}
 
-        public static ParseResult Parse(
-            this Option option,
-            params string[] args) =>
-            new Parser(option).Parse(args);
+		public static ParseResult Parse(
+			this Option option,
+			params string[] args) =>
+			new Parser(option).Parse(args);
 
-        public static ParseResult Parse(
-            this Option option,
-            string commandLine,
-            char[] delimiters = null) =>
-            new Parser(delimiters, option).Parse(commandLine);
-    }
+		public static ParseResult Parse(
+			this Option option,
+			string commandLine,
+			char[] delimiters = null) =>
+			new Parser(delimiters, option).Parse(commandLine);
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/OptionSet.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/OptionSet.cs
@@ -4,15 +4,15 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public class OptionSet : OptionSet<Option>
-    {
-        protected override bool HasAlias(Option option, string alias) =>
-            option.HasAlias(alias);
+	public class OptionSet : OptionSet<Option>
+	{
+		protected override bool HasAlias(Option option, string alias) =>
+			option.HasAlias(alias);
 
-        protected override bool HasRawAlias(Option option, string alias) =>
-            option.HasRawAlias(alias);
+		protected override bool HasRawAlias(Option option, string alias) =>
+			option.HasRawAlias(alias);
 
-        protected override IReadOnlyCollection<string> RawAliasesFor(Option option) =>
-            option.RawAliases;
-    }
+		protected override IReadOnlyCollection<string> RawAliasesFor(Option option) =>
+			option.RawAliases;
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/OptionSet{T}.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/OptionSet{T}.cs
@@ -6,75 +6,75 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    [DebuggerStepThrough]
-    public abstract class OptionSet<T> : IReadOnlyCollection<T>
-        where T : class
-    {
-        private readonly HashSet<T> options = new HashSet<T>();
+	[DebuggerStepThrough]
+	public abstract class OptionSet<T> : IReadOnlyCollection<T>
+		where T : class
+	{
+		private readonly HashSet<T> options = new HashSet<T>();
 
-        protected OptionSet()
-        {
-        }
+		protected OptionSet()
+		{
+		}
 
-        protected OptionSet(IReadOnlyCollection<T> options)
-        {
-            if (options == null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
+		protected OptionSet(IReadOnlyCollection<T> options)
+		{
+			if (options == null)
+			{
+				throw new ArgumentNullException(nameof(options));
+			}
 
-            foreach (var option in options)
-            {
-                Add(option);
-            }
-        }
+			foreach (var option in options)
+			{
+				Add(option);
+			}
+		}
 
-        public T this[string alias] =>
-            options.SingleOrDefault(o => HasRawAlias(o, alias)) ??
-            options.Single(o => HasAlias(o, alias));
+		public T this[string alias] =>
+			options.SingleOrDefault(o => HasRawAlias(o, alias)) ??
+			options.Single(o => HasAlias(o, alias));
 
-        public int Count => options.Count;
+		public int Count => options.Count;
 
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return GetEnumerator();
+		}
 
-        public IEnumerator<T> GetEnumerator()
-        {
-            return options.GetEnumerator();
-        }
+		public IEnumerator<T> GetEnumerator()
+		{
+			return options.GetEnumerator();
+		}
 
-        internal void AddRange(IEnumerable<T> options)
-        {
-            foreach (var option in options)
-            {
-                Add(option);
-            }
-        }
+		internal void AddRange(IEnumerable<T> options)
+		{
+			foreach (var option in options)
+			{
+				Add(option);
+			}
+		}
 
-        protected abstract bool HasAlias(T option, string alias);
+		protected abstract bool HasAlias(T option, string alias);
 
-        protected abstract bool HasRawAlias(T option, string alias);
+		protected abstract bool HasRawAlias(T option, string alias);
 
-        internal void Add(T option)
-        {
-            var preexistingAlias = RawAliasesFor(option)
-                .FirstOrDefault(alias =>
-                                    options.Any(o =>
-                                                    HasRawAlias(o, alias)));
+		internal void Add(T option)
+		{
+			var preexistingAlias = RawAliasesFor(option)
+				.FirstOrDefault(alias =>
+									options.Any(o =>
+													HasRawAlias(o, alias)));
 
-            if (preexistingAlias != null)
-            {
-                throw new ArgumentException($"Alias '{preexistingAlias}' is already in use.");
-            }
+			if (preexistingAlias != null)
+			{
+				throw new ArgumentException($"Alias '{preexistingAlias}' is already in use.");
+			}
 
-            options.Add(option);
-        }
+			options.Add(option);
+		}
 
-        protected abstract IReadOnlyCollection<string> RawAliasesFor(T option);
+		protected abstract IReadOnlyCollection<string> RawAliasesFor(T option);
 
-        public bool Contains(string alias) => 
-            options.Any(option => HasAlias(option, alias));
-    }
+		public bool Contains(string alias) =>
+			options.Any(option => HasAlias(option, alias));
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/ParseException.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/ParseException.cs
@@ -2,14 +2,14 @@ using System;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public class ParseException : Exception
-    {
-        public ParseException(string message) : base(message)
-        {
-        }
+	public class ParseException : Exception
+	{
+		public ParseException(string message) : base(message)
+		{
+		}
 
-        public ParseException(string message, Exception innerException) : base(message, innerException)
-        {
-        }
-    }
+		public ParseException(string message, Exception innerException) : base(message, innerException)
+		{
+		}
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/ParseResult.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/ParseResult.cs
@@ -9,85 +9,85 @@ using static Microsoft.DotNet.Cli.CommandLine.ValidationMessages;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    [DebuggerDisplay("{" + nameof(ToString) + "()}")]
-    public class ParseResult
-    {
-        private readonly ParserConfiguration configuration;
-        private readonly List<OptionError> errors = new List<OptionError>();
-        private Command command;
+	[DebuggerDisplay("{" + nameof(ToString) + "()}")]
+	public class ParseResult
+	{
+		private readonly ParserConfiguration configuration;
+		private readonly List<OptionError> errors = new List<OptionError>();
+		private Command command;
 
-        internal ParseResult(
-            IReadOnlyCollection<string> tokens,
-            AppliedOptionSet appliedOptions,
-            bool isProgressive,
-            ParserConfiguration configuration,
-            IReadOnlyCollection<string> unparsedTokens = null,
-            IReadOnlyCollection<string> unmatchedTokens = null,
-            IReadOnlyCollection<OptionError> errors = null)
-        {
-            Tokens = tokens ??
-                     throw new ArgumentNullException(nameof(tokens));
-            AppliedOptions = appliedOptions ??
-                             throw new ArgumentNullException(nameof(appliedOptions));
-            this.configuration = configuration ??
-                                 throw new ArgumentNullException(nameof(configuration));
+		internal ParseResult(
+			IReadOnlyCollection<string> tokens,
+			AppliedOptionSet appliedOptions,
+			bool isProgressive,
+			ParserConfiguration configuration,
+			IReadOnlyCollection<string> unparsedTokens = null,
+			IReadOnlyCollection<string> unmatchedTokens = null,
+			IReadOnlyCollection<OptionError> errors = null)
+		{
+			Tokens = tokens ??
+					 throw new ArgumentNullException(nameof(tokens));
+			AppliedOptions = appliedOptions ??
+							 throw new ArgumentNullException(nameof(appliedOptions));
+			this.configuration = configuration ??
+								 throw new ArgumentNullException(nameof(configuration));
 
-            IsProgressive = isProgressive;
-            UnparsedTokens = unparsedTokens;
-            UnmatchedTokens = unmatchedTokens;
+			IsProgressive = isProgressive;
+			UnparsedTokens = unparsedTokens;
+			UnmatchedTokens = unmatchedTokens;
 
-            if (errors != null)
-            {
-                this.errors.AddRange(errors);
-            }
+			if (errors != null)
+			{
+				this.errors.AddRange(errors);
+			}
 
-            CheckForErrors();
-        }
+			CheckForErrors();
+		}
 
-        public AppliedOptionSet AppliedOptions { get; }
+		public AppliedOptionSet AppliedOptions { get; }
 
-        public IEnumerable<OptionError> Errors => errors;
+		public IEnumerable<OptionError> Errors => errors;
 
-        public bool IsProgressive { get; }
+		public bool IsProgressive { get; }
 
-        public IReadOnlyCollection<string> Tokens { get; }
+		public IReadOnlyCollection<string> Tokens { get; }
 
-        public IReadOnlyCollection<string> UnmatchedTokens { get; }
+		public IReadOnlyCollection<string> UnmatchedTokens { get; }
 
-        public IReadOnlyCollection<string> UnparsedTokens { get; }
+		public IReadOnlyCollection<string> UnparsedTokens { get; }
 
-        public AppliedOption this[string alias] => AppliedOptions[alias];
+		public AppliedOption this[string alias] => AppliedOptions[alias];
 
-        public Command Command() =>
-            command ??
-            (command = configuration.RootCommandIsImplicit
-                           ? configuration.DefinedOptions.OfType<Command>().Single()
-                           : AppliedOptions.Command());
+		public Command Command() =>
+			command ??
+			(command = configuration.RootCommandIsImplicit
+						   ? configuration.DefinedOptions.OfType<Command>().Single()
+						   : AppliedOptions.Command());
 
-        private void CheckForErrors()
-        {
-            foreach (var option in AppliedOptions.FlattenBreadthFirst())
-            {
-                var error = option.Validate();
+		private void CheckForErrors()
+		{
+			foreach (var option in AppliedOptions.FlattenBreadthFirst())
+			{
+				var error = option.Validate();
 
-                if (error != null)
-                {
-                    errors.Add(error);
-                }
-            }
+				if (error != null)
+				{
+					errors.Add(error);
+				}
+			}
 
-            var command = Command();
+			var command = Command();
 
-            if (command != null &&
-                command.DefinedOptions.Any(o => o.IsCommand))
-            {
-                errors.Insert(0, new OptionError(
-                                  RequiredCommandWasNotProvided(),
-                                  command.Name,
-                                  this.AppliedCommand()));
-            }
-        }
+			if (command != null &&
+				command.DefinedOptions.Any(o => o.IsCommand))
+			{
+				errors.Insert(0, new OptionError(
+								  RequiredCommandWasNotProvided(),
+								  command.Name,
+								  this.AppliedCommand()));
+			}
+		}
 
-        public override string ToString() => this.Diagram();
-    }
+		public override string ToString() => this.Diagram();
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/ParseResultExtensions.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/ParseResultExtensions.cs
@@ -8,138 +8,138 @@ using System.Text;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public static class ParseResultExtensions
-    {
-        public static string TextToMatch(this ParseResult source)
-        {
-            var lastToken = source.Tokens.LastOrDefault();
+	public static class ParseResultExtensions
+	{
+		public static string TextToMatch(this ParseResult source)
+		{
+			var lastToken = source.Tokens.LastOrDefault();
 
-            if (string.IsNullOrWhiteSpace(lastToken))
-            {
-                return "";
-            }
+			if (string.IsNullOrWhiteSpace(lastToken))
+			{
+				return "";
+			}
 
-            if (source.IsProgressive)
-            {
-                return lastToken;
-            }
+			if (source.IsProgressive)
+			{
+				return lastToken;
+			}
 
-            return source.UnmatchedTokens.LastOrDefault() ?? "";
-        }
+			return source.UnmatchedTokens.LastOrDefault() ?? "";
+		}
 
-        internal static Command Command(this AppliedOptionSet options) =>
-            options.FlattenBreadthFirst()
-                   .Select(a => a.Option)
-                   .OfType<Command>()
-                   .LastOrDefault();
+		internal static Command Command(this AppliedOptionSet options) =>
+			options.FlattenBreadthFirst()
+				   .Select(a => a.Option)
+				   .OfType<Command>()
+				   .LastOrDefault();
 
-        public static AppliedOption AppliedCommand(this ParseResult result)
-        {
-            var commandPath = result
-                .Command()
-                .RecurseWhileNotNull(c => c.Parent as Command)
-                .Select(c => c.Name)
-                .Reverse()
-                .ToArray();
+		public static AppliedOption AppliedCommand(this ParseResult result)
+		{
+			var commandPath = result
+				.Command()
+				.RecurseWhileNotNull(c => c.Parent as Command)
+				.Select(c => c.Name)
+				.Reverse()
+				.ToArray();
 
-            var option = result[commandPath.First()];
+			var option = result[commandPath.First()];
 
-            foreach (var commandName in commandPath.Skip(1))
-            {
-                option = option[commandName];
-            }
+			foreach (var commandName in commandPath.Skip(1))
+			{
+				option = option[commandName];
+			}
 
-            return option;
-        }
+			return option;
+		}
 
-        internal static AppliedOption CurrentOption(this ParseResult result) =>
-            result.AppliedOptions
-                  .LastOrDefault()
-                  .AllOptions()
-                  .LastOrDefault();
+		internal static AppliedOption CurrentOption(this ParseResult result) =>
+			result.AppliedOptions
+				  .LastOrDefault()
+				  .AllOptions()
+				  .LastOrDefault();
 
-        public static string Diagram(this ParseResult result)
-        {
-            var builder = new StringBuilder();
+		public static string Diagram(this ParseResult result)
+		{
+			var builder = new StringBuilder();
 
-            foreach (var o in result.AppliedOptions)
-            {
-                builder.Diagram(o);
-            }
+			foreach (var o in result.AppliedOptions)
+			{
+				builder.Diagram(o);
+			}
 
-            if (result.UnmatchedTokens.Any())
-            {
-                builder.Append("   ???-->");
+			if (result.UnmatchedTokens.Any())
+			{
+				builder.Append("   ???-->");
 
-                foreach (var error in result.UnmatchedTokens)
-                {
-                    builder.Append(" ");
-                    builder.Append(error);
-                }
-            }
+				foreach (var error in result.UnmatchedTokens)
+				{
+					builder.Append(" ");
+					builder.Append(error);
+				}
+			}
 
-            return builder.ToString();
-        }
+			return builder.ToString();
+		}
 
-        public static string Diagram(this AppliedOption option)
-        {
-            var stringbuilder = new StringBuilder();
+		public static string Diagram(this AppliedOption option)
+		{
+			var stringbuilder = new StringBuilder();
 
-            stringbuilder.Diagram(option);
+			stringbuilder.Diagram(option);
 
-            return stringbuilder.ToString();
-        }
+			return stringbuilder.ToString();
+		}
 
-        private static void Diagram(
-            this StringBuilder builder,
-            AppliedOption option)
-        {
-            builder.Append("[ ");
+		private static void Diagram(
+			this StringBuilder builder,
+			AppliedOption option)
+		{
+			builder.Append("[ ");
 
-            builder.Append(option.Option);
+			builder.Append(option.Option);
 
-            foreach (var childOption in option.AppliedOptions)
-            {
-                builder.Append(" ");
-                builder.Diagram(childOption);
-            }
+			foreach (var childOption in option.AppliedOptions)
+			{
+				builder.Append(" ");
+				builder.Diagram(childOption);
+			}
 
-            foreach (var arg in option.Arguments)
-            {
-                builder.Append(" <");
-                builder.Append(arg);
-                builder.Append(">");
-            }
+			foreach (var arg in option.Arguments)
+			{
+				builder.Append(" <");
+				builder.Append(arg);
+				builder.Append(">");
+			}
 
-            builder.Append(" ]");
-        }
+			builder.Append(" ]");
+		}
 
-        public static CommandExecutionResult Execute(this ParseResult parseResult)
-        {
-            if (parseResult == null)
-            {
-                throw new ArgumentNullException(nameof(parseResult));
-            }
+		public static CommandExecutionResult Execute(this ParseResult parseResult)
+		{
+			if (parseResult == null)
+			{
+				throw new ArgumentNullException(nameof(parseResult));
+			}
 
-            return new CommandExecutionResult(parseResult);
-        }
+			return new CommandExecutionResult(parseResult);
+		}
 
-        public static bool HasOption(
-            this ParseResult parseResult,
-            string alias)
-        {
-            if (parseResult == null)
-            {
-                throw new ArgumentNullException(nameof(parseResult));
-            }
+		public static bool HasOption(
+			this ParseResult parseResult,
+			string alias)
+		{
+			if (parseResult == null)
+			{
+				throw new ArgumentNullException(nameof(parseResult));
+			}
 
-            return parseResult.AppliedOptions.Contains(alias);
-        }
+			return parseResult.AppliedOptions.Contains(alias);
+		}
 
-        public static IEnumerable<string> Suggestions(this ParseResult parseResult) =>
-            parseResult?.CurrentOption()
-                       ?.Option
-                       ?.Suggest(parseResult) ??
-            Array.Empty<string>();
-    }
+		public static IEnumerable<string> Suggestions(this ParseResult parseResult) =>
+			parseResult?.CurrentOption()
+					   ?.Option
+					   ?.Suggest(parseResult) ??
+			Array.Empty<string>();
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/Parser.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/Parser.cs
@@ -9,164 +9,164 @@ using static Microsoft.DotNet.Cli.CommandLine.ValidationMessages;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public class Parser
-    {
-        private readonly ParserConfiguration configuration;
+	public class Parser
+	{
+		private readonly ParserConfiguration configuration;
 
-        public Parser(params Option[] options) : this(new ParserConfiguration(options))
-        {
-        }
+		public Parser(params Option[] options) : this(new ParserConfiguration(options))
+		{
+		}
 
-        public Parser(char[] delimiters, params Option[] options) : this(new ParserConfiguration(options, argumentDelimiters: delimiters))
-        {
-        }
+		public Parser(char[] delimiters, params Option[] options) : this(new ParserConfiguration(options, argumentDelimiters: delimiters))
+		{
+		}
 
-        public Parser(ParserConfiguration configuration)
-        {
-            this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
-        }
+		public Parser(ParserConfiguration configuration)
+		{
+			this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+		}
 
-        public OptionSet DefinedOptions => configuration.DefinedOptions;
+		public OptionSet DefinedOptions => configuration.DefinedOptions;
 
-        public ParseResult Parse(string[] args) => Parse(args, false);
+		public ParseResult Parse(string[] args) => Parse(args, false);
 
-        internal ParseResult Parse(
-            IReadOnlyCollection<string> rawArgs,
-            bool isProgressive)
-        {
-            var unparsedTokens = new Queue<Token>(
-                NormalizeRootCommand(rawArgs)
-                    .Lex(configuration));
-            var rootAppliedOptions = new AppliedOptionSet();
-            var allAppliedOptions = new List<AppliedOption>();
-            var errors = new List<OptionError>();
-            var unmatchedTokens = new List<string>();
+		internal ParseResult Parse(
+			IReadOnlyCollection<string> rawArgs,
+			bool isProgressive)
+		{
+			var unparsedTokens = new Queue<Token>(
+				NormalizeRootCommand(rawArgs)
+					.Lex(configuration));
+			var rootAppliedOptions = new AppliedOptionSet();
+			var allAppliedOptions = new List<AppliedOption>();
+			var errors = new List<OptionError>();
+			var unmatchedTokens = new List<string>();
 
-            while (unparsedTokens.Any())
-            {
-                var token = unparsedTokens.Dequeue();
+			while (unparsedTokens.Any())
+			{
+				var token = unparsedTokens.Dequeue();
 
-                if (token.Type == TokenType.EndOfArguments)
-                {
-                    // stop parsing further tokens
-                    break;
-                }
+				if (token.Type == TokenType.EndOfArguments)
+				{
+					// stop parsing further tokens
+					break;
+				}
 
-                if (token.Type != TokenType.Argument)
-                {
-                    var definedOption =
-                        DefinedOptions.SingleOrDefault(o => o.HasAlias(token.Value));
+				if (token.Type != TokenType.Argument)
+				{
+					var definedOption =
+						DefinedOptions.SingleOrDefault(o => o.HasAlias(token.Value));
 
-                    if (definedOption != null)
-                    {
-                        var appliedOption = allAppliedOptions
-                            .LastOrDefault(o => o.HasAlias(token.Value));
+					if (definedOption != null)
+					{
+						var appliedOption = allAppliedOptions
+							.LastOrDefault(o => o.HasAlias(token.Value));
 
-                        if (appliedOption == null)
-                        {
-                            appliedOption = new AppliedOption(
-                                definedOption,
-                                token.Value);
-                            rootAppliedOptions.Add(appliedOption);
-                        }
+						if (appliedOption == null)
+						{
+							appliedOption = new AppliedOption(
+								definedOption,
+								token.Value);
+							rootAppliedOptions.Add(appliedOption);
+						}
 
-                        allAppliedOptions.Add(appliedOption);
+						allAppliedOptions.Add(appliedOption);
 
-                        continue;
-                    }
-                }
+						continue;
+					}
+				}
 
-                var added = false;
+				var added = false;
 
-                foreach (var appliedOption in Enumerable.Reverse(allAppliedOptions))
-                {
-                    var option = appliedOption.TryTakeToken(token);
+				foreach (var appliedOption in Enumerable.Reverse(allAppliedOptions))
+				{
+					var option = appliedOption.TryTakeToken(token);
 
-                    if (option != null)
-                    {
-                        allAppliedOptions.Add(option);
-                        added = true;
-                        break;
-                    }
+					if (option != null)
+					{
+						allAppliedOptions.Add(option);
+						added = true;
+						break;
+					}
 
-                    if (token.Type == TokenType.Argument &&
-                        appliedOption.Option.IsCommand)
-                    {
-                        break;
-                    }
-                }
+					if (token.Type == TokenType.Argument &&
+						appliedOption.Option.IsCommand)
+					{
+						break;
+					}
+				}
 
-                if (!added)
-                {
-                    unmatchedTokens.Add(token.Value);
-                }
-            }
+				if (!added)
+				{
+					unmatchedTokens.Add(token.Value);
+				}
+			}
 
-            if (rootAppliedOptions.Command()?.TreatUnmatchedTokensAsErrors == true)
-            {
-                errors.AddRange(
-                    unmatchedTokens.Select(UnrecognizedArg));
-            }
+			if (rootAppliedOptions.Command()?.TreatUnmatchedTokensAsErrors == true)
+			{
+				errors.AddRange(
+					unmatchedTokens.Select(UnrecognizedArg));
+			}
 
-            if (configuration.RootCommandIsImplicit)
-            {
-                rawArgs = rawArgs.Skip(1).ToArray();
-                var appliedOptions = rootAppliedOptions
-                    .SelectMany(o => o.AppliedOptions)
-                    .ToArray();
-                rootAppliedOptions = new AppliedOptionSet(appliedOptions);
-            }
+			if (configuration.RootCommandIsImplicit)
+			{
+				rawArgs = rawArgs.Skip(1).ToArray();
+				var appliedOptions = rootAppliedOptions
+					.SelectMany(o => o.AppliedOptions)
+					.ToArray();
+				rootAppliedOptions = new AppliedOptionSet(appliedOptions);
+			}
 
-            return new ParseResult(
-                rawArgs,
-                rootAppliedOptions,
-                isProgressive,
-                configuration,
-                unparsedTokens.Select(t => t.Value).ToArray(),
-                unmatchedTokens,
-                errors);
-        }
+			return new ParseResult(
+				rawArgs,
+				rootAppliedOptions,
+				isProgressive,
+				configuration,
+				unparsedTokens.Select(t => t.Value).ToArray(),
+				unmatchedTokens,
+				errors);
+		}
 
-        internal IReadOnlyCollection<string> NormalizeRootCommand(IReadOnlyCollection<string> args)
-        {
-            if (configuration.RootCommandIsImplicit)
-            {
-                args = new[] { configuration.RootCommand.Name }.Concat(args).ToArray();
-            }
+		internal IReadOnlyCollection<string> NormalizeRootCommand(IReadOnlyCollection<string> args)
+		{
+			if (configuration.RootCommandIsImplicit)
+			{
+				args = new[] { configuration.RootCommand.Name }.Concat(args).ToArray();
+			}
 
-            var firstArg = args.FirstOrDefault();
+			var firstArg = args.FirstOrDefault();
 
-            if (DefinedOptions.Count != 1)
-            {
-                return args;
-            }
+			if (DefinedOptions.Count != 1)
+			{
+				return args;
+			}
 
-            var commandName = DefinedOptions
-                .SingleOrDefault(o => o.IsCommand)
-                ?.Name;
+			var commandName = DefinedOptions
+				.SingleOrDefault(o => o.IsCommand)
+				?.Name;
 
-            if (commandName == null ||
-                string.Equals(firstArg, commandName, StringComparison.OrdinalIgnoreCase))
-            {
-                return args;
-            }
+			if (commandName == null ||
+				string.Equals(firstArg, commandName, StringComparison.OrdinalIgnoreCase))
+			{
+				return args;
+			}
 
-            if (firstArg != null &&
-                firstArg.Contains(Path.DirectorySeparatorChar) &&
-                (firstArg.EndsWith(commandName, StringComparison.OrdinalIgnoreCase) ||
-                 firstArg.EndsWith($"{commandName}.exe", StringComparison.OrdinalIgnoreCase)))
-            {
-                args = new[] { commandName }.Concat(args.Skip(1)).ToArray();
-            }
-            else
-            {
-                args = new[] { commandName }.Concat(args).ToArray();
-            }
+			if (firstArg != null &&
+				firstArg.Contains(Path.DirectorySeparatorChar) &&
+				(firstArg.EndsWith(commandName, StringComparison.OrdinalIgnoreCase) ||
+				 firstArg.EndsWith($"{commandName}.exe", StringComparison.OrdinalIgnoreCase)))
+			{
+				args = new[] { commandName }.Concat(args.Skip(1)).ToArray();
+			}
+			else
+			{
+				args = new[] { commandName }.Concat(args).ToArray();
+			}
 
-            return args;
-        }
+			return args;
+		}
 
-        private static OptionError UnrecognizedArg(string arg) =>
-            new OptionError(UnrecognizedCommandOrArgument(arg), arg);
-    }
+		private static OptionError UnrecognizedArg(string arg) =>
+			new OptionError(UnrecognizedCommandOrArgument(arg), arg);
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/ParserConfiguration.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/ParserConfiguration.cs
@@ -4,45 +4,45 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public class ParserConfiguration
-    {
-        public ParserConfiguration(
-            IReadOnlyCollection<Option> definedOptions,
-            IReadOnlyCollection<char> argumentDelimiters = null,
-            bool allowUnbundling = true)
-        {
-            if (definedOptions == null)
-            {
-                throw new ArgumentNullException(nameof(definedOptions));
-            }
+	public class ParserConfiguration
+	{
+		public ParserConfiguration(
+			IReadOnlyCollection<Option> definedOptions,
+			IReadOnlyCollection<char> argumentDelimiters = null,
+			bool allowUnbundling = true)
+		{
+			if (definedOptions == null)
+			{
+				throw new ArgumentNullException(nameof(definedOptions));
+			}
 
-            if (!definedOptions.Any())
-            {
-                throw new ArgumentException("You must specify at least one option.");
-            }
+			if (!definedOptions.Any())
+			{
+				throw new ArgumentException("You must specify at least one option.");
+			}
 
-            if (definedOptions.All(o => !o.IsCommand))
-            {
-                RootCommand = Create.RootCommand(definedOptions.ToArray());
-                DefinedOptions.Add(RootCommand);
-            }
-            else
-            {
-                DefinedOptions.AddRange(definedOptions);
-            }
+			if (definedOptions.All(o => !o.IsCommand))
+			{
+				RootCommand = Create.RootCommand(definedOptions.ToArray());
+				DefinedOptions.Add(RootCommand);
+			}
+			else
+			{
+				DefinedOptions.AddRange(definedOptions);
+			}
 
-            ArgumentDelimiters = argumentDelimiters ?? new[] { ':', '=' };
-            AllowUnbundling = allowUnbundling;
-        }
+			ArgumentDelimiters = argumentDelimiters ?? new[] { ':', '=' };
+			AllowUnbundling = allowUnbundling;
+		}
 
-        public OptionSet DefinedOptions { get; } = new OptionSet();
+		public OptionSet DefinedOptions { get; } = new OptionSet();
 
-        public IReadOnlyCollection<char> ArgumentDelimiters { get; }
+		public IReadOnlyCollection<char> ArgumentDelimiters { get; }
 
-        public bool AllowUnbundling { get; }
+		public bool AllowUnbundling { get; }
 
-        internal Option RootCommand { get; }
+		internal Option RootCommand { get; }
 
-        internal bool RootCommandIsImplicit => RootCommand != null;
-    }
+		internal bool RootCommandIsImplicit => RootCommand != null;
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/ParserExtensions.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/ParserExtensions.cs
@@ -6,10 +6,10 @@ using System.Linq;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public static class ParserExtensions
-    {
-        public static ParseResult Parse(this Parser parser, string s) =>
-            parser.Parse(s.Tokenize().ToArray(),
-                         isProgressive: !s.EndsWith(" "));
-    }
+	public static class ParserExtensions
+	{
+		public static ParseResult Parse(this Parser parser, string s) =>
+			parser.Parse(s.Tokenize().ToArray(),
+						 isProgressive: !s.EndsWith(" "));
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/StringExtensions.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/StringExtensions.cs
@@ -9,185 +9,185 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public static class StringExtensions
-    {
-        private static readonly char[] optionPrefixCharacters = { '-' };
+	public static class StringExtensions
+	{
+		private static readonly char[] optionPrefixCharacters = { '-' };
 
-        private static readonly Regex tokenizer = new Regex(
-            @"(""(?<q>[^""]*)"")|(?<q>\S+)",
-            RegexOptions.Compiled | RegexOptions.ExplicitCapture
-        );
+		private static readonly Regex tokenizer = new Regex(
+			@"(""(?<q>[^""]*)"")|(?<q>\S+)",
+			RegexOptions.Compiled | RegexOptions.ExplicitCapture
+		);
 
-        internal static bool ContainsCaseInsensitive(
-            this string source,
-            string value) =>
-            CultureInfo.InvariantCulture
-                       .CompareInfo
-                       .IndexOf(source,
-                                value ?? "",
-                                CompareOptions.OrdinalIgnoreCase) >= 0;
+		internal static bool ContainsCaseInsensitive(
+			this string source,
+			string value) =>
+			CultureInfo.InvariantCulture
+					   .CompareInfo
+					   .IndexOf(source,
+								value ?? "",
+								CompareOptions.OrdinalIgnoreCase) >= 0;
 
-        internal static IEnumerable<string> FindSuggestions(
-            this IReadOnlyCollection<string> candidates,
-            ParseResult parseResult) =>
-            candidates.FindSuggestions(parseResult.TextToMatch());
+		internal static IEnumerable<string> FindSuggestions(
+			this IReadOnlyCollection<string> candidates,
+			ParseResult parseResult) =>
+			candidates.FindSuggestions(parseResult.TextToMatch());
 
-        internal static IEnumerable<string> FindSuggestions(
-            this IReadOnlyCollection<string> candidates,
-            string textToMatch) =>
-            candidates
-                .OrderBy(c => c)
-                .Where(c => c.ContainsCaseInsensitive(textToMatch))
-                .Distinct()
-                .OrderBy(c => c);
+		internal static IEnumerable<string> FindSuggestions(
+			this IReadOnlyCollection<string> candidates,
+			string textToMatch) =>
+			candidates
+				.OrderBy(c => c)
+				.Where(c => c.ContainsCaseInsensitive(textToMatch))
+				.Distinct()
+				.OrderBy(c => c);
 
-        internal static string RemoveEnd(
-            this string source,
-            int length) =>
-            source.Remove(
-                source.Length - length,
-                length);
+		internal static string RemoveEnd(
+			this string source,
+			int length) =>
+			source.Remove(
+				source.Length - length,
+				length);
 
-        internal static string RemovePrefix(this string option) =>
-            option.TrimStart(optionPrefixCharacters);
+		internal static string RemovePrefix(this string option) =>
+			option.TrimStart(optionPrefixCharacters);
 
-        internal static IEnumerable<Token> Lex(
-            this IEnumerable<string> args,
-            ParserConfiguration configuration)
-        {
-            Option currentCommand = null;
-            bool foundEndOfArguments = false;
+		internal static IEnumerable<Token> Lex(
+			this IEnumerable<string> args,
+			ParserConfiguration configuration)
+		{
+			Option currentCommand = null;
+			bool foundEndOfArguments = false;
 
-            var argumentDelimiters = configuration.ArgumentDelimiters.ToArray();
+			var argumentDelimiters = configuration.ArgumentDelimiters.ToArray();
 
-            var knownTokens = new HashSet<Token>(configuration.DefinedOptions.SelectMany(ValidTokens));
+			var knownTokens = new HashSet<Token>(configuration.DefinedOptions.SelectMany(ValidTokens));
 
-            foreach (var arg in args)
-            {
-                if (foundEndOfArguments)
-                {
-                    yield return Operand(arg);
-                    continue;
-                }
-                else if (arg == "--")
-                {
-                    yield return EndOfArguments();
-                    foundEndOfArguments = true;
-                    continue;
-                }
+			foreach (var arg in args)
+			{
+				if (foundEndOfArguments)
+				{
+					yield return Operand(arg);
+					continue;
+				}
+				else if (arg == "--")
+				{
+					yield return EndOfArguments();
+					foundEndOfArguments = true;
+					continue;
+				}
 
-                var argHasPrefix = HasPrefix(arg);
+				var argHasPrefix = HasPrefix(arg);
 
-                if (argHasPrefix && HasDelimiter(arg))
-                {
-                    var parts = arg.Split(argumentDelimiters, 2);
+				if (argHasPrefix && HasDelimiter(arg))
+				{
+					var parts = arg.Split(argumentDelimiters, 2);
 
-                    if (knownTokens.Any(t => t.Value == parts.First()))
-                    {
-                        yield return Option(parts[0]);
+					if (knownTokens.Any(t => t.Value == parts.First()))
+					{
+						yield return Option(parts[0]);
 
-                        if (parts.Length > 1)
-                        {
-                            yield return Argument(parts[1]);
-                        }
-                    }
-                    else
-                    {
-                        yield return Argument(arg);
-                    }
-                }
-                else if (configuration.AllowUnbundling && arg.CanBeUnbundled(knownTokens))
-                {
-                    foreach (var character in arg.Skip(1))
-                    {
-                        // unbundle e.g. -xyz into -x -y -z
-                        yield return Option($"-{character}");
-                    }
-                }
-                else if (knownTokens.All(t => t.Value != arg) ||
-                         // if token matches the current command name, consider it an argument
-                         currentCommand?.Name == arg)
-                {
-                    yield return Argument(arg);
-                }
-                else
-                {
-                    if (argHasPrefix)
-                    {
-                        yield return Option(arg);
-                    }
-                    else
-                    {
-                        // when a subcommand is encountered, re-scope which tokens are valid
-                        currentCommand = (currentCommand?.DefinedOptions ??
-                                          configuration.DefinedOptions)[arg];
-                        knownTokens = currentCommand.ValidTokens();
-                        yield return Command(arg);
-                    }
-                }
-            }
-        }
+						if (parts.Length > 1)
+						{
+							yield return Argument(parts[1]);
+						}
+					}
+					else
+					{
+						yield return Argument(arg);
+					}
+				}
+				else if (configuration.AllowUnbundling && arg.CanBeUnbundled(knownTokens))
+				{
+					foreach (var character in arg.Skip(1))
+					{
+						// unbundle e.g. -xyz into -x -y -z
+						yield return Option($"-{character}");
+					}
+				}
+				else if (knownTokens.All(t => t.Value != arg) ||
+						 // if token matches the current command name, consider it an argument
+						 currentCommand?.Name == arg)
+				{
+					yield return Argument(arg);
+				}
+				else
+				{
+					if (argHasPrefix)
+					{
+						yield return Option(arg);
+					}
+					else
+					{
+						// when a subcommand is encountered, re-scope which tokens are valid
+						currentCommand = (currentCommand?.DefinedOptions ??
+										  configuration.DefinedOptions)[arg];
+						knownTokens = currentCommand.ValidTokens();
+						yield return Command(arg);
+					}
+				}
+			}
+		}
 
-        private static Token Argument(string value) => new Token(value, TokenType.Argument);
+		private static Token Argument(string value) => new Token(value, TokenType.Argument);
 
-        private static Token Command(string value) => new Token(value, TokenType.Command);
+		private static Token Command(string value) => new Token(value, TokenType.Command);
 
-        private static Token Option(string value) => new Token(value, TokenType.Option);
+		private static Token Option(string value) => new Token(value, TokenType.Option);
 
-        private static Token EndOfArguments() => new Token("--", TokenType.EndOfArguments);
+		private static Token EndOfArguments() => new Token("--", TokenType.EndOfArguments);
 
-        private static Token Operand(string value) => new Token(value, TokenType.Operand);
+		private static Token Operand(string value) => new Token(value, TokenType.Operand);
 
-        private static bool CanBeUnbundled(
-            this string arg,
-            IReadOnlyCollection<Token> knownTokens) =>
-            arg.StartsWith("-") &&
-            !arg.StartsWith("--") &&
-            arg.RemovePrefix()
-               .All(c => knownTokens
-                        .Where(t => t.Type == TokenType.Option)
-                        .Select(t => t.Value.RemovePrefix())
-                        .Contains(c.ToString()));
+		private static bool CanBeUnbundled(
+			this string arg,
+			IReadOnlyCollection<Token> knownTokens) =>
+			arg.StartsWith("-") &&
+			!arg.StartsWith("--") &&
+			arg.RemovePrefix()
+			   .All(c => knownTokens
+						.Where(t => t.Type == TokenType.Option)
+						.Select(t => t.Value.RemovePrefix())
+						.Contains(c.ToString()));
 
-        private static bool HasDelimiter(string arg) =>
-            arg.Contains("=") ||
-            arg.Contains(":");
+		private static bool HasDelimiter(string arg) =>
+			arg.Contains("=") ||
+			arg.Contains(":");
 
-        private static bool HasPrefix(string arg) =>
-            arg != string.Empty &&
-            optionPrefixCharacters.Contains(arg[0]);
+		private static bool HasPrefix(string arg) =>
+			arg != string.Empty &&
+			optionPrefixCharacters.Contains(arg[0]);
 
-        public static IEnumerable<string> Tokenize(this string s)
-        {
-            var matches = tokenizer.Matches(s);
+		public static IEnumerable<string> Tokenize(this string s)
+		{
+			var matches = tokenizer.Matches(s);
 
-            foreach (Match match in matches)
-            {
-                foreach (var capture in match.Groups["q"].Captures)
-                {
-                    yield return capture.ToString();
-                }
-            }
-        }
+			foreach (Match match in matches)
+			{
+				foreach (var capture in match.Groups["q"].Captures)
+				{
+					yield return capture.ToString();
+				}
+			}
+		}
 
-        internal static string NotWhitespace(this string value) =>
-            string.IsNullOrWhiteSpace(value) ? null : value;
+		internal static string NotWhitespace(this string value) =>
+			string.IsNullOrWhiteSpace(value) ? null : value;
 
-        private static HashSet<Token> ValidTokens(this Option option) =>
-            new HashSet<Token>(
-                option.RawAliases
-                      .Select(Command)
-                      .Concat(
-                          option.DefinedOptions
-                                .SelectMany(
-                                    o =>
-                                        o.RawAliases
-                                         .Select(
-                                             a =>
-                                                 new Token(
-                                                     a,
-                                                     o.IsCommand
-                                                         ? TokenType.Command
-                                                         : TokenType.Option)))));
-    }
+		private static HashSet<Token> ValidTokens(this Option option) =>
+			new HashSet<Token>(
+				option.RawAliases
+					  .Select(Command)
+					  .Concat(
+						  option.DefinedOptions
+								.SelectMany(
+									o =>
+										o.RawAliases
+										 .Select(
+											 a =>
+												 new Token(
+													 a,
+													 o.IsCommand
+														 ? TokenType.Command
+														 : TokenType.Option)))));
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/Suggest.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/Suggest.cs
@@ -5,5 +5,5 @@ using System.Collections.Generic;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public delegate IEnumerable<string> Suggest(ParseResult parseResult);
+	public delegate IEnumerable<string> Suggest(ParseResult parseResult);
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/Token.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/Token.cs
@@ -5,18 +5,18 @@ using System;
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public class Token
-    {
-        public Token(string value, TokenType type)
-        {
-            Value = value ?? "";
-            Type = type;
-        }
+	public class Token
+	{
+		public Token(string value, TokenType type)
+		{
+			Value = value ?? "";
+			Type = type;
+		}
 
-        public string Value { get; }
+		public string Value { get; }
 
-        public TokenType Type { get; }
+		public TokenType Type { get; }
 
-        public override string ToString() => $"{Type}: {Value}";
-    }
+		public override string ToString() => $"{Type}: {Value}";
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/TokenType.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/TokenType.cs
@@ -3,12 +3,12 @@
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public enum TokenType
-    {
-        Argument,
-        Command,
-        Option,
-        EndOfArguments,
-        Operand
-    }
+	public enum TokenType
+	{
+		Argument,
+		Command,
+		Option,
+		EndOfArguments,
+		Operand
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/ValidationMessages.cs
+++ b/Project2015To2017.Migrate2017.Tool/Microsoft.DotNet.Cli.CommandLine/ValidationMessages.cs
@@ -3,69 +3,69 @@
 
 namespace Microsoft.DotNet.Cli.CommandLine
 {
-    public static class ValidationMessages
-    {
-        private static IValidationMessages current = new DefaultValidationMessages();
-        private static IValidationMessages @default = current;
+	public static class ValidationMessages
+	{
+		private static IValidationMessages current = new DefaultValidationMessages();
+		private static IValidationMessages @default = current;
 
-        public static IValidationMessages Current
-        {
-            get => current;
-            set => current = value ?? new DefaultValidationMessages();
-        }
+		public static IValidationMessages Current
+		{
+			get => current;
+			set => current = value ?? new DefaultValidationMessages();
+		}
 
-        internal static string NoArgumentsAllowed(string option) =>
-            current.NoArgumentsAllowed(option).NotWhitespace() ??
-            @default.NoArgumentsAllowed(option);
+		internal static string NoArgumentsAllowed(string option) =>
+			current.NoArgumentsAllowed(option).NotWhitespace() ??
+			@default.NoArgumentsAllowed(option);
 
-        internal static string CommandAcceptsOnlyOneArgument(
-            string command,
-            int argumentCount) =>
-            current.CommandAcceptsOnlyOneArgument(command, argumentCount).NotWhitespace() ??
-            @default.CommandAcceptsOnlyOneArgument(command, argumentCount);
+		internal static string CommandAcceptsOnlyOneArgument(
+			string command,
+			int argumentCount) =>
+			current.CommandAcceptsOnlyOneArgument(command, argumentCount).NotWhitespace() ??
+			@default.CommandAcceptsOnlyOneArgument(command, argumentCount);
 
-        internal static string CommandAcceptsOnlyOneSubcommand(
-            string command,
-            string subcommandsSpecified) =>
-            current.CommandAcceptsOnlyOneSubcommand(command, subcommandsSpecified).NotWhitespace() ??
-            @default.CommandAcceptsOnlyOneSubcommand(command, subcommandsSpecified);
+		internal static string CommandAcceptsOnlyOneSubcommand(
+			string command,
+			string subcommandsSpecified) =>
+			current.CommandAcceptsOnlyOneSubcommand(command, subcommandsSpecified).NotWhitespace() ??
+			@default.CommandAcceptsOnlyOneSubcommand(command, subcommandsSpecified);
 
-        internal static string FileDoesNotExist(string filePath) =>
-            current.FileDoesNotExist(filePath).NotWhitespace() ??
-            @default.FileDoesNotExist(filePath);
+		internal static string FileDoesNotExist(string filePath) =>
+			current.FileDoesNotExist(filePath).NotWhitespace() ??
+			@default.FileDoesNotExist(filePath);
 
-        internal static string OptionAcceptsOnlyOneArgument(
-            string option,
-            int argumentCount) =>
-            current.OptionAcceptsOnlyOneArgument(option, argumentCount).NotWhitespace() ??
-            @default.OptionAcceptsOnlyOneArgument(option, argumentCount);
+		internal static string OptionAcceptsOnlyOneArgument(
+			string option,
+			int argumentCount) =>
+			current.OptionAcceptsOnlyOneArgument(option, argumentCount).NotWhitespace() ??
+			@default.OptionAcceptsOnlyOneArgument(option, argumentCount);
 
-        internal static string RequiredArgumentMissingForCommand(string command) =>
-            current.RequiredArgumentMissingForCommand(command).NotWhitespace() ??
-            @default.RequiredArgumentMissingForCommand(command);
+		internal static string RequiredArgumentMissingForCommand(string command) =>
+			current.RequiredArgumentMissingForCommand(command).NotWhitespace() ??
+			@default.RequiredArgumentMissingForCommand(command);
 
-        internal static string RequiredArgumentMissingForOption(string option) =>
-            current.RequiredArgumentMissingForOption(option).NotWhitespace() ??
-            @default.RequiredArgumentMissingForOption(option);
+		internal static string RequiredArgumentMissingForOption(string option) =>
+			current.RequiredArgumentMissingForOption(option).NotWhitespace() ??
+			@default.RequiredArgumentMissingForOption(option);
 
-        internal static string RequiredCommandWasNotProvided() =>
-            current.RequiredCommandWasNotProvided().NotWhitespace() ??
-            @default.RequiredCommandWasNotProvided();
+		internal static string RequiredCommandWasNotProvided() =>
+			current.RequiredCommandWasNotProvided().NotWhitespace() ??
+			@default.RequiredCommandWasNotProvided();
 
-        internal static string UnrecognizedArgument(
-            string unrecognizedArg,
-            string[] allowedValues) =>
-            current.UnrecognizedArgument(unrecognizedArg, allowedValues).NotWhitespace() ??
-            @default.UnrecognizedArgument(unrecognizedArg, allowedValues);
+		internal static string UnrecognizedArgument(
+			string unrecognizedArg,
+			string[] allowedValues) =>
+			current.UnrecognizedArgument(unrecognizedArg, allowedValues).NotWhitespace() ??
+			@default.UnrecognizedArgument(unrecognizedArg, allowedValues);
 
-        internal static string UnrecognizedCommandOrArgument(string arg) =>
-            current.UnrecognizedCommandOrArgument(arg).NotWhitespace() ??
-            @default.UnrecognizedCommandOrArgument(arg);
+		internal static string UnrecognizedCommandOrArgument(string arg) =>
+			current.UnrecognizedCommandOrArgument(arg).NotWhitespace() ??
+			@default.UnrecognizedCommandOrArgument(arg);
 
-        internal static string UnrecognizedOption(
-            string unrecognizedOption,
-            string[] allowedValues) =>
-            current.UnrecognizedOption(unrecognizedOption, allowedValues).NotWhitespace() ??
-            @default.UnrecognizedOption(unrecognizedOption, allowedValues);
-    }
+		internal static string UnrecognizedOption(
+			string unrecognizedOption,
+			string[] allowedValues) =>
+			current.UnrecognizedOption(unrecognizedOption, allowedValues).NotWhitespace() ??
+			@default.UnrecognizedOption(unrecognizedOption, allowedValues);
+	}
 }

--- a/Project2015To2017.Migrate2017.Tool/Project2015To2017.Migrate2017.Tool.csproj
+++ b/Project2015To2017.Migrate2017.Tool/Project2015To2017.Migrate2017.Tool.csproj
@@ -1,28 +1,28 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks Condition="$(Pack) != 'true'">net461;netcoreapp2.1</TargetFrameworks>
-		<TargetFramework Condition="$(Pack) == 'true'">netcoreapp2.1</TargetFramework>
-		<PackAsTool Condition="$(Pack) == 'true'">True</PackAsTool>
+  <PropertyGroup>
+	<TargetFrameworks Condition="$(Pack) != 'true'">net461;netcoreapp2.1</TargetFrameworks>
+	<TargetFramework Condition="$(Pack) == 'true'">netcoreapp2.1</TargetFramework>
+	<PackAsTool Condition="$(Pack) == 'true'">True</PackAsTool>
 
-		<AssemblyName>dotnet-migrate-2017</AssemblyName>
-		<PackageId>Project2015To2017.Migrate2017.Tool</PackageId>
-		<Product>Project2015To2017.Migrate2017.Tool</Product>
-		<OutputType>Exe</OutputType>
-	</PropertyGroup>
+	<AssemblyName>dotnet-migrate-2017</AssemblyName>
+	<PackageId>Project2015To2017.Migrate2017.Tool</PackageId>
+	<Product>Project2015To2017.Migrate2017.Tool</Product>
+	<OutputType>Exe</OutputType>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="DotNet.Glob" Version="2.1.1" />
-		<PackageReference Include="Serilog" Version="2.8.0" />
-		<PackageReference Include="Serilog.Enrichers.Demystify" Version="0.1.0-dev-00016" />
-		<PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
-		<PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-	</ItemGroup>
+  <ItemGroup>
+	<PackageReference Include="DotNet.Glob" Version="2.1.1" />
+	<PackageReference Include="Serilog" Version="2.8.0" />
+	<PackageReference Include="Serilog.Enrichers.Demystify" Version="0.1.0-dev-00016" />
+	<PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
+	<PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+  </ItemGroup>
 
-	<ItemGroup>
-	  <ProjectReference Include="..\Project2015To2017.Core\Project2015To2017.Core.csproj" />
-	  <ProjectReference Include="..\Project2015To2017.Migrate2017.Library\Project2015To2017.Migrate2017.Library.csproj" />
-	  <ProjectReference Include="..\Project2015To2017\Project2015To2017.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+	<ProjectReference Include="..\Project2015To2017.Core\Project2015To2017.Core.csproj" />
+	<ProjectReference Include="..\Project2015To2017.Migrate2017.Library\Project2015To2017.Migrate2017.Library.csproj" />
+	<ProjectReference Include="..\Project2015To2017\Project2015To2017.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/Project2015To2017.Migrate2019.Library/Project2015To2017.Migrate2019.Library.csproj
+++ b/Project2015To2017.Migrate2019.Library/Project2015To2017.Migrate2019.Library.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+	<TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Project2015To2017.Core\Project2015To2017.Core.csproj" />
-    <ProjectReference Include="..\Project2015To2017.Migrate2017.Library\Project2015To2017.Migrate2017.Library.csproj" />
+	<ProjectReference Include="..\Project2015To2017.Core\Project2015To2017.Core.csproj" />
+	<ProjectReference Include="..\Project2015To2017.Migrate2017.Library\Project2015To2017.Migrate2017.Library.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Project2015To2017.Tests/AssemblyAttributeTransformationTest.cs
+++ b/Project2015To2017.Tests/AssemblyAttributeTransformationTest.cs
@@ -13,7 +13,7 @@ namespace Project2015To2017.Tests
 	[TestClass]
 	public class AssemblyAttributeTransformationTest
 	{
-		private List<XElement> ProjectPropertyGroups = new [] {new XElement("PropertyGroup")}.ToList();
+		private List<XElement> ProjectPropertyGroups = new[] { new XElement("PropertyGroup") }.ToList();
 
 		private static AssemblyAttributes BaseAssemblyAttributes() =>
 			new AssemblyAttributes

--- a/Project2015To2017.Tests/AssemblyInfoReadTest.cs
+++ b/Project2015To2017.Tests/AssemblyInfoReadTest.cs
@@ -5,19 +5,19 @@ using Project2015To2017.Reading;
 namespace Project2015To2017.Tests
 {
 	[TestClass]
-    public class AssemblyInfoReadTest
-    {
-        [TestMethod]
-        public void FindsAttributes()
-        {
-	        var project = new ProjectReader().Read(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj"));
+	public class AssemblyInfoReadTest
+	{
+		[TestMethod]
+		public void FindsAttributes()
+		{
+			var project = new ProjectReader().Read(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj"));
 
-            Assert.IsNotNull(project.AssemblyAttributes.Company);
-            Assert.IsNotNull(project.AssemblyAttributes.Copyright);
-            Assert.IsNotNull(project.AssemblyAttributes.InformationalVersion);
-            Assert.IsNotNull(project.AssemblyAttributes.Product);
-            Assert.AreEqual("Title", project.AssemblyAttributes.Title);
-            Assert.IsNotNull(project.AssemblyAttributes.Version);
-        }
-    }
+			Assert.IsNotNull(project.AssemblyAttributes.Company);
+			Assert.IsNotNull(project.AssemblyAttributes.Copyright);
+			Assert.IsNotNull(project.AssemblyAttributes.InformationalVersion);
+			Assert.IsNotNull(project.AssemblyAttributes.Product);
+			Assert.AreEqual("Title", project.AssemblyAttributes.Title);
+			Assert.IsNotNull(project.AssemblyAttributes.Version);
+		}
+	}
 }

--- a/Project2015To2017.Tests/FileTransformationTest.cs
+++ b/Project2015To2017.Tests/FileTransformationTest.cs
@@ -53,7 +53,7 @@ namespace Project2015To2017.Tests
 			Assert.AreEqual(7, includeItems.Count(x => x.Name.LocalName == "Import"));
 			Assert.AreEqual(0, includeItems.Count(x => x.Name.LocalName == "Import" && x.Attribute("Include") == null));
 			Assert.AreEqual(2, includeItems.Count(x => x.Name.LocalName == "ProjectReference"));
-			Assert.AreEqual(2, includeItems.Count(x=> x.Name.LocalName.Equals("Antlr4")));
+			Assert.AreEqual(2, includeItems.Count(x => x.Name.LocalName.Equals("Antlr4")));
 			Assert.AreEqual(1, includeItems.Count(x => x.Name.LocalName.Equals("Antlr3")));
 			Assert.AreEqual(11, includeItems.Count(x => x.Name.LocalName == "Compile"));
 			Assert.AreEqual(5, includeItems.Count(x => x.Name.LocalName == "Compile" && x.Attribute("Update") != null));
@@ -66,7 +66,7 @@ namespace Project2015To2017.Tests
 
 			var resourceDesigner = includeItems.Single(
 				x => x.Name.LocalName == "Compile"
-				     && x.Attribute("Update")?.Value == @"Properties\Resources.Designer.cs"
+					 && x.Attribute("Update")?.Value == @"Properties\Resources.Designer.cs"
 			);
 
 			Assert.AreEqual(3, resourceDesigner.Elements().Count());
@@ -76,7 +76,7 @@ namespace Project2015To2017.Tests
 
 			var linkedFile = includeItems.Single(
 				x => x.Name.LocalName == "Compile"
-				     && x.Attribute("Include")?.Value == @"..\OtherTestProjects\OtherTestClass.cs"
+					 && x.Attribute("Include")?.Value == @"..\OtherTestProjects\OtherTestClass.cs"
 			);
 			var linkAttribute = linkedFile.Attributes().FirstOrDefault(a => a.Name.LocalName == "Link");
 			Assert.IsNotNull(linkAttribute);
@@ -84,7 +84,7 @@ namespace Project2015To2017.Tests
 
 			var sourceWithDesigner = includeItems.Single(
 				x => x.Name.LocalName == "Compile"
-				     && x.Attribute("Update")?.Value == @"SourceFileWithDesigner.cs"
+					 && x.Attribute("Update")?.Value == @"SourceFileWithDesigner.cs"
 			);
 
 			var subTypeElement = sourceWithDesigner.Elements().Single();
@@ -93,7 +93,7 @@ namespace Project2015To2017.Tests
 
 			var designerForSource = includeItems.Single(
 				x => x.Name.LocalName == "Compile"
-				     && x.Attribute("Update")?.Value == @"SourceFileWithDesigner.Designer.cs"
+					 && x.Attribute("Update")?.Value == @"SourceFileWithDesigner.Designer.cs"
 			);
 
 			var dependentUponElement2 = designerForSource.Elements().Single();
@@ -103,7 +103,7 @@ namespace Project2015To2017.Tests
 
 			var fileWithAnotherAttribute = includeItems.Single(
 				x => x.Name.LocalName == "Compile"
-				     && x.Attribute("Update")?.Value == @"AnotherFile.cs"
+					 && x.Attribute("Update")?.Value == @"AnotherFile.cs"
 			);
 
 			Assert.AreEqual(2, fileWithAnotherAttribute.Attributes().Count());
@@ -111,7 +111,7 @@ namespace Project2015To2017.Tests
 
 			var removeMatchingWildcard = includeItems.Where(
 					x => x.Name.LocalName == "Compile"
-					     && x.Attribute("Remove")?.Value != null
+						 && x.Attribute("Remove")?.Value != null
 				)
 				.ToImmutableList();
 			Assert.IsNotNull(removeMatchingWildcard);

--- a/Project2015To2017.Tests/ImportsTargetsFilterPackageReferencesTransformationTest.cs
+++ b/Project2015To2017.Tests/ImportsTargetsFilterPackageReferencesTransformationTest.cs
@@ -20,7 +20,7 @@ namespace Project2015To2017.Tests
 			//Then attempt to clear any referencing the nuget packages folder
 			transformation.Transform(project);
 
-			var expectedRemaining = new []
+			var expectedRemaining = new[]
 			{
 				@"<Import Project=""C:\SomeTargets.props"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"" />",
 				@"<Import Project=""C:\SomeTargets.targets"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"" />"

--- a/Project2015To2017.Tests/NuGetPackageTransformationTest.cs
+++ b/Project2015To2017.Tests/NuGetPackageTransformationTest.cs
@@ -16,7 +16,8 @@ namespace Project2015To2017.Tests
 			var project = new ProjectReader().Read(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj"));
 
 			project.AssemblyAttributes =
-								new AssemblyAttributes {
+								new AssemblyAttributes
+								{
 									InformationalVersion = "7.0",
 									Version = "8.0",
 									FileVersion = "9.0",
@@ -46,7 +47,8 @@ namespace Project2015To2017.Tests
 			var project = new ProjectReader().Read(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj"));
 
 			project.AssemblyAttributes =
-				new AssemblyAttributes {
+				new AssemblyAttributes
+				{
 					Version = "8.0",
 					FileVersion = "9.0",
 					Copyright = "copyright from assembly",

--- a/Project2015To2017.Tests/NuSpecReaderTest.cs
+++ b/Project2015To2017.Tests/NuSpecReaderTest.cs
@@ -5,16 +5,16 @@ using Project2015To2017.Reading;
 namespace Project2015To2017.Tests
 {
 	[TestClass]
-    public class NuSpecReaderTest
-    {
-	    [TestMethod]
-	    public void LoadsNuSpecWithNoNamespace()
-	    {
-		    var reader = new NuSpecReader(NoopLogger.Instance);
-		    var nuspec = reader.Read(new FileInfo(@"TestFiles\nuSpecs\dummy.csproj"));
+	public class NuSpecReaderTest
+	{
+		[TestMethod]
+		public void LoadsNuSpecWithNoNamespace()
+		{
+			var reader = new NuSpecReader(NoopLogger.Instance);
+			var nuspec = reader.Read(new FileInfo(@"TestFiles\nuSpecs\dummy.csproj"));
 
-		    Assert.IsNotNull(nuspec);
-	    }
+			Assert.IsNotNull(nuspec);
+		}
 
-    }
+	}
 }

--- a/Project2015To2017.Tests/Project2015To2017.Tests.csproj
+++ b/Project2015To2017.Tests/Project2015To2017.Tests.csproj
@@ -1,270 +1,270 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+	<TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="OtherPackagesConfig\**" />
-    <Compile Remove="TestFiles\FileInclusion\Resources.resx\**" />
-    <Compile Remove="TestFiles\Solutions\ClassLibrary\obj\**" />
-    <EmbeddedResource Remove="OtherPackagesConfig\**" />
-    <EmbeddedResource Remove="TestFiles\FileInclusion\Resources.resx\**" />
-    <EmbeddedResource Remove="TestFiles\Solutions\ClassLibrary\obj\**" />
-    <None Remove="TestFiles\FileInclusion\Resources.resx\**" />
-    <None Remove="TestFiles\Solutions\ClassLibrary\obj\**" />
+	<Compile Remove="OtherPackagesConfig\**" />
+	<Compile Remove="TestFiles\FileInclusion\Resources.resx\**" />
+	<Compile Remove="TestFiles\Solutions\ClassLibrary\obj\**" />
+	<EmbeddedResource Remove="OtherPackagesConfig\**" />
+	<EmbeddedResource Remove="TestFiles\FileInclusion\Resources.resx\**" />
+	<EmbeddedResource Remove="TestFiles\Solutions\ClassLibrary\obj\**" />
+	<None Remove="TestFiles\FileInclusion\Resources.resx\**" />
+	<None Remove="TestFiles\Solutions\ClassLibrary\obj\**" />
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Remove="TestFiles\AssemblyInfo.cs" />
-    <Compile Remove="TestFiles\AssemblyInfoHandling\ClassDataLeft\Properties\AssemblyInfo.cs" />
-    <Compile Remove="TestFiles\AssemblyInfoHandling\Empty\Properties\AssemblyInfo.cs" />
-    <Compile Remove="TestFiles\AssemblyInfoHandling\Redundant\AssemblyInfo.cs" />
-    <Compile Remove="TestFiles\AssemblyInfoHandling\Redundant\Properties\AssemblyInfo.cs" />
-    <Compile Remove="TestFiles\FileInclusion\AnotherFile.cs" />
-    <Compile Remove="TestFiles\FileInclusion\Class1.cs" />
-    <Compile Remove="TestFiles\FileInclusion\Folder\FileIncludedByWildcard.cs" />
-    <Compile Remove="TestFiles\FileInclusion\Folder\FileInFolder.cs" />
-    <Compile Remove="TestFiles\FileInclusion\IncludedFile.cs" />
-    <Compile Remove="TestFiles\FileInclusion\Program.cs" />
-    <Compile Remove="TestFiles\FileInclusion\Properties\AssemblyInfo.cs" />
-    <Compile Remove="TestFiles\FileInclusion\Properties\Resources.Designer.cs" />
-    <Compile Remove="TestFiles\FileInclusion\Resources.Designer.cs" />
-    <Compile Remove="TestFiles\FileInclusion\SourceFileAsResource.cs" />
-    <Compile Remove="TestFiles\FileInclusion\SourceFileSubTypeCode.cs" />
-    <Compile Remove="TestFiles\FileInclusion\SourceFileWithDesigner.cs" />
-    <Compile Remove="TestFiles\FileInclusion\WildcardFolder\WildcardSubFolder\SubFolderWildcardFile.cs" />
-    <Compile Remove="TestFiles\OtherTestProjects\AssemblyInfo.cs" />
-    <Compile Remove="TestFiles\Solutions\ClassLibrary\Properties\AssemblyInfo.cs" />
+	<Compile Remove="TestFiles\AssemblyInfo.cs" />
+	<Compile Remove="TestFiles\AssemblyInfoHandling\ClassDataLeft\Properties\AssemblyInfo.cs" />
+	<Compile Remove="TestFiles\AssemblyInfoHandling\Empty\Properties\AssemblyInfo.cs" />
+	<Compile Remove="TestFiles\AssemblyInfoHandling\Redundant\AssemblyInfo.cs" />
+	<Compile Remove="TestFiles\AssemblyInfoHandling\Redundant\Properties\AssemblyInfo.cs" />
+	<Compile Remove="TestFiles\FileInclusion\AnotherFile.cs" />
+	<Compile Remove="TestFiles\FileInclusion\Class1.cs" />
+	<Compile Remove="TestFiles\FileInclusion\Folder\FileIncludedByWildcard.cs" />
+	<Compile Remove="TestFiles\FileInclusion\Folder\FileInFolder.cs" />
+	<Compile Remove="TestFiles\FileInclusion\IncludedFile.cs" />
+	<Compile Remove="TestFiles\FileInclusion\Program.cs" />
+	<Compile Remove="TestFiles\FileInclusion\Properties\AssemblyInfo.cs" />
+	<Compile Remove="TestFiles\FileInclusion\Properties\Resources.Designer.cs" />
+	<Compile Remove="TestFiles\FileInclusion\Resources.Designer.cs" />
+	<Compile Remove="TestFiles\FileInclusion\SourceFileAsResource.cs" />
+	<Compile Remove="TestFiles\FileInclusion\SourceFileSubTypeCode.cs" />
+	<Compile Remove="TestFiles\FileInclusion\SourceFileWithDesigner.cs" />
+	<Compile Remove="TestFiles\FileInclusion\WildcardFolder\WildcardSubFolder\SubFolderWildcardFile.cs" />
+	<Compile Remove="TestFiles\OtherTestProjects\AssemblyInfo.cs" />
+	<Compile Remove="TestFiles\Solutions\ClassLibrary\Properties\AssemblyInfo.cs" />
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Remove="TestFiles\FileInclusion\Properties\Resources.resx" />
-    <EmbeddedResource Remove="TestFiles\FileInclusion\Resources.resx" />
+	<EmbeddedResource Remove="TestFiles\FileInclusion\Properties\Resources.resx" />
+	<EmbeddedResource Remove="TestFiles\FileInclusion\Resources.resx" />
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="TestFiles\Solutions\ClassLibrary\Properties\AssemblyInfo.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+	<Content Include="TestFiles\Solutions\ClassLibrary\Properties\AssemblyInfo.cs">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</Content>
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="TestFiles\AssemblyInfoHandling\ClassDataLeft\Properties\AssemblyInfo.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\Deletions\Test4.csproj">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\Deletions\Test3.csproj">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\Deletions\Test2.csproj">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\Deletions\Test1.csproj">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\AssemblyInfoHandling\Empty\Properties\AssemblyInfo.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\AssemblyInfoHandling\Redundant\Properties\AssemblyInfo.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\FileInclusion\AnotherFile.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\FileInclusion\fileExclusion.testcsproj">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\FileInclusion\intermediatePathExclusion.testcsproj">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\FileInclusion\SourceFileSubTypeCode.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\FileInclusion\Class1.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\FileInclusion\Program.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+	<None Include="TestFiles\AssemblyInfoHandling\ClassDataLeft\Properties\AssemblyInfo.cs">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\Deletions\Test4.csproj">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\Deletions\Test3.csproj">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\Deletions\Test2.csproj">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\Deletions\Test1.csproj">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\AssemblyInfoHandling\Empty\Properties\AssemblyInfo.cs">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\AssemblyInfoHandling\Redundant\Properties\AssemblyInfo.cs">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\FileInclusion\AnotherFile.cs">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\FileInclusion\fileExclusion.testcsproj">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\FileInclusion\intermediatePathExclusion.testcsproj">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\FileInclusion\SourceFileSubTypeCode.cs">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\FileInclusion\Class1.cs">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\FileInclusion\Program.cs">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
   </ItemGroup>
   <ItemGroup>
-    <None Include="TestFiles\AltNugetConfig\ProjectFolder\net46console.testcsproj">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="OtherPackagesConfig\net46console.testcsproj">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\FileInclusion\fileinclusion.testcsproj">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\FileInclusion\Folder\FileIncludedByWildcard.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\FileInclusion\Folder\FileInFolder.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\FileInclusion\IncludedFile.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\FileInclusion\Properties\AssemblyInfo.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\FileInclusion\Properties\Resources.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Resources.resx</DependentUpon>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\FileInclusion\Properties\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </None>
-    <None Include="TestFiles\FileInclusion\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </None>
-    <None Include="TestFiles\FileInclusion\Resources.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Resources.resx</DependentUpon>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\FileInclusion\SourceFileAsResource.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\FileInclusion\SourceFileWithDesigner.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>SourceFileWithDesigner.Designer.cs</LastGenOutput>
-    </None>
-    <None Include="TestFiles\FileInclusion\SourceFileWithDesigner.Designer.cs">
-      <DependentUpon>SourceFileWithDesigner.cs</DependentUpon>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-    </None>
+	<None Include="TestFiles\AltNugetConfig\ProjectFolder\net46console.testcsproj">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="OtherPackagesConfig\net46console.testcsproj">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\FileInclusion\fileinclusion.testcsproj">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\FileInclusion\Folder\FileIncludedByWildcard.cs">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\FileInclusion\Folder\FileInFolder.cs">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\FileInclusion\IncludedFile.cs">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\FileInclusion\Properties\AssemblyInfo.cs">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\FileInclusion\Properties\Resources.Designer.cs">
+	  <DesignTime>True</DesignTime>
+	  <AutoGen>True</AutoGen>
+	  <DependentUpon>Resources.resx</DependentUpon>
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\FileInclusion\Properties\Resources.resx">
+	  <Generator>ResXFileCodeGenerator</Generator>
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+	</None>
+	<None Include="TestFiles\FileInclusion\Resources.resx">
+	  <Generator>ResXFileCodeGenerator</Generator>
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+	</None>
+	<None Include="TestFiles\FileInclusion\Resources.Designer.cs">
+	  <DesignTime>True</DesignTime>
+	  <AutoGen>True</AutoGen>
+	  <DependentUpon>Resources.resx</DependentUpon>
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\FileInclusion\SourceFileAsResource.cs">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\FileInclusion\SourceFileWithDesigner.cs">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  <Generator>ResXFileCodeGenerator</Generator>
+	  <LastGenOutput>SourceFileWithDesigner.Designer.cs</LastGenOutput>
+	</None>
+	<None Include="TestFiles\FileInclusion\SourceFileWithDesigner.Designer.cs">
+	  <DependentUpon>SourceFileWithDesigner.cs</DependentUpon>
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  <DesignTime>True</DesignTime>
+	  <AutoGen>True</AutoGen>
+	</None>
 
-    <None Include="TestFiles\FileInclusion\WildcardFolder\WildcardSubFolder\SubFolderWildcardFile.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\OtherTestProjects\AssemblyInfo.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\OtherTestProjects\containsTestSDK.testcsproj">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\OtherTestProjects\readonly.testcsproj">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\OtherTestProjects\net46console.testcsproj">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="TestFiles\OtherTestProjects\unittest.testcsproj">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+	<None Include="TestFiles\FileInclusion\WildcardFolder\WildcardSubFolder\SubFolderWildcardFile.cs">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\OtherTestProjects\AssemblyInfo.cs">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\OtherTestProjects\containsTestSDK.testcsproj">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\OtherTestProjects\readonly.testcsproj">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\OtherTestProjects\net46console.testcsproj">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Include="TestFiles\OtherTestProjects\unittest.testcsproj">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
   </ItemGroup>
 
   <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+	<PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
+	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+	<PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+	<PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Update="FileTransformationTest.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Compile>
-    <Compile Update="TestFiles\AssemblyInfo.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Compile>
-    <Compile Update="TestFiles\FileInclusion\SourceFileWithDesigner.Designer.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Compile>
-    <Compile Update="TestFiles\Folder\FileInFolder.cs">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Compile>
-    <Compile Update="TestFiles\Solutions\ClassLibrary\Class1.cs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Compile>
+	<Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="OtherPackagesConfig\packages.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TestFiles\AltNugetConfig\nuget.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestFiles\AltNugetConfig\ProjectFolder\packages.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TestFiles\Deletions\AssemblyInfo.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Update="TestFiles\Deletions\a.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TestFiles\Deletions\EmptyFolder\a.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TestFiles\Deletions\NonEmptyFolder2\a.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TestFiles\Deletions\NonEmptyFolder\a.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TestFiles\FileInclusion\app.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TestFiles\FileInclusion\packages.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TestFiles\OtherTestProjects\packages.config">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TestFiles\nuSpecs\noNamespace.nuspec">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TestFiles\OtherTestProjects\test.nuspec">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TestFiles\Solutions\sampleSolution.testsln">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TestFiles\Solutions\TextFile.txt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="TestFiles\test.nuspec">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+	<Compile Update="FileTransformationTest.cs">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</Compile>
+	<Compile Update="TestFiles\AssemblyInfo.cs">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</Compile>
+	<Compile Update="TestFiles\FileInclusion\SourceFileWithDesigner.Designer.cs">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</Compile>
+	<Compile Update="TestFiles\Folder\FileInFolder.cs">
+	  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	</Compile>
+	<Compile Update="TestFiles\Solutions\ClassLibrary\Class1.cs">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</Compile>
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Properties\" />
+	<None Update="OtherPackagesConfig\packages.config">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Update="TestFiles\AltNugetConfig\nuget.config">
+	  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	</None>
+	<None Update="TestFiles\AltNugetConfig\ProjectFolder\packages.config">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Update="TestFiles\Deletions\AssemblyInfo.txt">
+	  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	</None>
+	<None Update="TestFiles\Deletions\a.txt">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Update="TestFiles\Deletions\EmptyFolder\a.txt">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Update="TestFiles\Deletions\NonEmptyFolder2\a.txt">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Update="TestFiles\Deletions\NonEmptyFolder\a.txt">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Update="TestFiles\FileInclusion\app.config">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Update="TestFiles\FileInclusion\packages.config">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Update="TestFiles\OtherTestProjects\packages.config">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Update="TestFiles\nuSpecs\noNamespace.nuspec">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Update="TestFiles\OtherTestProjects\test.nuspec">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Update="TestFiles\Solutions\sampleSolution.testsln">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Update="TestFiles\Solutions\TextFile.txt">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
+	<None Update="TestFiles\test.nuspec">
+	  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Project2015To2017.Core\Project2015To2017.Core.csproj" />
-    <ProjectReference Include="..\Project2015To2017.Migrate2017.Library\Project2015To2017.Migrate2017.Library.csproj" />
-    <ProjectReference Include="..\Project2015To2017\Project2015To2017.csproj" />
+	<Folder Include="Properties\" />
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Update="TestFiles\Resources.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
+	<ProjectReference Include="..\Project2015To2017.Core\Project2015To2017.Core.csproj" />
+	<ProjectReference Include="..\Project2015To2017.Migrate2017.Library\Project2015To2017.Migrate2017.Library.csproj" />
+	<ProjectReference Include="..\Project2015To2017\Project2015To2017.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+	<EmbeddedResource Update="TestFiles\Resources.resx">
+	  <Generator>ResXFileCodeGenerator</Generator>
+	  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	  <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+	</EmbeddedResource>
   </ItemGroup>
 
 </Project>

--- a/Project2015To2017.Tests/ProjectReferenceReadTest.cs
+++ b/Project2015To2017.Tests/ProjectReferenceReadTest.cs
@@ -6,15 +6,15 @@ using Project2015To2017.Reading;
 namespace Project2015To2017.Tests
 {
 	[TestClass]
-    public class ProjectReferenceReadTest
-    {
-        [TestMethod]
-        public void TransformsProjectReferences()
-        {
+	public class ProjectReferenceReadTest
+	{
+		[TestMethod]
+		public void TransformsProjectReferences()
+		{
 			var project = new ProjectReader().Read(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj"));
 
-            Assert.AreEqual(2, project.ProjectReferences.Count);
-            Assert.IsTrue(project.ProjectReferences.Any(x => x.Include == @"..\SomeOtherProject\SomeOtherProject.csproj" && x.Aliases == "global,one"));
-        }
-    }
+			Assert.AreEqual(2, project.ProjectReferences.Count);
+			Assert.IsTrue(project.ProjectReferences.Any(x => x.Include == @"..\SomeOtherProject\SomeOtherProject.csproj" && x.Aliases == "global,one"));
+		}
+	}
 }

--- a/Project2015To2017.Tests/ProjectWriterTest.cs
+++ b/Project2015To2017.Tests/ProjectWriterTest.cs
@@ -135,7 +135,7 @@ namespace Project2015To2017.Tests
 			var writer = new ProjectWriter();
 			var xmlNode = writer.CreateXml(new Project
 			{
-				PropertyGroups = new[] {new XElement("PropertyGroup")},
+				PropertyGroups = new[] { new XElement("PropertyGroup") },
 				FilePath = new FileInfo("test.cs")
 			});
 
@@ -149,7 +149,7 @@ namespace Project2015To2017.Tests
 			var writer = new ProjectWriter();
 			var xmlNode = writer.CreateXml(new Project
 			{
-				PropertyGroups = new[] {new XElement("PropertyGroup", new XElement("DelaySign", "true"))},
+				PropertyGroups = new[] { new XElement("PropertyGroup", new XElement("DelaySign", "true")) },
 				FilePath = new FileInfo("test.cs")
 			});
 
@@ -164,7 +164,7 @@ namespace Project2015To2017.Tests
 			var writer = new ProjectWriter();
 			var xmlNode = writer.CreateXml(new Project
 			{
-				PropertyGroups = new[] {new XElement("PropertyGroup", new XElement("DelaySign", "false"))},
+				PropertyGroups = new[] { new XElement("PropertyGroup", new XElement("DelaySign", "false")) },
 				FilePath = new FileInfo("test.cs")
 			});
 

--- a/Project2015To2017.Tests/SolutionReaderTests.cs
+++ b/Project2015To2017.Tests/SolutionReaderTests.cs
@@ -13,7 +13,7 @@ namespace Project2015To2017.Tests
 		{
 			var testFile = @"TestFiles/Solutions/sampleSolution.testsln";
 
-			var logger = new DummyLogger {MinimumLogLevel = LogLevel.Warning};
+			var logger = new DummyLogger { MinimumLogLevel = LogLevel.Warning };
 
 			SolutionReader.Instance.Read(testFile, logger);
 

--- a/Project2015To2017.Tests/TestFiles/Solutions/ClassLibrary/Class1.cs
+++ b/Project2015To2017.Tests/TestFiles/Solutions/ClassLibrary/Class1.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace ClassLibrary
 {
-    public class Class1
-    {
-    }
+	public class Class1
+	{
+	}
 }

--- a/Project2015To2017.Tests/TestProjectPackageReferenceTransformationTest.cs
+++ b/Project2015To2017.Tests/TestProjectPackageReferenceTransformationTest.cs
@@ -8,80 +8,80 @@ using Project2015To2017.Reading;
 namespace Project2015To2017.Tests
 {
 	[TestClass]
-    public class TestProjectPackageReferenceTransformationTest
-    {
-        [TestMethod]
-        public void AddsTestPackages()
-        {
-	        var project = new ProjectReader().Read(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj"));
+	public class TestProjectPackageReferenceTransformationTest
+	{
+		[TestMethod]
+		public void AddsTestPackages()
+		{
+			var project = new ProjectReader().Read(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj"));
 
-	        project.Type = ApplicationType.TestProject;
-	        project.TargetFrameworks.Add("net45");
-
-            var transformation = new TestProjectPackageReferenceTransformation();
-
-            transformation.Transform(project);
-
-            Assert.AreEqual(10, project.PackageReferences.Count);
-            Assert.AreEqual(1, project.PackageReferences.Count(x => x.Id == "Microsoft.Owin.Host.HttpListener" && x.Version == "3.1.0"));
-            Assert.AreEqual(1, project.PackageReferences.Count(x => x.Id == "Microsoft.NET.Test.Sdk" && !string.IsNullOrWhiteSpace(x.Version)));
-            Assert.AreEqual(1, project.PackageReferences.Count(x => x.Id == "AutoMapper" && x.Version == "6.1.1" && x.IsDevelopmentDependency));
-        }
-
-        [TestMethod]
-        public void AcceptsNetStandardFramework()
-        {
-	        var project = new ProjectReader().Read(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj"));
-
-	        project.Type = ApplicationType.TestProject;
-	        project.TargetFrameworks.Add("netstandard2.0");
+			project.Type = ApplicationType.TestProject;
+			project.TargetFrameworks.Add("net45");
 
 			var transformation = new TestProjectPackageReferenceTransformation();
 
-            transformation.Transform(project);
+			transformation.Transform(project);
 
-            Assert.AreEqual(10, project.PackageReferences.Count);
-            Assert.AreEqual(1, project.PackageReferences.Count(x => x.Id == "Microsoft.Owin.Host.HttpListener" && x.Version == "3.1.0"));
-            Assert.AreEqual(1, project.PackageReferences.Count(x => x.Id == "Microsoft.NET.Test.Sdk" && !string.IsNullOrWhiteSpace(x.Version)));
-            Assert.AreEqual(1, project.PackageReferences.Count(x => x.Id == "AutoMapper" && x.Version == "6.1.1" && x.IsDevelopmentDependency));
-        }
+			Assert.AreEqual(10, project.PackageReferences.Count);
+			Assert.AreEqual(1, project.PackageReferences.Count(x => x.Id == "Microsoft.Owin.Host.HttpListener" && x.Version == "3.1.0"));
+			Assert.AreEqual(1, project.PackageReferences.Count(x => x.Id == "Microsoft.NET.Test.Sdk" && !string.IsNullOrWhiteSpace(x.Version)));
+			Assert.AreEqual(1, project.PackageReferences.Count(x => x.Id == "AutoMapper" && x.Version == "6.1.1" && x.IsDevelopmentDependency));
+		}
 
-        [TestMethod]
-        public void DoesNotAddTestPackagesIfExists()
-        {
-            var transformation = new TestProjectPackageReferenceTransformation();
+		[TestMethod]
+		public void AcceptsNetStandardFramework()
+		{
+			var project = new ProjectReader().Read(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj"));
+
+			project.Type = ApplicationType.TestProject;
+			project.TargetFrameworks.Add("netstandard2.0");
+
+			var transformation = new TestProjectPackageReferenceTransformation();
+
+			transformation.Transform(project);
+
+			Assert.AreEqual(10, project.PackageReferences.Count);
+			Assert.AreEqual(1, project.PackageReferences.Count(x => x.Id == "Microsoft.Owin.Host.HttpListener" && x.Version == "3.1.0"));
+			Assert.AreEqual(1, project.PackageReferences.Count(x => x.Id == "Microsoft.NET.Test.Sdk" && !string.IsNullOrWhiteSpace(x.Version)));
+			Assert.AreEqual(1, project.PackageReferences.Count(x => x.Id == "AutoMapper" && x.Version == "6.1.1" && x.IsDevelopmentDependency));
+		}
+
+		[TestMethod]
+		public void DoesNotAddTestPackagesIfExists()
+		{
+			var transformation = new TestProjectPackageReferenceTransformation();
 
 			var project = new ProjectReader().Read(Path.Combine("TestFiles", "OtherTestProjects", "containsTestSDK.testcsproj"));
 
-	        project.TargetFrameworks.Add("net45");
+			project.TargetFrameworks.Add("net45");
 
-            transformation.Transform(project);
+			transformation.Transform(project);
 
-            Assert.AreEqual(6, project.PackageReferences.Count);
-            Assert.AreEqual(0, project.PackageReferences.Count(x => x.Id == "MSTest.TestAdapter"));
-        }
+			Assert.AreEqual(6, project.PackageReferences.Count);
+			Assert.AreEqual(0, project.PackageReferences.Count(x => x.Id == "MSTest.TestAdapter"));
+		}
 
-        [TestMethod]
-        public void TransformsPackages()
-        {
-	        var project = new ProjectReader().Read(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj"));
+		[TestMethod]
+		public void TransformsPackages()
+		{
+			var project = new ProjectReader().Read(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj"));
 
-            var transformation = new TestProjectPackageReferenceTransformation();
+			var transformation = new TestProjectPackageReferenceTransformation();
 
-            transformation.Transform(project);
+			transformation.Transform(project);
 
-            Assert.AreEqual(7, project.PackageReferences.Count);
-            Assert.AreEqual(2, project.PackageReferences.Count(x => x.IsDevelopmentDependency));
-            Assert.AreEqual(1, project.PackageReferences.Count(x => x.Id == "Microsoft.Owin" && x.Version == "3.1.0"));
-        }
+			Assert.AreEqual(7, project.PackageReferences.Count);
+			Assert.AreEqual(2, project.PackageReferences.Count(x => x.IsDevelopmentDependency));
+			Assert.AreEqual(1, project.PackageReferences.Count(x => x.Id == "Microsoft.Owin" && x.Version == "3.1.0"));
+		}
 
-        [TestMethod]
-        public void HandlesNonXml()
-        {
-            var project = new ProjectReader().Read(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj"));
-            var transformation = new TestProjectPackageReferenceTransformation();
+		[TestMethod]
+		public void HandlesNonXml()
+		{
+			var project = new ProjectReader().Read(Path.Combine("TestFiles", "OtherTestProjects", "net46console.testcsproj"));
+			var transformation = new TestProjectPackageReferenceTransformation();
 
-            transformation.Transform(project);
-        }
-    }
+			transformation.Transform(project);
+		}
+	}
 }

--- a/Project2015To2017/Facility.cs
+++ b/Project2015To2017/Facility.cs
@@ -149,22 +149,22 @@ namespace Project2015To2017
 					switch (extension)
 					{
 						case ".sln":
-						{
-							var solution = SolutionReader.Instance.Read(file, Logger);
-							convertedSolutions.Add(solution);
-							convertedProjects.AddRange(converter.ProcessSolutionFile(solution).Where(x => x != null));
-							break;
-						}
-						default:
-						{
-							var converted = converter.ProcessProjectFile(file, null);
-							if (converted != null)
 							{
-								convertedProjects.Add(converted);
+								var solution = SolutionReader.Instance.Read(file, Logger);
+								convertedSolutions.Add(solution);
+								convertedProjects.AddRange(converter.ProcessSolutionFile(solution).Where(x => x != null));
+								break;
 							}
+						default:
+							{
+								var converted = converter.ProcessProjectFile(file, null);
+								if (converted != null)
+								{
+									convertedProjects.Add(converted);
+								}
 
-							break;
-						}
+								break;
+							}
 					}
 				}
 				catch (Exception e)

--- a/Project2015To2017/Project2015To2017.csproj
+++ b/Project2015To2017/Project2015To2017.csproj
@@ -1,20 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-		<PackageId>Project2015To2017</PackageId>
-		<TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
-	</PropertyGroup>
+  <PropertyGroup>
+	<TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+	<PackageId>Project2015To2017</PackageId>
+	<TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
+  </PropertyGroup>
 
+  <ItemGroup>
+	<ProjectReference Include="..\Project2015To2017.Core\Project2015To2017.Core.csproj" PrivateAssets="All" />
+	<ProjectReference Include="..\Project2015To2017.Migrate2017.Library\Project2015To2017.Migrate2017.Library.csproj" PrivateAssets="All" />
+  </ItemGroup>
+
+  <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="BuildOnlySettings;ResolveReferences">
 	<ItemGroup>
-		<ProjectReference Include="..\Project2015To2017.Core\Project2015To2017.Core.csproj" PrivateAssets="All" />
-		<ProjectReference Include="..\Project2015To2017.Migrate2017.Library\Project2015To2017.Migrate2017.Library.csproj" PrivateAssets="All" />
+	  <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
 	</ItemGroup>
-
-	<Target Name="CopyProjectReferencesToPackage" DependsOnTargets="BuildOnlySettings;ResolveReferences">
-		<ItemGroup>
-			<BuildOutputInPackage Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
-		</ItemGroup>
-	</Target>
+  </Target>
 
 </Project>


### PR DESCRIPTION
I hope this can be a step towards avoiding accidental formatting changes in future. Up to now there has been a legacy of inconsistent formatting which is a problem when then trying to format our own changes using ctrl+k+d or whatever other tool you like to use.

I've manually done two things:
- Run dotnet-format
- Use ctrl+k+d on each .csproj file

I'm not an expert at `editorconfig` files, nor am I hugely opinionated about which conventions we use (spaces or tabs etc., I don't really mind). But I think it would be great to get things standardised as part of a check-in hook or just a validation that dotnet-format doesn't caused any changed when run in the build script.