### PR TITLE
In cases where AssemblyInfo is being preserved and there are multiple…

### DIFF
--- a/Project2015To2017.Core/Transforms/NuGetPackageTransformation.cs
+++ b/Project2015To2017.Core/Transforms/NuGetPackageTransformation.cs
@@ -57,10 +57,10 @@ namespace Project2015To2017.Transforms
 			{
 				//Id does not need to be specified in new project format if it is just the same as the assembly name
 				Id = rawPackageConfig.Id == "$id$" ? null : rawPackageConfig.Id,
-				Version = PopulatePlaceHolder("version", rawPackageConfig.Version, assemblyAttributes.InformationalVersion ?? assemblyAttributes.Version),
-				Authors = PopulatePlaceHolder("author", rawPackageConfig.Authors, assemblyAttributes.Company),
-				Description = PopulatePlaceHolder("description", rawPackageConfig.Description, assemblyAttributes.Description),
-				Copyright = PopulatePlaceHolder("copyright", rawPackageConfig.Copyright, assemblyAttributes.Copyright),
+				Version = PopulatePlaceHolder("version", rawPackageConfig.Version, assemblyAttributes?.InformationalVersion ?? assemblyAttributes?.Version),
+				Authors = PopulatePlaceHolder("author", rawPackageConfig.Authors, assemblyAttributes?.Company),
+				Description = PopulatePlaceHolder("description", rawPackageConfig.Description, assemblyAttributes?.Description ),
+				Copyright = PopulatePlaceHolder("copyright", rawPackageConfig.Copyright, assemblyAttributes?.Copyright),
 				LicenseUrl = rawPackageConfig.LicenseUrl,
 				ProjectUrl = rawPackageConfig.ProjectUrl,
 				IconUrl = rawPackageConfig.IconUrl,


### PR DESCRIPTION
… AssemblyInfo files present (very common in GitVersion implementations where there is a single common AssemblyInfo file containing version info and an AssemblyInfo file containing library specific details), AssemblyDetails will be null (multiple files not currently supported) but there is no null check in NuGetPackageTransformation. Added null propagation on the assemblyAttributes object. If time allows I will add support for multiple assemblyinfo files but at a minimum this fixes the null reference exception when assembly info details are being preserved.