### PR TITLE
Transform assembly signing attributes

### DIFF
--- a/Project2015To2017.Core/Definition/AssemblyAttributes.cs
+++ b/Project2015To2017.Core/Definition/AssemblyAttributes.cs
@@ -91,6 +91,21 @@ namespace Project2015To2017.Definition
 			(this.FileVersion != null && this.FileVersion.Contains("*")) ||
 			(this.Version != null && this.Version.Contains("*"));
 
+		public bool IsSigned => 
+			this.KeyFile != null;
+
+		public string DelaySign
+		{
+			get => GetAttribute(typeof(AssemblyDelaySignAttribute));
+			set => SetAttribute(typeof(AssemblyDelaySignAttribute), value);
+		}
+
+		public string KeyFile
+		{
+			get => GetAttribute(typeof(AssemblyKeyFileAttribute));
+			set => SetAttribute(typeof(AssemblyKeyFileAttribute), value);
+		}
+
 		public FileInfo File { get; set; }
 
 		private (AttributeListSyntax attList, AttributeSyntax att) FindAttribute(Type attributeType)
@@ -121,7 +136,7 @@ namespace Project2015To2017.Definition
 
 			//Make the assumption that it just has a single string argument
 			//because all of the attributes we currently look for do have
-			return att?.ArgumentList.Arguments.Single().ToString().Trim('"');
+			return att?.ArgumentList.Arguments.Single().ToString().TrimStart('@').Trim('"');
 		}
 
 		public void SetAttribute(Type attributeType, string value)

--- a/Project2015To2017.Core/Transforms/AssemblyAttributeTransformation.cs
+++ b/Project2015To2017.Core/Transforms/AssemblyAttributeTransformation.cs
@@ -87,9 +87,10 @@ namespace Project2015To2017.Transforms
 			logger.LogDebug("Moving attributes from AssemblyInfo to project file");
 
 			var versioningProperties = VersioningProperties(assemblyAttributes, packageConfig, logger);
+			var signingProperties = SigningProperties(assemblyAttributes, packageConfig, logger);
 			var otherProperties = OtherProperties(assemblyAttributes, packageConfig, logger);
 
-			var childNodes = otherProperties.Concat(versioningProperties).ToArray();
+			var childNodes = otherProperties.Concat(signingProperties).Concat(versioningProperties).ToArray();
 
 			if (childNodes.Length == 0)
 			{
@@ -188,6 +189,22 @@ namespace Project2015To2017.Transforms
 			assemblyAttributes.InformationalVersion = null;
 			assemblyAttributes.Version = null;
 			assemblyAttributes.FileVersion = null;
+
+			return toReturn;
+		}
+
+		private static IReadOnlyList<XElement> SigningProperties(AssemblyAttributes assemblyAttributes,
+			PackageConfiguration packageConfig, ILogger logger)
+		{
+			var toReturn = new[]
+			{
+				assemblyAttributes.IsSigned ? new XElement("SignAssembly", true) : null,
+				assemblyAttributes.KeyFile != null ? CreateElementIfNotNullOrEmpty(assemblyAttributes.DelaySign, "DelaySign") : null,
+				CreateElementIfNotNullOrEmpty(assemblyAttributes.KeyFile, "AssemblyOriginatorKeyFile")
+			}.Where(x => x != null).ToArray();
+
+			assemblyAttributes.DelaySign = null;
+			assemblyAttributes.KeyFile = null;
 
 			return toReturn;
 		}


### PR DESCRIPTION
Siging of an assembly can also be done using assembly attributes in the assemblyinfo.cs

[assembly: AssemblyDelaySign(true)]
[assembly: AssemblyKeyFile(@"..\..\PublicKey.snk")]

With this pull request these attributes get also transformed