### PR TITLE
Fix #260: Crash when project contains NeutralResourcesLanguage attribute

### DIFF
--- a/Project2015To2017.Core/Definition/AssemblyAttributes.cs
+++ b/Project2015To2017.Core/Definition/AssemblyAttributes.cs
@@ -119,9 +119,9 @@ namespace Project2015To2017.Definition
 		{
 			var att = FindAttribute(attributeType).att;
 
-			//Make the assumption that it just has a single string argument
+			//Make the assumption that it at least has a string argument
 			//because all of the attributes we currently look for do have
-			return att?.ArgumentList.Arguments.Single().ToString().Trim('"');
+			return att?.ArgumentList.Arguments.First().ToString().Trim('"');
 		}
 
 		public void SetAttribute(Type attributeType, string value)

--- a/Project2015To2017.Tests/TestFiles/Solutions/ClassLibrary/Properties/AssemblyInfo.cs
+++ b/Project2015To2017.Tests/TestFiles/Solutions/ClassLibrary/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Resources;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -13,6 +14,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright ©  2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+[assembly: NeutralResourcesLanguage("en-US", UltimateResourceFallbackLocation.MainAssembly)]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from


### PR DESCRIPTION
Also updated ```TestFiles/Solutions/ClassLibrary/Properties/AssemblyInfo.cs```, however I did not find a test where this is used...